### PR TITLE
Skip animation during fast tab switch.

### DIFF
--- a/src/browser/perspective-ui.js
+++ b/src/browser/perspective-ui.js
@@ -85,7 +85,7 @@ export const update = (model, action) =>
       ( Browser.update
       , model
       , [ action
-        , Browser.SelectWebView
+        , Browser.RequestTabSelector
         ]
       )
     : action.type === 'Focus'


### PR DESCRIPTION
This change is sort of bolted on so I would like to rethink on how to do it. That being said we can land it for now and than redo it later.

Also on servo it totally misbehaves for me & I'm not entirely sure what's going on.