### PR TITLE
Cargoify browser.html

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -8,6 +8,7 @@ import uglify from 'gulp-uglify';
 import sourcemaps from 'gulp-sourcemaps';
 import gutil from 'gulp-util';
 import watchify from 'watchify';
+import watch from 'gulp-watch';
 import child from 'child_process';
 import http from 'http';
 import path from 'path';
@@ -109,7 +110,7 @@ var bundler = function(entry) {
 // Starts a static http server that serves browser.html directory.
 gulp.task('server', function() {
   var server = http.createServer(ecstatic({
-    root: path.join(module.filename, '../'),
+    root: path.join(module.filename, '../dist/'),
     cache: 0
   }));
   server.listen(settings.port);
@@ -208,6 +209,15 @@ gulp.task('hotreload', function() {
   settings.transform.push(hotify);
 });
 
+gulp.task('copydist', function() {
+  gulp.src('./index.html')
+      .pipe(watch('./index.html'))
+      .pipe(gulp.dest('./dist/'));
+  gulp.src('./css/*')
+      .pipe(watch('./css/*'))
+      .pipe(gulp.dest('./dist/css/'));
+});
+
 bundler('browser/index');
 bundler('service/history-worker');
 bundler('about/settings/main');
@@ -218,7 +228,8 @@ gulp.task('build', [
   'browser/index',
   // 'service/history-worker',
   'about/settings/main',
-  'about/repl/main'
+  'about/repl/main',
+  'copydist'
 ]);
 
 gulp.task('watch', [
@@ -226,7 +237,8 @@ gulp.task('watch', [
   'browser/index',
   // 'service/history-worker',
   'about/settings/main',
-  'about/repl/main'
+  'about/repl/main',
+  'copydist'
 ]);
 
 gulp.task('develop', sequencial('watch', 'server', 'gecko'));

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -19,6 +19,8 @@ import hmr from 'browserify-hmr';
 import hotify from 'hotify';
 var fs = require('fs');
 
+var dist = gutil.env.dist || "./dist/";
+
 var settings = {
   port: process.env.BROWSER_HTML_PORT ||
         '6060',
@@ -95,7 +97,7 @@ Bundler.prototype.build = function() {
                     error.message);
     })
     .pipe(sourcemaps.write('./'))
-    .pipe(gulp.dest('./dist/'))
+    .pipe(gulp.dest(dist))
     .on('end', () => {
       gutil.log(`Completed bundling: '${this.entry}'`);
     });
@@ -110,7 +112,7 @@ var bundler = function(entry) {
 // Starts a static http server that serves browser.html directory.
 gulp.task('server', function() {
   var server = http.createServer(ecstatic({
-    root: path.join(module.filename, '../dist/'),
+    root: dist,
     cache: 0
   }));
   server.listen(settings.port);
@@ -209,13 +211,17 @@ gulp.task('hotreload', function() {
   settings.transform.push(hotify);
 });
 
+function copy_files(src, dst) {
+  var s = gulp.src(src);
+  if (settings.watch) {
+    s = s.pipe(watch(src));
+  }
+  s.pipe(gulp.dest(dst));
+}
+
 gulp.task('copydist', function() {
-  gulp.src('./index.html')
-      .pipe(watch('./index.html'))
-      .pipe(gulp.dest('./dist/'));
-  gulp.src('./css/*')
-      .pipe(watch('./css/*'))
-      .pipe(gulp.dest('./dist/css/'));
+  copy_files('./index.html', dist);
+  copy_files('./css/*', path.join(dist, "css/"));
 });
 
 bundler('browser/index');

--- a/index.html
+++ b/index.html
@@ -20,5 +20,5 @@
   </head>
   <body tabindex="-1">
   </body>
-  <script src="./dist/browser/index.js"></script>
+  <script src="browser/index.js"></script>
 </html>

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "gulp-sourcemaps": "1.5.2",
     "gulp-uglify": "1.2.0",
     "gulp-util": "3.0.6",
+    "gulp-watch": "4.3.5",
     "hotify": "0.0.1",
     "jscs": "1.8.1",
     "mocha": "2.2.4",


### PR DESCRIPTION
Under Cargo this outputs the dist directory under Cargo's $OUT_DIR. It
uses an added --dest commandline option to achieve this.