### PR TITLE
Make browser.html usable on electron.

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,0 +1,44 @@
+const electron = require('electron');
+const app = electron.app;  // Module to control application life.
+const BrowserWindow = electron.BrowserWindow;  // Module to create native browser window.
+const path = require('path');
+
+var mainWindow = null;
+
+// Quit when all windows are closed.
+
+const onQuit = function() {
+  app.quit()
+};
+
+
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+
+var onReady = function() {
+  // Create the browser window.
+  mainWindow = new BrowserWindow
+  ( { width: 800
+    , height: 600
+    , frame: false
+    }
+  );
+
+  // and load the index.html of the app.
+  mainWindow.loadURL
+  (`file://${path.resolve(module.filename, '../dist/index.html')}`);
+
+  // Open the DevTools.
+  mainWindow.webContents.openDevTools();
+
+  // Emitted when the window is closed.
+  mainWindow.on('closed', function() {
+    // Dereference the window object, usually you would store windows
+    // in an array if your app supports multi windows, this is the time
+    // when you should delete the corresponding element.
+    mainWindow = null;
+  });
+};
+
+app.on('window-all-closed', onQuit);
+app.on('ready', onReady);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "browser": {
     "driver": "./src/driver/virtual-dom/index.js"
   },
+  "main": "./main.js",
   "scripts": {
     "develop": "gulp develop",
     "start": "gulp live",

--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -522,9 +522,10 @@ const openWebView = model =>
   ( model
   , Open
     ( { uri: URL.read(model.input.value)
-      , inBackground: false
+      , disposition: 'default'
       , name: ''
       , features: ''
+      , ref: null
       }
     )
   );
@@ -535,9 +536,10 @@ const openURL = (model, uri) =>
   , model
   , [ Open
       ( { uri
-        , inBackground: false
+        , disposition: 'default'
         , name: ''
         , features: ''
+        , ref: null
         }
       )
     , ShowWebView

--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -811,6 +811,7 @@ const styleSheet = StyleSheet.create({
     overflow: 'hidden',
     position: 'absolute',
     MozWindowDragging: 'drag',
+    WebkitAppRegion: 'drag'
   },
   content: {
     position: 'absolute',

--- a/src/browser/sidebar/tab.js
+++ b/src/browser/sidebar/tab.js
@@ -60,6 +60,7 @@ const tabHeight = '32px';
 const styleSheet = Style.createSheet({
   base: {
     MozWindowDragging: 'no-drag',
+    WebkitAppRegion: 'no-drag',
     borderRadius: '5px',
     height: tabHeight,
     color: '#fff',

--- a/src/browser/sidebar/toolbar.js
+++ b/src/browser/sidebar/toolbar.js
@@ -128,6 +128,7 @@ const viewPin = Toggle.view('pin-button', Style.createSheet({
 const viewClose = Button.view('create-tab-button', Style.createSheet({
   base:
   { MozWindowDragging: 'no-drag'
+  , WebkitAppRegion: 'no-drag'
   , color: 'rgb(255,255,255)'
   , fontFamily: 'FontAwesome'
   , fontSize: '18px'

--- a/src/browser/web-view.js
+++ b/src/browser/web-view.js
@@ -588,7 +588,8 @@ const styleSheet = StyleSheet.create({
     mozUserSelect: 'none', // necessary to pass text drag to iframe's content
     borderWidth: 0,
     backgroundColor: 'white',
-    MozWindowDragging: 'no-drag'
+    MozWindowDragging: 'no-drag',
+    WebkitAppRegion: 'no-drag'
   },
 
   topbar: {
@@ -602,6 +603,7 @@ const styleSheet = StyleSheet.create({
 
   combobox: {
     MozWindowDragging: 'no-drag',
+    WebkitAppRegion: 'no-drag',
     position: 'absolute',
     left: '50%',
     top: 0,
@@ -655,6 +657,7 @@ const styleSheet = StyleSheet.create({
 
   iconShowTabs: {
     MozWindowDragging: 'no-drag',
+    WebkitAppRegion: 'no-drag',
     backgroundImage: 'url(css/hamburger.sprite.png)',
     backgroundRepeat: 'no-repeat',
     backgroundPosition: '0 0',
@@ -674,6 +677,7 @@ const styleSheet = StyleSheet.create({
 
   iconCreateTab: {
     MozWindowDragging: 'no-drag',
+    WebkitAppRegion: 'no-drag',
     color: 'rgba(0,0,0,0.8)',
     fontFamily: 'FontAwesome',
     fontSize: '18px',

--- a/src/browser/web-view.js
+++ b/src/browser/web-view.js
@@ -10,6 +10,7 @@ import {merge, always, batch} from '../common/prelude';
 import {cursor} from '../common/cursor';
 import {compose} from '../lang/functional';
 import {on} from 'driver';
+import {isElectron} from "../common/runtime";
 import * as Shell from './web-view/shell';
 import * as Progress from './web-view/progress';
 import * as Navigation from './web-view/navigation';
@@ -24,6 +25,9 @@ import * as Driver from 'driver';
 import * as URL from '../common/url-helper';
 import * as Focusable from '../common/focusable';
 import * as Easing from 'eased';
+import * as MozBrowserFrame from './web-view/moz-browser-frame';
+import * as ElectronFrame from './web-view/electron-frame';
+
 
 /*::
 import type {Address, DOM} from "reflex"
@@ -31,6 +35,7 @@ import type {ID, URI, Time, Display, Options, Model, Action} from "./web-view"
 import {performance} from "../common/performance"
 */
 
+const NoOp = always({ type: "NoOp" });
 export const Select/*:Action*/ =
   { type: "Select"
   };
@@ -94,52 +99,12 @@ export const Load =
     }
   );
 
-export const OpenSyncWithMyIFrame =
-  ({frameElement, uri, name, features}/*:Options*/)/*:Action*/ => {
-    Driver.element.use(frameElement);
-    return {
-      type: "Open!WithMyIFrameAndInTheCurrentTick"
-    , isForced: true
-    , options: {uri, name, features, inBackground: false, frameElement: null}
-    };
-  };
-
-export const ModalPrompt =
-  (detail/*:any*/)/*:Action*/ =>
-  ({type: "ModalPrompt", detail});
-
-export const Authentificate =
-  (detail/*:any*/)/*:Action*/ =>
-  ({type: "Authentificate", detail});
-
-export const ReportError =
-  (detail/*:any*/)/*:Action*/ =>
-  ({type: "Error", detail});
-
-export const LoadStart =
-  (time/*:Time*/)/*:Action*/ =>
-  ({type: 'LoadStart', time});
-
-export const LoadEnd =
-  (time/*:Time*/)/*:Action*/ =>
-  ({type: 'LoadEnd', time});
-
-export const LocationChanged =
-  (uri/*:URI*/, canGoBack/*:?boolean*/, canGoForward/*:?boolean*/, time/*:Time*/)/*:Action*/ =>
-  ({type: 'LocationChanged', uri, canGoBack, canGoForward, time});
-
-export const ContextMenu =
-  (detail/*:any*/)/*:Action*/ =>
-  ({type: "ContextMenu", detail});
 
 const ShellAction = action =>
   ( { type: 'Shell'
     , shell: action
     }
   );
-
-const FocusShell = ShellAction(Shell.Focus);
-const BlurShell = ShellAction(Shell.Blur);
 
 export const ZoomIn/*:Action*/ = ShellAction(Shell.ZoomIn);
 export const ZoomOut/*:Action*/ = ShellAction(Shell.ZoomOut);
@@ -164,7 +129,10 @@ export const GoForward/*:Action*/ =
   NavigationAction(Navigation.GoForward);
 
 const SecurityAction = action =>
-  ({type: 'Security', action});
+  ( { type: 'Security'
+    , security: action
+    }
+  );
 
 const SecurityChanged =
   compose
@@ -174,7 +142,7 @@ const SecurityChanged =
 
 
 const PageAction = action =>
-  ({type: "Page", action});
+  ({type: "Page", page: action});
 
 const FirstPaint = PageAction(Page.FirstPaint);
 const DocumentFirstPaint = PageAction(Page.DocumentFirstPaint);
@@ -216,8 +184,12 @@ const TabAction = action =>
     }
   );
 
-const ProgressAction/*type.ProgressAction*/ = action =>
-  ({type: "Progress", action});
+const ProgressAction =
+  action =>
+  ( { type: "Progress"
+    , progress: action
+    }
+  );
 
 const SelectAnimationAction = action =>
   ( action.type === "End"
@@ -231,16 +203,7 @@ const updateProgress = cursor
   ( { get: model => model.progress
     , set: (model, progress) => merge(model, {progress})
     , tag: ProgressAction
-    , update: (model, action) =>
-        Progress.update
-        ( model
-        , ( action.type === "LoadStart"
-          ? Progress.Start(action.time)
-          : action.type === "LoadEnd"
-          ? Progress.LoadEnd(action.time)
-          : action
-          )
-        )
+    , update: Progress.update
     }
   );
 
@@ -249,16 +212,7 @@ const updatePage = cursor
   ( { get: model => model.page
     , set: (model, page) => merge(model, {page})
     , tag: PageAction
-    , update: (model, action) =>
-        Page.update
-        ( model
-        , ( action.type === "LoadStart"
-          ? Page.LoadStart
-          : action.type === "LoadEnd"
-          ? Page.LoadEnd
-          : action
-          )
-        )
+    , update: Page.update
     }
   );
 
@@ -329,7 +283,7 @@ const updateSelectAnimation = (model, action) => {
 
 export const init =
   (id/*:ID*/, options/*:Options*/)/*:[Model, Effects<Action>]*/ => {
-  const [shell, shellFx] = Shell.init(id, !options.inBackground);
+  const [shell, shellFx] = Shell.init(id, options.disposition !== 'background-tab');
   const [navigation, navigationFx] = Navigation.init(id, options.uri);
   const [page, pageFx] = Page.init(options.uri);
   const [security, securityFx] = Security.init();
@@ -506,6 +460,8 @@ export const update =
   ? deactivated(model)
   : action.type === "Focus"
   ? focus(model)
+  : action.type === "Blur"
+  ? updateShell(model, action)
 
   : action.type === 'Load'
   ? load(model, action.uri)
@@ -524,6 +480,20 @@ export const update =
   : action.type === "LocationChanged"
   ? changeLocation(model, action.uri, action.canGoBack, action.canGoForward)
 
+  : action.type === "SecurityChanged"
+  ? updateSecurity(model, action)
+  : action.type === "TitleChanged"
+  ? updatePage(model, action)
+  : action.type === "IconChanged"
+  ? updatePage(model, action)
+  : action.type === "MetaChanged"
+  ? updatePage(model, action)
+  : action.type === "LoadFail"
+  ? [ model
+    , Effects.task(Unknown.warn(action))
+      .map(NoOp)
+    ]
+
   : action.type === "Close"
   ? close(model)
 
@@ -534,15 +504,15 @@ export const update =
   // Delegate
 
   : action.type === "Progress"
-  ? updateProgress(model, action.action)
+  ? updateProgress(model, action.progress)
   : action.type === "Shell"
   ? updateShell(model, action.shell)
   : action.type === "Page"
-  ? updatePage(model, action.action)
+  ? updatePage(model, action.page)
   : action.type === "Tab"
   ? updateTab(model, action.source)
   : action.type === "Security"
-  ? updateSecurity(model, action.action)
+  ? updateSecurity(model, action.security)
   : action.type === "Navigation"
   ? updateNavigation(model, action.navigation)
 
@@ -578,8 +548,7 @@ const styleSheet = StyleSheet.create({
     zIndex: 1
   },
 
-  iframe: {
-    display: 'block', // iframe are inline by default
+  base: {
     position: 'absolute',
     top: topBarHeight,
     left: 0,
@@ -589,7 +558,7 @@ const styleSheet = StyleSheet.create({
     borderWidth: 0,
     backgroundColor: 'white',
     MozWindowDragging: 'no-drag',
-    WebkitAppRegion: 'no-drag'
+    WebkitAppRegion: 'no-drag',
   },
 
   topbar: {
@@ -723,57 +692,11 @@ const styleSheet = StyleSheet.create({
   }
 });
 
-const viewFrame = (model, address) =>
-  html.iframe({
-    id: `web-view-${model.id}`,
-    src: model.navigation.initiatedURI,
-    'data-current-uri': model.navigation.currentURI,
-    'data-name': model.name,
-    'data-features': model.features,
-    element: Driver.element,
-    style: Style(styleSheet.iframe
-                , ( model.page.pallet.background != null
-                  ? { backgroundColor: model.page.pallet.background }
-                  : null
-                  )
-                ),
-    attributes: {
-      mozbrowser: true,
-      remote: true,
-      mozapp: URL.isPrivileged(model.navigation.currentURI) ?
-                URL.getManifestURL().href :
-                void(0),
-      mozallowfullscreen: true
-    },
-    // isVisible: visiblity(model.isActive),
-    // zoom: zoom(model.shell.zoom),
-
-    isFocused: Driver.focus(model.shell.isFocused),
-
-    // Events
-
-    onBlur: on(address, always(BlurShell)),
-    onFocus: on(address, always(FocusShell)),
-    // onMozbrowserAsyncScroll: on(address, decodeAsyncScroll),
-    onMozBrowserClose: on(address, always(Close)),
-    onMozBrowserOpenWindow: on(address, decodeOpenWindow),
-    onMozBrowserOpenTab: on(address, decodeOpenTab),
-    onMozBrowserContextMenu: on(address, decodeContexMenu),
-    onMozBrowserError: on(address, decodeError),
-    onMozBrowserLoadStart: on(address, decodeLoadStart),
-    onMozBrowserConnected: on(address, decodeConnected),
-    onMozBrowserLoadEnd: on(address, decodeLoadEnd),
-    onMozBrowserFirstPaint: on(address, decodeFirstPaint),
-    onMozBrowserDocumentFirstPaint: on(address, decodeDocumentFirstPaint),
-    onMozBrowserMetaChange: on(address, decodeMetaChange),
-    onMozBrowserIconChange: on(address, decodeIconChange),
-    onMozBrowserLocationChange: on(address, decodeLocationChange),
-    onMozBrowserSecurityChange: on(address, decodeSecurityChange),
-    onMozBrowserTitleChange: on(address, decodeTitleChange),
-    onMozBrowserShowModalPrompt: on(address, decodeModalPrompt),
-    onMozBrowserUserNameAndPasswordRequired: on(address, decodeAuthenticate),
-    onMozBrowserScrollAreaChanged: on(address, decodeScrollAreaChange),
-  });
+const Frame =
+  ( isElectron
+  ? ElectronFrame
+  : MozBrowserFrame
+  );
 
 export const view =
   (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ => {
@@ -795,7 +718,7 @@ export const view =
       , model.display
       )
     }
-  , [ viewFrame(model, address)
+  , [ Frame.view(styleSheet, model, address)
     , html.div
       ( { className: 'webview-topbar'
         , style: Style
@@ -897,85 +820,3 @@ export const view =
     ]
   );
 };
-
-
-const decodeClose = always(Close);
-
-// TODO: Figure out what's in detail
-const decodeDetail = ({detail}) => detail;
-const decodeTime = ({detail}) => performance.now();
-
-// Detail is different in each case, so we define a special reader function
-// for this particular case.
-const decodeOpenDetail = ({detail}) =>
-  ( { frameElement: detail.frameElement
-    // Change url to uri for naming consistency.
-    , uri: detail.url
-    , name: detail.name
-    , features: detail.features
-    }
-  );
-
-const decodeOpenWindow = compose(OpenSyncWithMyIFrame, decodeOpenDetail);
-const decodeOpenTab = compose(OpenSyncWithMyIFrame, decodeOpenDetail);
-
-
-const decodeContexMenu = compose(ContextMenu, decodeDetail);
-
-// TODO: Figure out what's in detail
-const decodeModalPrompt = compose(ModalPrompt, decodeDetail);
-
-// TODO: Figure out what's in detail
-const decodeAuthenticate = compose(Authentificate, decodeDetail);
-
-// TODO: Figure out what's in detail
-const decodeError = compose(ReportError, decodeDetail);
-
-// Navigation
-
-const decodeLocationChange = ({detail}) =>
-  // Servo and Gecko have different implementation of detail.
-  // In Gecko, detail is a string (the uri).
-  // In Servo, detail is an object {uri,canGoBack,canGoForward}
-  ( typeof detail === 'string'
-  ? LocationChanged(detail, null, null, performance.now())
-  : LocationChanged
-    ( detail.uri
-    , detail.canGoBack
-    , detail.canGoForward
-    , performance.now()
-    )
-  );
-
-// Progress
-
-// @TODO This is not ideal & we should probably convert passed `timeStamp` to
-// the same format as `performance.now()` so that time passed through animation
-// frames is in the same format, but for now we just call `performance.now()`.
-
-const decodeLoadStart = compose(LoadStart, decodeTime);
-
-const decodeConnected = compose(Progress.Connect, decodeTime);
-
-const decodeLoadEnd = compose(LoadEnd, decodeTime);
-
-// Page
-
-const decodeFirstPaint = always(FirstPaint);
-const decodeDocumentFirstPaint = always(DocumentFirstPaint);
-const decodeTitleChange = compose(TitleChanged, decodeDetail);
-const decodeIconChange = compose(IconChanged, decodeDetail);
-
-const decodeMetaChange = ({detail: {name, content}}) =>
-  MetaChanged(name, content);
-
-// TODO: Figure out what's in detail
-const decodeAsyncScroll = ({detail}) =>
-  Scrolled(detail);
-
-const decodeScrollAreaChange = ({detail, target}) =>
-  OverflowChanged(detail.height > target.parentNode.clientHeight);
-
-const decodeSecurityChange =
-  ({detail: {state, extendedValidation}}) =>
-  SecurityChanged(state, extendedValidation);

--- a/src/browser/web-view.js.flow
+++ b/src/browser/web-view.js.flow
@@ -6,7 +6,9 @@
 
 import {Effects} from "reflex"
 import type {Address, DOM} from "reflex"
-import type {ID, URI, Time, Float} from "../common/prelude"
+import type {ID, URI, Time, Integer, Float} from "../common/prelude"
+import type {Icon} from "../common/favicon"
+
 import * as Shell from "./web-view/shell"
 import * as Progress from "./web-view/progress"
 import * as Navigation from "./web-view/navigation"
@@ -16,18 +18,27 @@ import * as Stopwatch from "../common/stopwatch"
 import * as Sidebar from "./sidebar/tab"
 import * as Tab from './sidebar/tab';
 
+
 export type {ID, URI, Time}
 
 export type Display =
   { opacity: Float
   }
 
+export type Disposition =
+  | 'default'
+  | 'foreground-tab'
+  | 'background-tab'
+  | 'new-window'
+  | 'new-popup'
+
 export type Options =
   { uri: URI
-  , inBackground: boolean
+  , disposition: Disposition
   , name: string
   , features: string
-  , frameElement?: any
+  , options?: {}
+  , ref: any
   }
 
 export type Model =
@@ -48,6 +59,7 @@ export type Model =
   }
 
 export type Action =
+  | { type: "NoOp" }
   | { type: "Select" }
   | { type: "Selected" }
   | { type: "Unselect" }
@@ -57,6 +69,7 @@ export type Action =
   | { type: "Deactivate" }
   | { type: "Deactivated" }
   | { type: "Focus" }
+  | { type: "Blur" }
   | { type: "Load"
     , uri: URI
     }
@@ -75,6 +88,17 @@ export type Action =
     , canGoForward: ?boolean
     , time: Time
     }
+  | { type: "FirstPaint" }
+  | { type: "DocumentFirstPaint" }
+  | { type: "MetaChanged", name: string, content: string }
+  | { type: "IconChanged", icon: Icon }
+  | { type: "TitleChanged", title: string }
+  | { type: "SecurityChanged"
+    , state: "broken" | "secure" | "insecure"
+    , extendedValidation: boolean
+    , trackingContent: boolean
+    , mixedContent: boolean
+    }
   | { type: "Close" }
   | { type: "Closed" }
   | { type: "Edit" }
@@ -84,38 +108,46 @@ export type Action =
     , action: Stopwatch.Action
     }
   | { type: "Progress"
-    , action: Progress.Action
+    , progress: Progress.Action
     }
   | { type: "Shell"
     , shell: Shell.Action
     }
   | { type: "Page"
-    , action: Page.Action
+    , page: Page.Action
     }
   | { type: "Tab"
     , source: Tab.Action
     }
   | { type: "Security"
-    , action: Security.Action
+    , security: Security.Action
     }
   | { type: "Navigation"
     , navigation: Navigation.Action
     }
-  | { type: "Open!WithMyIFrameAndInTheCurrentTick"
+  | { type: "Open"
     , options: Options
-    , isForced: true
     }
   | { type: "ContextMenu"
-    , detail: any
+    , clientX: Float
+    , clientY: Float
+    , systemTargets: any
+    , contextMenu: any
     }
   | { type: "Authentificate"
-    , detail: any
+    , host: string
+    , realm: string
+    , isProxy: boolean
     }
-  | { type: "Error"
-    , detail: any
+  | { type: "LoadFail"
+    , time: Time
+    , reason: string
+    , code: Integer
     }
   | { type: "ModalPrompt"
-    , detail: any
+    , kind: "alert" | "confirm" | "prompt"
+    , title: string
+    , message: string
     }
 
 
@@ -159,10 +191,6 @@ declare export function LocationChanged
  (uri:URI, time:Time):
   Action
 
-
-declare export function OpenSyncWithMyIFrame
-  (options:Options):
-  Action
 
 declare export function ModalPrompt
   (detail:any):

--- a/src/browser/web-view/electron-frame.js
+++ b/src/browser/web-view/electron-frame.js
@@ -1,0 +1,148 @@
+/* @flow */
+
+import {Effects, node, html, forward} from 'reflex';
+import * as URL from '../../common/url-helper';
+import * as Driver from 'driver';
+import * as Style from '../../common/style';
+import {on} from 'driver';
+import {always} from '../../common/prelude';
+
+
+/*::
+import type {Address, DOM} from "reflex"
+import type {ID, URI, Time, Display, Options, Model, Action} from "../web-view"
+import {performance} from "../../common/performance"
+*/
+
+const Blur = always({ type: "Blur" });
+const Focus = always({ type: "Focus" });
+const Close = always({ type: "Close" });
+const FirstPaint = always({ type: "FirstPaint" });
+const DocumentFirstPaint = always({ type: "DocumentFirstPaint" });
+
+
+
+export const view =
+  ( styleSheet/*:{ base: Style.Rules }*/
+  , model/*:Model*/
+  , address/*:Address<Action>*/
+  )/*:DOM*/ =>
+  node
+  ( 'webview'
+  , { id: `web-view-${model.id}`
+    , src: model.navigation.initiatedURI
+    , 'data-current-uri': model.navigation.currentURI
+    , 'data-name': model.name
+    , 'data-features': model.features
+    , style: Style.mix
+      ( styleSheet.base
+      , ( model.page.pallet.background != null
+        ? { backgroundColor: model.page.pallet.background }
+        : null
+        )
+      )
+
+    // Events
+
+    , onBlur: forward(address, Blur)
+    , onFocus: forward(address, Focus)
+    , onClose: forward(address, Close)
+    , "onNew-Window": on(address, decodeOpenWindow)
+    , "onPage-Favicon-Updated": on(address, decodeIconChange)
+    , "onPage-Title-Updated": on(address, decodeTitleChange)
+    , "onDid-Start-Loading": on(address, decodeLoadStart)
+    , "onDid-Navigate": on(address, decodeLocationChange)
+    , "onDid-Fail-Load": on(address, decodeLoadFail)
+    , "onDid-Stop-Loading": on(address, decodeLoadEnd)
+    , "onDid-Change-Theme-Color": on(address, decodeMetaChange)
+    , "onDOM-Ready": forward(address, DocumentFirstPaint)
+    ,
+    }
+  );
+
+// See: http://electron.atom.io/docs/v0.37.4/api/web-view-tag/#event-new-window
+const decodeOpenWindow =
+  ( event ) =>
+  ( { type: "Open"
+    , uri: event.url
+    , name: event.frameName
+    , disposition: event.disposition
+    , features: ''
+    , options: event.options
+    }
+  );
+
+// See: http://electron.atom.io/docs/v0.37.4/api/web-view-tag/#event-page-favicon-updated
+const decodeIconChange =
+  ( event ) =>
+  ( { type: "IconChanged"
+    , icon:
+      { href:
+        ( event.favicons.length > 0
+        ? event.favicons[0]
+        : ''
+        )
+      , sizes: null
+      , rel: null
+      }
+    }
+  );
+
+// See: http://electron.atom.io/docs/v0.37.4/api/web-view-tag/#event-page-title-updated
+const decodeTitleChange =
+  ( event ) =>
+  ( { type: "TitleChanged"
+    , title: event.title
+    }
+  );
+
+// See: http://electron.atom.io/docs/v0.37.4/api/web-view-tag/#event-load-commit
+const decodeLoadStart =
+  ( event ) =>
+  ( { type: "LoadStart"
+    , time: performance.now()
+    }
+  );
+
+// See: http://electron.atom.io/docs/v0.37.4/api/web-view-tag/#event-did-frame-finish-load
+const decodeLoadEnd =
+  ( event ) =>
+  ( { type: "LoadEnd"
+    , time: performance.now()
+    }
+  );
+
+// See: http://electron.atom.io/docs/v0.37.4/api/web-view-tag/#event-did-fail-load
+const decodeLoadFail =
+  ( event ) =>
+  ( { type: "LoadFail"
+    , time: performance.now()
+    , reason: event.errorDescription
+    , code: event.errorCode
+    }
+  );
+
+// @TODO: We are missing "Connected" event and I think 'did-get-response-details'
+// maybe it in electron.
+// See: http://electron.atom.io/docs/v0.37.4/api/web-view-tag/#event-did-get-response-details
+
+// See: http://electron.atom.io/docs/v0.37.4/api/web-view-tag/#event-did-navigate
+// TODO: Consider `will-navigate` event instead.
+const decodeLocationChange =
+  ( event ) =>
+  ( { type: "LocationChanged"
+    , uri: event.url
+    , time: performance.now()
+    , canGoBack: event.target.canGoBack()
+    , canGoForward: event.target.canGoForward()
+    }
+  );
+
+// See: http://electron.atom.io/docs/v0.37.4/api/web-view-tag/#event-did-change-theme-color
+const decodeMetaChange =
+  ( event ) =>
+  ( { type: "MetaChanged"
+    , name: "theme-color"
+    , content: event.themeColor
+    }
+  );

--- a/src/browser/web-view/moz-browser-frame.js
+++ b/src/browser/web-view/moz-browser-frame.js
@@ -1,0 +1,229 @@
+/* @flow */
+
+import {Effects, node, html, forward} from 'reflex';
+import * as URL from '../../common/url-helper';
+import * as Driver from 'driver';
+import * as Style from '../../common/style';
+import {on} from 'driver';
+import {always} from '../../common/prelude';
+
+
+/*::
+import type {Address, DOM} from "reflex"
+import type {ID, URI, Time, Display, Options, Model, Action} from "../web-view"
+import {performance} from "../../common/performance"
+*/
+
+const Blur = always({ type: "Blur" });
+const Focus = always({ type: "Focus" });
+const Close = always({ type: "Close" });
+const FirstPaint = always({ type: "FirstPaint" });
+const DocumentFirstPaint = always({ type: "DocumentFirstPaint" });
+
+export const view =
+  ( styleSheet/*:{ base: Style.Rules }*/
+  , model/*:Model*/
+  , address/*:Address<Action>*/
+  )/*:DOM*/ =>
+  html.iframe
+  ( { id: `web-view-${model.id}`
+    , src: model.navigation.initiatedURI
+    , 'data-current-uri': model.navigation.currentURI
+    , 'data-name': model.name
+    , 'data-features': model.features
+    , element: Driver.element
+    , style: Style.mix
+      ( styleSheet.base
+      , ( model.page.pallet.background != null
+        ? { backgroundColor: model.page.pallet.background }
+        : null
+        )
+      )
+    , attributes:
+      { mozbrowser: true
+      , remote: true
+      , mozapp:
+        ( URL.isPrivileged(model.navigation.currentURI)
+        ? URL.getManifestURL().href
+        : void(0)
+        )
+      , mozallowfullscreen: true
+      }
+
+    // Events
+
+    , onBlur: forward(address, Blur)
+    , onFocus: forward(address, Focus)
+    , onMozBrowserClose: forward(address, Close)
+    , onMozBrowserOpenWindow: on(address, decodeOpenWindow)
+    , onMozBrowserOpenTab: on(address, decodeOpenTab)
+    , onMozBrowserContextMenu: on(address, decodeContexMenu)
+    , onMozBrowserError: on(address, decodeLoadFail)
+    , onMozBrowserLoadStart: on(address, decodeLoadStart)
+    , onMozBrowserConnected: on(address, decodeConnected)
+    , onMozBrowserLoadEnd: on(address, decodeLoadEnd)
+    , onMozBrowserFirstPaint: forward(address, FirstPaint)
+    , onMozBrowserDocumentFirstPaint: forward(address, DocumentFirstPaint)
+    , onMozBrowserMetaChange: on(address, decodeMetaChange)
+    , onMozBrowserIconChange: on(address, decodeIconChange)
+    , onMozBrowserLocationChange: on(address, decodeLocationChange)
+    , onMozBrowserSecurityChange: on(address, decodeSecurityChange)
+    , onMozBrowserTitleChange: on(address, decodeTitleChange)
+    , onMozBrowserShowModalPrompt: on(address, decodeModalPrompt)
+    , onMozBrowserUserNameAndPasswordRequired: on(address, decodeAuthenticate)
+    }
+  );
+
+// See: https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowseropenwindow
+const decodeOpenWindow =
+  ( { detail } ) =>
+  ( { type: "Open"
+    , options:
+      { uri: detail.url
+      , disposition: 'default'
+      , name: detail.name
+      , features: detail.features
+      , ref: Driver.element.use(detail.frameElement)
+      }
+    }
+  );
+
+// See: https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowseropentab
+const decodeOpenTab =
+  ( { detail } ) =>
+  ( { type: "Open"
+    , options:
+      { uri: detail.url
+      , disposition: 'default'
+      , name: ''
+      , features: ''
+      , ref: null
+      }
+    }
+  );
+
+// See: https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowsererror
+const decodeLoadFail =
+  ( { detail } ) =>
+  ( { type: "LoadFail"
+    , time: performance.now()
+    , reason: detail.type
+    // Gecko unlike Electron does not actually pass error codes. Absense of
+    // it is identified as `-1` which is what used here.
+    , code: -1
+    }
+  );
+
+// See: https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowsercontextmenu
+const decodeContexMenu =
+  ( { detail } ) =>
+  ( { type: "ContextMenu"
+    , clientX: detail.clientX
+    , clientY: detail.clientY
+    , systemTargets: detail.systemTargets
+    , contextMenu: detail.contextmenu
+    }
+  );
+
+// See: https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowserloadstart
+const decodeLoadStart =
+  ( { detail } ) =>
+  ( { type: "LoadStart"
+    , time: performance.now()
+    }
+  );
+
+// See: https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowserloadend
+const decodeLoadEnd =
+  ( { detail } ) =>
+  ( { type: "LoadEnd"
+    , time: performance.now()
+    }
+  );
+
+const decodeConnected =
+  ( { detail } ) =>
+  ( { type: "Connect"
+    , time: performance.now()
+    }
+  );
+
+const decodeMetaChange =
+  ( { detail } ) =>
+  ( { type: "MetaChanged"
+    , name: detail.name
+    , content: detail.content
+    }
+  );
+
+// See: https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowsericonchange
+const decodeIconChange =
+  ( { detail } ) =>
+  ( { type: "IconChanged"
+    , icon:
+      { href: detail.href
+      , sizes: detail.sizes
+      , rel: detail.rel
+      }
+    }
+  );
+
+// See: https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowserlocationchange
+
+const decodeLocationChange =
+  ( { detail } ) =>
+  // Servo and Gecko have different implementation of detail.
+  // In Gecko, detail is a string (the uri).
+  // In Servo, detail is an object {uri,canGoBack,canGoForward}
+  ( typeof(detail) === "string"
+  ? { type: "LocationChanged"
+    , uri: detail
+    , time: performance.now()
+    , canGoBack: null
+    , canGoForward: null
+    }
+  : { type: "LocationChanged"
+    , uri: detail.uri
+    , time: performance.now()
+    , canGoBack: detail.canGoBack
+    , canGoForward: detail.canGoForward
+    }
+  );
+
+// See: https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowsersecuritychange
+const decodeSecurityChange =
+  ( { detail } ) =>
+  ( { type: "SecurityChanged"
+    , state: detail.state
+    , extendedValidation: detail.extendedValidation
+    , trackingContent: detail.trackingContent
+    , mixedContent: detail.mixedContent
+    }
+  );
+
+const decodeTitleChange =
+  ( { detail } ) =>
+  ( { type: "TitleChanged"
+    , title: detail
+    }
+  );
+
+// See: https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowsershowmodalprompt
+const decodeModalPrompt =
+  ( { detail } ) =>
+  ( { type: "ModalPrompt"
+    , kind: detail.promptType
+    , title: detail.title
+    , message: detail.message
+    }
+  );
+
+// See: https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowserusernameandpasswordrequired
+const decodeAuthenticate =
+  ( { detail } ) =>
+  ( { type: "Authentificate"
+    , host: detail.host
+    , realm: detail.realm
+    , isProxy: detail.isProxy
+    }
+  );

--- a/src/browser/web-view/security.js
+++ b/src/browser/web-view/security.js
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /*::
-import type {Model, Action} from './security'
+import type {Model, Action, State} from './security'
 */
 
 import {Effects} from 'reflex';
@@ -17,8 +17,8 @@ export const LoadStart/*:Action*/ =
   };
 
 export const Changed =
-  (state/*:string*/, extendedValidation/*:boolean*/)/*:Action*/ =>
-  ( { type: "Changed"
+  (state/*:State*/, extendedValidation/*:boolean*/)/*:Action*/ =>
+  ( { type: "SecurityChanged"
     , state
     , extendedValidation
     }
@@ -45,7 +45,7 @@ export const update =
       )
     , Effects.none
     ]
-  : action.type === 'Changed'
+  : action.type === 'SecurityChanged'
   ? [ merge
       ( model
       , { state: action.state

--- a/src/browser/web-view/security.js.flow
+++ b/src/browser/web-view/security.js.flow
@@ -2,17 +2,22 @@
 
 import {Effects} from "reflex"
 
+export type State =
+  | "broken"
+  | "secure"
+  | "insecure"
 
 export type Model =
-  { state: string
+  { state: State
   , secure: boolean
   , extendedValidation: boolean
   }
 
+
 export type Action =
   | { type: "LoadStart" }
-  | { type: "Changed"
-    , state: string
+  | { type: "SecurityChanged"
+    , state: State
     , extendedValidation: boolean
     }
 

--- a/src/browser/web-view/shell.js
+++ b/src/browser/web-view/shell.js
@@ -37,8 +37,8 @@ const FocusableAction =
   action =>
   ({type: "Focusable", action});
 
-export const Focus/*:Action*/ = FocusableAction(Focusable.Focus);
-export const Blur/*:Action*/ = FocusableAction(Focusable.Blur);
+export const Focus/*:Action*/ = Focusable.Focus;
+export const Blur/*:Action*/ = Focusable.Blur;
 
 const NoOp = always({type: "NoOp"});
 
@@ -111,11 +111,7 @@ const report =
   });
 
 
-const updateFocus = cursor
-  ( { update: Focusable.update
-    , tag: FocusableAction
-    }
-  );
+const updateFocus = Focusable.update;
 
 export const init =
   (id/*:ID*/, isFocused/*:boolean*/)/*:[Model, Effects<Action>]*/ =>
@@ -180,8 +176,10 @@ export const update =
     )
 
   // Delegate
-  : action.type === 'Focusable'
-  ? updateFocus(model, action.action)
+  : action.type === 'Focus'
+  ? updateFocus(model, action)
+  : action.type === 'Blur'
+  ? updateFocus(model, action)
 
   : [model, Effects.none]
   );

--- a/src/browser/web-view/shell.js.flow
+++ b/src/browser/web-view/shell.js.flow
@@ -34,9 +34,8 @@ export type Action =
   | { type: "VisibilityChanged"
     , visibilityResult: any //Result<Error, boolean>
     }
-  | { type: "Focusable"
-    , action: Focusable.Action
-    }
+  | { type: "Focus" }
+  | { type: "Blur" }
 
 declare export var ZoomIn:Action
 declare export var ZoomOut:Action

--- a/src/browser/web-views.js
+++ b/src/browser/web-views.js
@@ -45,13 +45,14 @@ export const NavigateTo =
 // ### Open WebView
 
 export const Open =
-  ({uri, inBackground, name, features}/*:WebView.Options*/)/*:Action*/ =>
+  ({uri, disposition, name, features, ref}/*:WebView.Options*/)/*:Action*/ =>
   ( { type: "Open"
     , options:
       { uri
-      , inBackground: Boolean(inBackground)
-      , name: name == null ? '' : name
-      , features: features == null ? '' : features
+      , disposition
+      , name
+      , features
+      , ref
       }
     }
   );
@@ -145,7 +146,7 @@ const ActiveWebViewAction = action =>
 // not anotated instead they produce special actions recognized by this module.
 const WebViewAction =
   (id, action) =>
-  ( action.type === "Open!WithMyIFrameAndInTheCurrentTick"
+  ( action.type === "Open"
   ? action
   : action.type === "Selected"
   ? Selected(id)
@@ -267,8 +268,12 @@ const navigateTo = (model, uri) =>
   // If there are 0 web-views open we open a first one.
   ? open
     ( model
-    , {uri, inBackground: false, name: '', features: '' }
-    , false
+    , { uri
+      , disposition: 'default'
+      , name: ''
+      , features: ''
+      , ref: null
+      }
     )
   // Otherwise we load given `uri` into active one.
   : load(model, uri)
@@ -281,7 +286,7 @@ const load = (model, uri) =>
 
 // ### Open WebView
 
-const open = (model, options, isForced=false) => {
+const open = (model, options) => {
   const id = String(model.nextID);
   const [ entry, initFX ] = WebView.init(id, options);
 
@@ -298,7 +303,7 @@ const open = (model, options, isForced=false) => {
   // Next state is a resulting state which matches intermidate state
   // cumputed earlier or it's a version with selection changes.
   const [ next, activateFX ] =
-    ( options.inBackground
+    ( options.disposition === 'background-tab'
     ? [ intermidate, Effects.none ]
     : activateByID(intermidate, id)
     );
@@ -308,7 +313,7 @@ const open = (model, options, isForced=false) => {
     , Effects.batch
       ( [ initFX.map(ByID(id))
         , activateFX
-        , ( isForced
+        , ( options.ref != null
           ? Driver.force
           : Effects.none
           )
@@ -593,9 +598,7 @@ export const update =
   // Open web-view
 
   : action.type === "Open"
-  ? open(model, action.options, false)
-  : action.type === "Open!WithMyIFrameAndInTheCurrentTick"
-  ? open(model, action.options, true)
+  ? open(model, action.options)
 
   // Close web-view
   : action.type === "CloseActive"

--- a/src/common/keyboard.js
+++ b/src/common/keyboard.js
@@ -13,6 +13,94 @@ import * as OS from './os';
 
 const platform = OS.platform();
 
+const getCharCode =
+  ({charCode, keyCode}) =>
+  ( keyCode === 13
+  ? 13
+  : charCode == null
+  ? keyCode
+  : charCode >= 32
+  ? charCode
+  : 0
+  );
+
+
+if (!('key' in window.KeyboardEvent.prototype)) {
+  const keyTable =
+    { "3": "Enter"
+    , "8": "Backspace"
+    , "9": "Tab"
+    , "12": "Clear"
+    , "13": "Enter"
+    , "16": "Shift"
+    , "17": "Control"
+    , "18": "Alt"
+    , "19": "Pause"
+    , "20": "CapsLock"
+    , "27": "Escape"
+    , "32": "Space"
+    , "33": "PageUp"
+    , "34": "PageDown"
+    , "35": "End"
+    , "36": "Home"
+    , "37": "ArrowLeft"
+    , "38": "ArrowUp"
+    , "39": "ArrowRight"
+    , "40": "ArrowDown"
+    , "44": "PrintScreen"
+    , "45": "Insert"
+    , "46": "Delete"
+    , "112": "F1"
+    , "113": "F2"
+    , "114": "F3"
+    , "115": "F4"
+    , "116": "F5"
+    , "117": "F6"
+    , "118": "F7"
+    , "119": "F8"
+    , "120": "F9"
+    , "121": "F10"
+    , "122": "F11"
+    , "123": "F12"
+    , "144": "NumLock"
+    , "145": "ScrollLock"
+    , "224": "Meta"
+    , "91": "Meta"
+    , "92": "Meta"
+    , "93": "Meta"
+    , "63273": "Home"
+    , "63275": "End"
+    , "63276": "PageUp"
+    , "63277": "PageDown"
+    , "63302": "Insert"
+    };
+
+  const getKey = function() {
+    if (this.type === 'keypress') {
+      const charCode = getCharCode(this)
+      const key =
+        ( charCode === 13
+        ? keyTable[charCode]
+        : String.fromCharCode(charCode)
+        );
+
+      return key
+    }
+    else if (this.type === 'keyup' || this.type === 'keydown') {
+      return keyTable[this.keyCode]
+    } else {
+      return ''
+    }
+  };
+
+  Object.defineProperty
+  ( window.KeyboardEvent.prototype
+  , 'key'
+  , { get: getKey
+    /*::, value: void(0)*/
+    }
+  );
+}
 
 const readModifiers = ({type, metaKey, shiftKey, altKey, ctrlKey}) => {
   const modifiers = [];

--- a/src/common/runtime.js
+++ b/src/common/runtime.js
@@ -72,12 +72,12 @@ export const isServo/*:boolean*/ =
   .toLowerCase()
   .indexOf(' servo') != -1
 
-export const isElector/*:boolean*/ =
+export const isElectron/*:boolean*/ =
   window
   .navigator
   .userAgent
   .toLowerCase()
-  .indexOf(' Electron') != -1
+  .indexOf(' electron') != -1
 
 export const never/*:Task<Never, any>*/ =
   new Task(succeed => void(0));

--- a/src/common/runtime.js
+++ b/src/common/runtime.js
@@ -72,6 +72,13 @@ export const isServo/*:boolean*/ =
   .toLowerCase()
   .indexOf(' servo') != -1
 
+export const isElector/*:boolean*/ =
+  window
+  .navigator
+  .userAgent
+  .toLowerCase()
+  .indexOf(' Electron') != -1
+
 export const never/*:Task<Never, any>*/ =
   new Task(succeed => void(0));
 

--- a/src/common/runtime.js.flow
+++ b/src/common/runtime.js.flow
@@ -93,6 +93,7 @@ declare export function request <request, response>
   Task<Never, response>
 
 declare export var isServo:boolean;
+declare export var isElectron:boolean;
 
 declare export var quit:Task<Never, Result<Error, void>>;
 declare export var minimize:Task<Never, Result<Error, void>>;

--- a/src/common/style.js
+++ b/src/common/style.js
@@ -61,7 +61,7 @@ export const mix = (...styles/*:Array<?Rules>*/)/*:Rules*/ => {
   }
 
   const composedStyle = id !== null ?
-    composedStyles[id] :
+    composedStyles[id/*::.toString()*/] :
     null;
 
   if (composedStyle != null) {
@@ -71,7 +71,7 @@ export const mix = (...styles/*:Array<?Rules>*/)/*:Rules*/ => {
     const composedStyle = Object.assign({}, ...styles);
     // @FlowIssue: Flow does not get spread here.
     composedStyle[ID] = id;
-    composedStyles[id] = composedStyle;
+    composedStyles[id/*::.toString()*/] = composedStyle;
     return composedStyle;
   }
   else {

--- a/src/common/style.js.flow
+++ b/src/common/style.js.flow
@@ -5,6 +5,7 @@ export type Name = string
 export type Value
   = string
   | number
+  | boolean
 
 export type Selector = string
 


### PR DESCRIPTION
With this changes you can run browser.html on top of Electron. To do so you need, to:


1. Install electron on your machine. You can do it by running `npm install -g electron-prebuilt`
2. Run browser.html on top of Electron from project root via command `electron .`