### PR TITLE
Fix brief appearance of full length progress bar.

### DIFF
--- a/src/browser/web-view/progress.js
+++ b/src/browser/web-view/progress.js
@@ -140,7 +140,7 @@ const tick = (time, model) =>
       , { updateTime: time
         , display:
           { opacity: 1
-          , x: (-100 + (100 * progress(model)))
+          , x: progress(model) * 100
           }
         }
       )
@@ -218,7 +218,7 @@ export const view =
     className: 'progressbar',
     style: Style(style.bar, {
       backgroundColor: '#4A90E2',
-      transform: `translateX(${model.display.x}%)`,
+      transform: `translateX(${(model.display.x) - 100}%)`,
       opacity: model.display.opacity
     }),
   }, [html.div({


### PR DESCRIPTION
Before `display.x` was changing from 1 to 0 and when progress idle `display.x` was set to 0 which meant seeing full progress bar. This change reverses meaning of x so it grows from 0 to 1.

Fixes #928