### PR TITLE
Add `npm run status` to check flow status.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "build-server": "gulp build-server",
     "live-server": "gulp live-server",
     "flow": "flow check",
-    "test": "flow check"
+    "test": "flow check",
+    "status": "flow status"
   },
   "dependencies": {
     "eased": "0.1.0",


### PR DESCRIPTION
This resolves the issue for cases where user might have multiple versions of flow installed. Different versions may fail to type check.