### PR TITLE
Handle window close/reload diff on servo

### DIFF
--- a/src/common/runtime.js.flow
+++ b/src/common/runtime.js.flow
@@ -92,6 +92,8 @@ declare export function request <request, response>
   (type:string, message:request):
   Task<Never, response>
 
+declare export var isServo:boolean;
+
 declare export var quit:Task<Never, Result<Error, void>>;
 declare export var minimize:Task<Never, Result<Error, void>>;
 declare export var toggleFullscreen:Task<Never, Result<Error, void>>;


### PR DESCRIPTION
Runtime.quit -> window.close()
Runtime.reload -> window.location.reload()
Runtime.cleanReload -> Runtime.location.reload(true)

Fixes #944 Depends on #957 