### PR TITLE
Iframe display block

### DIFF
--- a/src/browser/web-view.js
+++ b/src/browser/web-view.js
@@ -585,7 +585,6 @@ const styleSheet = StyleSheet.create({
     backgroundColor: 'white',
     MozWindowDragging: 'no-drag',
     WebkitAppRegion: 'no-drag',
-    display: 'block',
   },
 
   topbar: {

--- a/src/browser/web-view/moz-browser-frame.js
+++ b/src/browser/web-view/moz-browser-frame.js
@@ -33,6 +33,7 @@ export const view =
     , 'data-features': model.features
     , style: Style.mix
       ( styleSheet.base
+      , frameStyleSheet.mozbrowser
       , ( model.page.pallet.background != null
         ? { backgroundColor: model.page.pallet.background }
         : null
@@ -226,5 +227,13 @@ const decodeAuthenticate =
     , host: detail.host
     , realm: detail.realm
     , isProxy: detail.isProxy
+    }
+  );
+
+
+const frameStyleSheet = Style.createSheet
+  ( { mozbrowser:
+      { display: "block"
+      }
     }
   );


### PR DESCRIPTION
This change reverts d15d0ae as it was breaking layout on Electron & instead add's `display:block` to only `mozbrowser` iframes.