### PR TITLE
Fix connection between window & it’s opener

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -526,6 +526,7 @@ const openWebView = model =>
       , name: ''
       , features: ''
       , ref: null
+      , guestInstanceId: null
       }
     )
   );
@@ -540,6 +541,7 @@ const openURL = (model, uri) =>
         , name: ''
         , features: ''
         , ref: null
+        , guestInstanceId: null
         }
       )
     , ShowWebView

--- a/src/browser/web-view.js
+++ b/src/browser/web-view.js
@@ -301,13 +301,14 @@ export const init =
 
   return [
     { id
+    , guestInstanceId: options.guestInstanceId
     , name: options.name
     , features: options.name
     , isSelected: false
     , isActive: false
     , display:
       { opacity:
-          ( options.inBackground
+          ( options.disposition === "background-tab"
           ? 0
           : 1
           )
@@ -328,9 +329,19 @@ export const init =
       , navigationFx.map(NavigationAction)
       , progressFx.map(ProgressAction)
       , animationFx.map(SelectAnimationAction)
-      , ( options.inBackground
+      , ( options.disposition === "background-tab"
         ? Effects.none
         : Effects.receive(Activate)
+        )
+      , ( options.ref != null
+        ? Effects.task
+          ( Driver.forceReplace
+            ( `#web-view-${id}`
+            , options.ref
+            )
+          )
+          .map(NoOp)
+        : Effects.none
         )
       ]
     )
@@ -448,7 +459,9 @@ const close = model =>
 
 export const update =
   (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
-  ( action.type === "Select"
+  ( action.type === "NoOp"
+  ? [ model, Effects.none ]
+  : action.type === "Select"
   ? select(model)
   : action.type === "Selected"
   ? [ model, Effects.none ]

--- a/src/browser/web-view.js.flow
+++ b/src/browser/web-view.js.flow
@@ -39,10 +39,12 @@ export type Options =
   , features: string
   , options?: {}
   , ref: any
+  , guestInstanceId: ?string
   }
 
 export type Model =
   { id: ID
+  , guestInstanceId: ?string
   , name: string
   , features: string
   , isSelected: boolean

--- a/src/browser/web-view/electron-frame.js
+++ b/src/browser/web-view/electron-frame.js
@@ -34,6 +34,16 @@ export const view =
     , 'data-current-uri': model.navigation.currentURI
     , 'data-name': model.name
     , 'data-features': model.features
+    // Stock electron does not actually connect window with it's opener in any
+    // way. Brave desktop browser has patched Electron to add support for it
+    // via `data-guest-instance-id` attribute. Once that patch is uplifted
+    // this will take take care of connecting window and it's opener. For more
+    // details see: https://github.com/browserhtml/browserhtml/issues/566
+    , 'data-guest-instance-id':
+      ( model.guestInstanceId == null
+      ? void(0)
+      : model.guestInstanceId
+      )
     , style: Style.mix
       ( styleSheet.base
       , ( model.page.pallet.background != null
@@ -64,11 +74,15 @@ export const view =
 const decodeOpenWindow =
   ( event ) =>
   ( { type: "Open"
-    , uri: event.url
-    , name: event.frameName
-    , disposition: event.disposition
-    , features: ''
-    , options: event.options
+    , options:
+      { uri: event.url
+      , name: event.frameName
+      , disposition: event.disposition
+      , features: ''
+      , guestInstanceId: event.options.webPreferences.guestInstanceId
+      , ref: null
+      , options: event.options
+      }
     }
   );
 

--- a/src/browser/web-view/moz-browser-frame.js
+++ b/src/browser/web-view/moz-browser-frame.js
@@ -31,7 +31,6 @@ export const view =
     , 'data-current-uri': model.navigation.currentURI
     , 'data-name': model.name
     , 'data-features': model.features
-    , element: Driver.element
     , style: Style.mix
       ( styleSheet.base
       , ( model.page.pallet.background != null
@@ -83,7 +82,8 @@ const decodeOpenWindow =
       , disposition: 'default'
       , name: detail.name
       , features: detail.features
-      , ref: Driver.element.use(detail.frameElement)
+      , ref: detail.frameElement
+      , guestInstanceId: null
       }
     }
   );
@@ -98,6 +98,7 @@ const decodeOpenTab =
       , name: ''
       , features: ''
       , ref: null
+      , guestInstanceId: null
       }
     }
   );

--- a/src/browser/web-views.js
+++ b/src/browser/web-views.js
@@ -51,15 +51,9 @@ export const NavigateTo =
 // ### Open WebView
 
 export const Open =
-  ({uri, disposition, name, features, ref}/*:WebView.Options*/)/*:Action*/ =>
+  (options/*:WebView.Options*/)/*:Action*/ =>
   ( { type: "Open"
-    , options:
-      { uri
-      , disposition
-      , name
-      , features
-      , ref
-      }
+    , options
     }
   );
 
@@ -281,6 +275,7 @@ const navigateTo = (model, uri) =>
       , name: ''
       , features: ''
       , ref: null
+      , guestInstanceId: null
       }
     )
   // Otherwise we load given `uri` into active one.
@@ -321,10 +316,6 @@ const open = (model, options) => {
     , Effects.batch
       ( [ initFX.map(ByID(id))
         , activateFX
-        , ( options.ref != null
-          ? Driver.force
-          : Effects.none
-          )
         ]
       )
     ]

--- a/src/main.js
+++ b/src/main.js
@@ -46,18 +46,7 @@ const application = start
 
 const renderer = new Renderer({target: document.body});
 application.view.subscribe(renderer.address);
-
-// Mozbrowser API has cerntain events that need to be handler with-in
-// the same tick otherwise it's not going to work. To handle those events
-// properly we use `Driver.force` effect that sends in special
-// `{type: "Driver.Execute"}` action on which we force a render to run in
-// the same tick.
-application.task.subscribe(Effects.driver(action => {
-  if (action.type === "Driver.Execute") {
-    renderer.execute();
-  } else {
-    application.address(action);
-  }
-}));
+application.task.subscribe(Effects.driver(application.address));
 
 window.application = application;
+window.renderer = renderer;


### PR DESCRIPTION
To make `window.open(uri).close()` we relied on bunch of fragile hacks that broke at some point. This patch removes some of the hacks and instead adds several tasks to make avoid platform limitations:

forceRender - Forces renderer to update DOM in the same tick (which is needs to be a case for mozbrowseropenwindow)

replaceElement(selector, element) - Replaces element matching passed query selector with passed element. It also copies over attributes, properties & event listeners from element being replaced.

forceReplace(selector, element) - Forces render in the same tick & replaced element

Patch also removes some of the obsolete code that has being long replaced by other tasks.