### PR TITLE
Make colors less opinionated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser.html",
   "description": "Experimental Servo browser built in HTML",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "homepage": "https://github.com/mozilla/browser.html",
   "repository": {
     "type": "git",

--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -777,7 +777,7 @@ export const update/*:type.update*/ = (model, action) =>
 
 const styleSheet = StyleSheet.create({
   root: {
-    background: '#24303D',
+    background: '#171814',
     perspective: '1000px',
     // These styles prevent scrolling with the arrow keys in the root window
     // when elements move outside of viewport.

--- a/src/browser/sidebar.js
+++ b/src/browser/sidebar.js
@@ -18,7 +18,7 @@ import * as Easing from "eased";
 
 const styleSheet = StyleSheet.create({
   base:
-  { backgroundColor: '#24303D'
+  { backgroundColor: '#272822'
   , height: '100%'
   , position: 'absolute'
   , right: 0

--- a/src/browser/sidebar/tab.js
+++ b/src/browser/sidebar/tab.js
@@ -50,19 +50,20 @@ export const update = (model, action) =>
   : Unknown.update(model, action)
   );
 
+const tabHeight = '32px';
 
 const styleSheet = StyleSheet.create({
   base: {
     MozWindowDragging: 'no-drag',
     borderRadius: '5px',
-    height: '32px',
+    height: tabHeight,
     color: '#fff',
     overflow: 'hidden'
   },
 
   container: {
-    height: '32px',
-    lineHeight: '32px',
+    height: tabHeight,
+    lineHeight: tabHeight,
     width: '288px',
     color: '#fff',
     fontSize: '14px',
@@ -71,7 +72,7 @@ const styleSheet = StyleSheet.create({
   },
 
   selected: {
-    backgroundColor: '#3D91F2'
+    backgroundColor: 'rgb(86,87,81)'
   },
   unselected: {
   },
@@ -90,11 +91,11 @@ const styleSheet = StyleSheet.create({
   closeMask: {
     background: `linear-gradient(
       to right,
-      rgba(36,48,61,0) 0%,
-      rgba(36,48,61,1) 20%,
-      rgba(36,48,61,1) 100%)`,
-    width: '32px',
-    height: '32px',
+      rgba(39,40,34,0) 0%,
+      rgba(39,40,34,1) 20%,
+      rgba(39,40,34,1) 100%)`,
+    width: tabHeight,
+    height: tabHeight,
     position: 'absolute',
     paddingLeft: '10px',
     right: 0,
@@ -106,9 +107,9 @@ const styleSheet = StyleSheet.create({
   closeMaskSelected: {
     background: `linear-gradient(
       to right,
-      rgba(61,145,242,0) 0%,
-      rgba(61,145,242,1) 20%,
-      rgba(61,145,242,1) 100%)`
+      rgba(86,87,81,0) 0%,
+      rgba(86,87,81,1) 20%,
+      rgba(86,87,81,1) 100%)`,
   },
   closeMaskUnselected: {
 
@@ -128,9 +129,9 @@ const styleSheet = StyleSheet.create({
     color: '#fff',
     fontFamily: 'FontAwesome',
     fontSize: '12px',
-    width: '32px',
-    height: '32px',
-    lineHeight: '32px',
+    width: tabHeight,
+    height: tabHeight,
+    lineHeight: tabHeight,
     textAlign: 'center'
   }
 });

--- a/src/browser/sidebar/toolbar.js
+++ b/src/browser/sidebar/toolbar.js
@@ -126,7 +126,7 @@ const viewPin = Toggle.view('pin-button', StyleSheet.create({
 const viewClose = Button.view('create-tab-button', StyleSheet.create({
   base:
   { MozWindowDragging: 'no-drag'
-  , color: 'rgba(255,255,255,0.8)'
+  , color: 'rgb(255,255,255)'
   , fontFamily: 'FontAwesome'
   , fontSize: '18px'
   , lineHeight: '32px'

--- a/src/browser/web-view.js
+++ b/src/browser/web-view.js
@@ -694,7 +694,28 @@ const styleSheet = StyleSheet.create({
   iconCreateTabDark: {
     color: 'rgba(255,255,255,0.8)',
   },
-  iconCreateTabBright: null
+
+  iconCreateTabBright: null,
+
+  iconBack: {
+    MozWindowDragging: 'no-drag',
+    color: 'rgba(0,0,0,0.8)',
+    fontFamily: 'FontAwesome',
+    fontSize: '18px',
+    lineHeight: '32px',
+    position: 'absolute',
+    textAlign: 'center',
+    bottom: 0,
+    left: 0,
+    width: '30px',
+    height: '32px',
+  },
+
+  iconBackDark: {
+    color: 'rgba(255,255,255,0.8)',
+  },
+
+  iconBackBright: null
 });
 
 const viewFrame = (model, address) =>
@@ -844,6 +865,20 @@ export const view/*:type.view*/ = (model, address) => {
         , onClick: forward(address, always(Create))
         }
       , ['']
+      )
+    , html.div
+      ( { className: 'global-create-tab-icon'
+        , style:
+            Style
+            ( styleSheet.iconBack
+            , ( isModelDark
+              ? styleSheet.iconBackDark
+              : styleSheet.iconBackBright
+              )
+            )
+        , onClick: forward(address, always(GoBack))
+        }
+      , ['']
       )
     ]
   );


### PR DESCRIPTION
Update close mask colors
Change background color to neutral dark
Bring tab selected color closer to osx standard
Match plus button to pin button

Flattened version of https://github.com/browserhtml/browserhtml/pull/945.