### PR TITLE
Include babel-polyfill

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -2,7 +2,8 @@
 .*/dist/.*
 .*/browser.html/.profile/.*
 .*/browser.html/.bin/.*
-.*/node_modules/babel.*
+.*/node_modules/babel-core/.*
+.*/node_modules/babel-plugin.*
 .*/node_modules/tap/.*
 .*/node_modules/reflex-virtual-dom-driver/examlpes/.*
 .*/type/.*

--- a/src/about/newtab/main.js
+++ b/src/about/newtab/main.js
@@ -4,6 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import "babel-polyfill";
 import {start, Effects} from "reflex";
 import * as NewTab from "./newtab";
 import {Renderer} from "driver";

--- a/src/about/repl/main.js
+++ b/src/about/repl/main.js
@@ -4,6 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import "babel-polyfill";
 import {start, Effects} from "reflex";
 import * as UI from "./repl";
 import {Renderer} from "driver";

--- a/src/about/settings/main.js
+++ b/src/about/settings/main.js
@@ -4,6 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import "babel-polyfill";
 import {start, Effects} from "reflex";
 import * as UI from "./settings";
 import {Renderer} from "driver";

--- a/src/browser/index.js
+++ b/src/browser/index.js
@@ -4,6 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import "babel-polyfill";
 import {start, Effects} from "reflex";
 import * as UI from "./perspective-ui";
 import {version} from "../../package.json";


### PR DESCRIPTION
Turns out new babel no longer polyfills Promises by default. It also seems turns out that we don’t have promises on servo. This changes includes polyfill to have Promises in Servo.