### PR TITLE
Fix regression in live reloading.

### DIFF
--- a/src/devtools.js
+++ b/src/devtools.js
@@ -29,6 +29,7 @@ export type Action <model, action> =
   | { type: "Replay", replay: Replay.Action<model, action> }
   | { type: "Log", log: Log.Action<model, action> }
   | { type: "ReplayDebuggee", model: model }
+  | { type: "Persist" }
 
 
 
@@ -88,6 +89,22 @@ const TagDebuggee = /*::<model, action>*/
     , debuggee: action
     }
   )
+
+export const Persist = { type: "Persist" }
+
+export const persist = /*::<model, action, flags>*/
+  ( model/*:Model<model, action>*/
+  )/*:Step<model, action>*/ =>
+  [ model
+  , Effects.none
+  ];
+
+export const restore = /*::<model, action, flags>*/
+  ({Debuggee, flags}/*:Flags<model, action, flags>*/
+  )/*:Step<model, action>*/ =>
+  [ merge(window.application.model.value, {Debuggee, flags})
+  , Effects.none
+  ];
 
 export const init = /*::<model, action, flags>*/
   ({Debuggee, flags}/*:Flags<model, action, flags>*/)/*:Step<model, action>*/ => {
@@ -159,6 +176,10 @@ export const update = /*::<model, action, flags>*/
     )
   : action.type === "ReplayDebuggee"
   ? replayDebuggee(model, action.model)
+
+  : action.type === "Persist"
+  ? persist(model)
+  
   : Unknown.update(model, action)
   )
 

--- a/src/main.js
+++ b/src/main.js
@@ -24,17 +24,11 @@ console.timeStamp =
 // If hotswap change address so it points to a new mailbox &r
 // re-render.
 if (isReload) {
-  window.application.address(UI.LiveReload);
+  window.application.address(Devtools.Persist);
 }
 
 document.body.classList.toggle('use-native-titlebar',
                                Runtime.useNativeTitlebar());
-
-const restore =
-  () =>
-  [ window.application.model.value
-  , Effects.none
-  ]
 
 const application = start
   ( { flags:
@@ -43,7 +37,7 @@ const application = start
       }
     , init:
       ( isReload
-      ? restore
+      ? Devtools.restore
       : Devtools.init
       )
 
@@ -55,8 +49,8 @@ const application = start
   );
 
 
-
 const renderer = new Renderer({target: document.body});
+
 application.view.subscribe(renderer.address);
 application.task.subscribe(Effects.driver(application.address));
 


### PR DESCRIPTION
New devtools code stores module it instruments in the model, this broke live reload as application is restored from last state which still used to point to old module code that has not changed.