### PR TITLE
Hide back button if you can't go back

### DIFF
--- a/src/browser/web-view.js
+++ b/src/browser/web-view.js
@@ -125,7 +125,7 @@ export const LoadEnd =
   ({type: 'LoadEnd', time});
 
 export const LocationChanged =
-  (uri/*:URI*/, canGoBack/*:boolean*/, canGoForward/*:boolean*/, time/*:Time*/)/*:Action*/ =>
+  (uri/*:URI*/, canGoBack/*:?boolean*/, canGoForward/*:?boolean*/, time/*:Time*/)/*:Action*/ =>
   ({type: 'LocationChanged', uri, canGoBack, canGoForward, time});
 
 export const ContextMenu =
@@ -934,7 +934,7 @@ const decodeLocationChange = ({detail}) =>
   // In Gecko, detail is a string (the uri).
   // In Servo, detail is an object {uri,canGoBack,canGoForward}
   ( typeof detail === 'string'
-  ? LocationChanged(detail, false, false, performance.now())
+  ? LocationChanged(detail, null, null, performance.now())
   : LocationChanged
     ( detail.uri
     , detail.canGoBack

--- a/src/browser/web-view.js
+++ b/src/browser/web-view.js
@@ -125,7 +125,7 @@ export const LoadEnd =
   ({type: 'LoadEnd', time});
 
 export const LocationChanged =
-  (uri/*:URI*/, canGoBack/*:bool*/, canGoForward/*:bool*/, time/*:Time*/)/*:Action*/ =>
+  (uri/*:URI*/, canGoBack/*:boolean*/, canGoForward/*:boolean*/, time/*:Time*/)/*:Action*/ =>
   ({type: 'LocationChanged', uri, canGoBack, canGoForward, time});
 
 export const ContextMenu =

--- a/src/browser/web-view.js.flow
+++ b/src/browser/web-view.js.flow
@@ -71,6 +71,8 @@ export type Action =
     }
   | { type: "LocationChanged"
     , uri: URI
+    , canGoBack: boolean
+    , canGoForward: boolean
     , time: Time
     }
   | { type: "Close" }

--- a/src/browser/web-view.js.flow
+++ b/src/browser/web-view.js.flow
@@ -71,8 +71,8 @@ export type Action =
     }
   | { type: "LocationChanged"
     , uri: URI
-    , canGoBack: boolean
-    , canGoForward: boolean
+    , canGoBack: ?boolean
+    , canGoForward: ?boolean
     , time: Time
     }
   | { type: "Close" }

--- a/src/browser/web-view/navigation.js
+++ b/src/browser/web-view/navigation.js
@@ -28,8 +28,8 @@ export const Load =
   ({type: "Load", uri});
 
 export const LocationChanged =
-  (uri/*:URI*/)/*:Action*/ =>
-  ({type: "LocationChanged", uri});
+  (uri/*:URI*/, canGoBack/*:bool*/, canGoForward/*:bool*/)/*:Action*/ =>
+  ({type: "LocationChanged", uri, canGoBack, canGoForward});
 
 const CanGoBackChanged =
   result =>
@@ -155,7 +155,13 @@ export const update =
     : [ model, Effects.task(report(action.result.error)) ]
     )
   : action.type === "LocationChanged"
-  ? [ merge(model, {currentURI: action.uri})
+  ? [ merge
+      ( model
+      , { currentURI: action.uri
+        , canGoBack: action.canGoBack
+        , canGoForward: action.canGoForward
+        }
+      )
     , Effects.batch
       ( [ Effects
             .task(canGoBack(model.id))

--- a/src/browser/web-view/navigation.js
+++ b/src/browser/web-view/navigation.js
@@ -28,7 +28,7 @@ export const Load =
   ({type: "Load", uri});
 
 export const LocationChanged =
-  (uri/*:URI*/, canGoBack/*:boolean*/, canGoForward/*:boolean*/)/*:Action*/ =>
+  (uri/*:URI*/, canGoBack/*:?boolean*/, canGoForward/*:?boolean*/)/*:Action*/ =>
   ({type: "LocationChanged", uri, canGoBack, canGoForward});
 
 const CanGoBackChanged =
@@ -155,22 +155,29 @@ export const update =
     : [ model, Effects.task(report(action.result.error)) ]
     )
   : action.type === "LocationChanged"
-  ? [ merge
-      ( model
-      , { currentURI: action.uri
-        , canGoBack: action.canGoBack
-        , canGoForward: action.canGoForward
-        }
+  ? [ ( canGoBack != null && canGoForward != null
+      ? merge
+        ( model
+        , { currentURI: action.uri
+          , canGoBack: action.canGoBack
+          , canGoForward: action.canGoForward
+          }
+        )
+      : merge
+        ( model
+        , { currentURI: action.uri
+          }
+        )
       )
-    , Effects.batch
-      ( [ Effects
-            .task(canGoBack(model.id))
-            .map(CanGoBackChanged)
-        , Effects
-            .task(canGoForward(model.id))
-            .map(CanGoForwardChanged)
-        ]
-      )
+      , Effects.batch
+        ( [ Effects
+              .task(canGoBack(model.id))
+              .map(CanGoBackChanged)
+          , Effects
+              .task(canGoForward(model.id))
+              .map(CanGoForwardChanged)
+          ]
+        )
     ]
   : action.type === "Load"
   ? [ merge

--- a/src/browser/web-view/navigation.js
+++ b/src/browser/web-view/navigation.js
@@ -28,7 +28,7 @@ export const Load =
   ({type: "Load", uri});
 
 export const LocationChanged =
-  (uri/*:URI*/, canGoBack/*:bool*/, canGoForward/*:bool*/)/*:Action*/ =>
+  (uri/*:URI*/, canGoBack/*:boolean*/, canGoForward/*:boolean*/)/*:Action*/ =>
   ({type: "LocationChanged", uri, canGoBack, canGoForward});
 
 const CanGoBackChanged =

--- a/src/browser/web-view/navigation.js.flow
+++ b/src/browser/web-view/navigation.js.flow
@@ -32,6 +32,8 @@ export type Action =
   // directly corresponds `currentURI` in the model.
   | { type: "LocationChanged"
     , uri: URI
+    , canGoBack: boolean
+    , canGoForward: boolean
     }
   // Editing uri in the location bar causes `ChangeLocation` action. It's
   // `uri` field directly corresponds to `initiatedURI` field on the model,

--- a/src/browser/web-view/navigation.js.flow
+++ b/src/browser/web-view/navigation.js.flow
@@ -32,8 +32,8 @@ export type Action =
   // directly corresponds `currentURI` in the model.
   | { type: "LocationChanged"
     , uri: URI
-    , canGoBack: boolean
-    , canGoForward: boolean
+    , canGoBack: ?boolean
+    , canGoForward: ?boolean
     }
   // Editing uri in the location bar causes `ChangeLocation` action. It's
   // `uri` field directly corresponds to `initiatedURI` field on the model,

--- a/src/browser/web-view/util.js
+++ b/src/browser/web-view/util.js
@@ -36,3 +36,7 @@ export const isDark =
   ? model.page.pallet.isDark
   : false
   );
+
+export const canGoBack =
+  (model/*:WebView.Model*/)/*:boolean*/ =>
+  model.navigation.canGoBack;

--- a/src/browser/web-view/util.js
+++ b/src/browser/web-view/util.js
@@ -39,4 +39,4 @@ export const isDark =
 
 export const canGoBack =
   (model/*:WebView.Model*/)/*:boolean*/ =>
-  model.navigation.canGoBack;
+  model.navigation.canGoBack === true;

--- a/src/browser/web-view/util.js.flow
+++ b/src/browser/web-view/util.js.flow
@@ -19,3 +19,7 @@ declare export function readFaviconURI
 declare export function isDark
   (model:WebView.Model):
   boolean
+
+declare export function canGoBack
+  (model:WebView.Model):
+  boolean


### PR DESCRIPTION
@Gozala can you review this? I didn't remove the Gecko `canGoBackChanged` code path, but augmented it.

@paulrouget This works in Gecko, but I see no change in Servo. For Servo we should have `canGoBack` and `canGoForward` in `event.detail` (per https://github.com/servo/servo/commit/6577409b95bc782c0493cc5186fa4ed0d31d680d), but the latest servo-binary build doesn't seem to have this feature yet?

Fixes https://github.com/browserhtml/browserhtml/issues/941.