### PR TITLE
Avoid errors on incomplete URLSearchParams implementations

### DIFF
--- a/src/common/runtime.js
+++ b/src/common/runtime.js
@@ -189,7 +189,7 @@ const Env =
   () => {
     const url = URL.parse(window.location.href);
     const params = url.searchParams;
-    try {
+    if (params != null && Symbol.iterator in params) {
       const env = Object.create(null);
       for (let [key, value] of params) {
         if (env[key] == null) {
@@ -202,14 +202,11 @@ const Env =
           env[key] = [env[key], value]
         }
       }
+      return env
     }
-    // URL.prototype.searchParams is not fully functional everywhere
-    // yet there for we fallback to manual query parsing if we hit some
-    // of the implementation gaps.
-    catch (_) {
+    else {
       return QueryString.parse(url.search.substr(1));
     }
-    return env
   }
 
 export const env/*:{[key:string]: ?string|?Array<?string>}*/ = Env();

--- a/src/common/runtime.js
+++ b/src/common/runtime.js
@@ -187,14 +187,10 @@ export const useNativeTitlebar =
 
 const Env =
   () => {
-    const env = Object.create(null);
     const url = URL.parse(window.location.href);
     const params = url.searchParams;
-    // @Hack: On servo searchParams don't show up (See  servo/servo#10335)
-    if (params == null) {
-      return QueryString.parse(url.search.substr(1));
-    }
-    else {
+    try {
+      const env = Object.create(null);
       for (let [key, value] of params) {
         if (env[key] == null) {
           env[key] = value;
@@ -206,6 +202,12 @@ const Env =
           env[key] = [env[key], value]
         }
       }
+    }
+    // URL.prototype.searchParams is not fully functional everywhere
+    // yet there for we fallback to manual query parsing if we hit some
+    // of the implementation gaps.
+    catch (_) {
+      return QueryString.parse(url.search.substr(1));
     }
     return env
   }

--- a/src/common/url-helper.js
+++ b/src/common/url-helper.js
@@ -26,7 +26,19 @@ const nullURL =
   , pathname: ''
   , search: ''
   , hash: ''
-  , searchParams: new window.URLSearchParams()
+  , searchParams:
+    ( window.URLSearchParams != null
+    ? new window.URLSearchParams()
+    : { append() { throw Error('Not Implemented') }
+      , delete() { throw Error('Not Implemented') }
+      , get() { return void(0) }
+      , getAll() { return [] }
+      , has() { return false }
+      , set() { throw Error('Not Implemented') }
+      , ['@@iterator']() { return [].values() }
+      , [Symbol.iterator]() { return [].values() }
+      }
+    )
   }
 
 export const parse = (input/*:string*/)/*:URL*/ => {

--- a/src/common/url-helper.js.flow
+++ b/src/common/url-helper.js.flow
@@ -38,7 +38,7 @@ declare class URLSearchParams {
   append(name:USVString, value:USVString):void;
   delete(name:USVString):void;
   get(name:USVString):?USVString;
-  getAll(name:USVString):Iterator<USVString>;
+  getAll(name:USVString):Array<USVString>;
   has(name:USVString):boolean;
   set(name:USVString, value:USVString):void;
   @@iterator(): Iterator<[USVString, USVString]>;


### PR DESCRIPTION
- WebKit does not even have `window.URLSearchParams` so attempt to construct was throwing an error.
- Servo does no implement iteration protocol for `URLSearchParams[Symbol.iterator]` so attempt to iterate was throwing.

Fixes #985