### PR TITLE
Add config file for logging and devtools

### DIFF
--- a/browserhtml.json
+++ b/browserhtml.json
@@ -1,0 +1,3 @@
+{ "logging": true
+, "devtools": false
+}

--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -6,6 +6,7 @@
 
 
 import {version} from "../../package.json";
+import * as Config from "../../browserhtml.json";
 import {Effects, html, forward, thunk} from "reflex";
 
 import * as Shell from "./shell";
@@ -36,7 +37,7 @@ import {onWindow} from "driver";
 /*:: import * as type from "../../type/browser/browser" */
 
 export const init/*:type.init*/ = () => {
-  const [devtools, devtoolsFx] = Devtools.init();
+  const [devtools, devtoolsFx] = Devtools.init({isActive: Config.devtools});
   const [updater, updaterFx] = Updater.init();
   const [input, inputFx] = Input.init(false, false, "");
   const [shell, shellFx] = Shell.init();

--- a/src/browser/index.js
+++ b/src/browser/index.js
@@ -9,6 +9,7 @@ import * as UI from "./perspective-ui";
 
 // import * as Session from "./session";
 import {version} from "../../package.json";
+import * as Config from "../../browserhtml.json";
 import {Renderer} from "driver";
 
 
@@ -42,7 +43,7 @@ const application = start({
   initial: isReload ?
             window.application.model.value :
             UI.init(),
-  step: logger(UI.update),
+  step: Config.logging ? logger(UI.update) : UI.update,
   view: UI.view
 });
 

--- a/src/common/devtools.js
+++ b/src/common/devtools.js
@@ -134,12 +134,12 @@ const report = (model, result) =>
     )
   ];
 
-export const init/*:type.init*/ = () => {
+export const init/*:type.init*/ = ({isActive}) => {
   const [settings, fx] =
     Settings.init(Object.keys(descriptions));
 
   const result =
-    [ { isActive: false
+    [ { isActive
       , settings
       }
     , fx.map(SettingsAction)


### PR DESCRIPTION
This is a simple commit that adds a `browserhtml.json` config file for developers. This file lets us configure default settings.

Fixes https://github.com/browserhtml/browserhtml/issues/875.

@Gozala do you have strong opinions about this? It's the simplest possible solution I could think of.