### PR TITLE
Implement basic force-push to show tabs

### DIFF
--- a/src/browser/web-view.js
+++ b/src/browser/web-view.js
@@ -87,11 +87,11 @@ export const Focus/*:Action*/ =
   { type: 'Focus'
   };
 
-export const PushDown =
+export const PushDown/*:Action*/ =
   { type: 'PushDown'
   };
 
-export const PushedDown =
+export const PushedDown/*:Action*/ =
   { type: 'PushedDown'
   };
 

--- a/src/browser/web-view.js
+++ b/src/browser/web-view.js
@@ -87,6 +87,14 @@ export const Focus/*:Action*/ =
   { type: 'Focus'
   };
 
+export const PushDown =
+  { type: 'PushDown'
+  };
+
+export const PushedDown =
+  { type: 'PushedDown'
+  };
+
 export const Load =
   (uri/*:URI*/)/*:Action*/ =>
   ( { type: 'Load'
@@ -527,6 +535,11 @@ export const update =
   : action.type === "Close"
   ? close(model)
 
+  // Force push actions.
+  // We forward these up to WebViews.
+  : action.type === "PushDown"
+  ? [ model, Effects.receive(PushedDown) ]
+
   // Animation
   : action.type === "SelectAnimation"
   ? updateSelectAnimation(model, action.action)
@@ -751,6 +764,10 @@ const viewFrame = (model, address) =>
     onBlur: on(address, always(BlurShell)),
     onFocus: on(address, always(FocusShell)),
     // onMozbrowserAsyncScroll: on(address, decodeAsyncScroll),
+    // @TODO send force changed actions and update webviews animation code
+    // to respond live 1:1 with push.
+    // onServoMouseForceChanged: on(address, decodeForceChanged),
+    onServoMouseForceDown: on(address, decodeForceDown),
     onMozBrowserClose: on(address, always(Close)),
     onMozBrowserOpenWindow: on(address, decodeOpenWindow),
     onMozBrowserOpenTab: on(address, decodeOpenTab),
@@ -975,3 +992,5 @@ const decodeScrollAreaChange = ({detail, target}) =>
 const decodeSecurityChange =
   ({detail: {state, extendedValidation}}) =>
   SecurityChanged(state, extendedValidation);
+
+const decodeForceDown = always(PushDown);

--- a/src/browser/web-view.js.flow
+++ b/src/browser/web-view.js.flow
@@ -80,6 +80,8 @@ export type Action =
   | { type: "Edit" }
   | { type: "ShowTabs" }
   | { type: "Create" }
+  | { type: "PushDown" }
+  | { type: "PushedDown" }
   | { type: "SelectAnimation"
     , action: Stopwatch.Action
     }

--- a/src/browser/web-views.js
+++ b/src/browser/web-views.js
@@ -37,7 +37,7 @@ const NoOp =
     }
   );
 
-const PushedDown =
+const PushedDown/*:Action*/ =
   ( { type: 'PushedDown'
     }
   );

--- a/src/browser/web-views.js
+++ b/src/browser/web-views.js
@@ -36,6 +36,12 @@ const NoOp =
   ( { type: "NoOp"
     }
   );
+
+const PushedDown =
+  ( { type: 'PushedDown'
+    }
+  );
+
 // ### Navigate WebView
 
 export const NavigateTo =
@@ -153,6 +159,8 @@ const WebViewAction =
   ? Activated(id)
   : action.type === "Closed"
   ? Closed(id)
+  : action.type === "PushedDown"
+  ? PushedDown
   : action.type === "ShowTabs"
   ? ShowTabs
   : action.type === "Create"
@@ -493,6 +501,13 @@ const selectByID = (model, id) =>
 
 // Animations
 
+const pushedDown = (model) =>
+  ( model.isFolded
+  // If model is folded, we should forward this action up a level.
+  ? [ model, Effects.receive(ShowTabs) ]
+  : [ model, Effects.none ]
+  );
+
 const fold = model =>
   ( model.isFolded
   ? [ model, Effects.none ]
@@ -606,6 +621,9 @@ export const update =
 
   : action.type === "Closed"
   ? removeByID(model, action.id)
+
+  : action.type === "PushedDown"
+  ? pushedDown(model)
 
   // Change activate web-view
   : action.type === "ActivateSelected"

--- a/src/browser/web-views.js.flow
+++ b/src/browser/web-views.js.flow
@@ -35,6 +35,7 @@ export type Model =
 
 export type Action =
   | { type: "NoOp" }
+  | { type: "PushedDown" }
   | { type: "NavigateTo"
     , uri: URI
     }


### PR DESCRIPTION
This is a simple implementation of "force touch to show tabs".

This PR does **not** attempt to use `servoMouseForceChanged` to follow force 1:1. Instead, it uses a fixed-duration animation. This is because animation code for show-tabs transition assumes hard-coded duration, and will require some non-trivial refactoring. I suggest that we merge this PR first, then do a follow-up PR.

This PR fixes some problems with https://github.com/browserhtml/browserhtml/pull/946.

Fixes https://github.com/browserhtml/browserhtml/issues/872.

cc @paulrouget.