### PR TITLE
Add babel-polyfill to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "babel-plugin-syntax-flow": "6.3.13",
     "babel-plugin-transform-es2015-modules-umd": "6.4.3",
     "babel-plugin-transform-flow-strip-types": "6.4.0",
+    "babel-polyfill": "6.7.4",
     "babel-preset-es2015": "6.3.13",
     "babel-register": "6.7.2",
     "babelify": "7.2.0",


### PR DESCRIPTION
This fixes regression I introduced #957, where I forgot to include babel-polyfill into dependencies.