### PR TITLE
Update to reflex 0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eased": "0.1.0",
     "pouchdb": "4.0.0",
     "querystring": "0.2.0",
-    "reflex": "0.2.0",
+    "reflex": "0.3.1",
     "reflex-virtual-dom-driver": "0.2.0",
     "tinycolor2": "1.1.2"
   },


### PR DESCRIPTION
New version of reflex has new task scheduler which was rewritten to dramatically reduce number of allocations performed during task execution. Before this change task scheduler was in top 5 allocation sights when profiling page load. After this change scheduler does not appear even in top 20 allocation sights whine profiling page load.

Unfortunately I don't think this has a significant impact on overall performance as far as I can tell, but it should help us reduce GC pauses overall.