### PR TITLE
Make interact with about:newtab different from regular tabs

### DIFF
--- a/src/about/newtab/newtab.js
+++ b/src/about/newtab/newtab.js
@@ -136,7 +136,12 @@ export const view =
         , readWallpaper(activeWallpaper)
         )
       }
-    , [ thunk
+    , [ html.meta
+        ( { name: "theme-color"
+          , content: activeWallpaper.color
+          }
+        )
+      , thunk
         ( 'tiles'
         , Tiles.view
         , tiles

--- a/src/browser/Navigators.js
+++ b/src/browser/Navigators.js
@@ -108,6 +108,14 @@ const tagDeck =
               type: "Deck"
             , deck: action.modify
             }
+          case "Select":
+            return {
+              type: "Deck"
+            , deck:
+              { type: "Select"
+              , id: action.id
+              }
+            }
           case "Closed":
             return {
               type: "Deck"
@@ -156,6 +164,8 @@ export const init =
         }
       , assistant: true
       , overlay: true
+      , isPinned: true
+      , isInputEmbedded: true
       }
 
     const [deck, $deck] = Deck.init();

--- a/src/browser/Navigators/Navigator/WebView.js
+++ b/src/browser/Navigators/Navigator/WebView.js
@@ -324,7 +324,7 @@ export const init =
       , options.name
       , options.features
       , Tab.init()
-      , Shell.init(ref, options.disposition !== 'background-tab')
+      , Shell.init(ref, false)
       , Navigation.init(ref, options.uri)
       , Security.init()
       , Page.init(options.uri)

--- a/src/browser/Sidebar/Tab.js
+++ b/src/browser/Sidebar/Tab.js
@@ -251,7 +251,10 @@ export const render =
           , [ readTitle(model.output, 'Untitled')
             ]
           )
-        , thunk('close', viewClose, model.isSelected, model.output.tab, address)
+        , ( model.isPinned
+          ? ""
+          : thunk('close', viewClose, model.isSelected, model.output.tab, address)
+          )
         ]
       )
     ]


### PR DESCRIPTION
With this patch following changes are made:

1. `about:newtab` page sets a meta tag on theme changes to update titlebar so it matches the wallpaper.
2. `about:newtab` always has a input field displayed & it can't be dismissed.
3. `about:newtab` does not get's overlay when input is active.
4. It is not possible to close `about:newtab`.
5. Entering urls / search queries in `about:newtab` opens them in new tabs.

Please note this pull is based off #1065 there for it includes changes from there, in other words I'd just look at last two commits. Also all other pulls have being factored out from here and there for all changes are necessary to get expected experience.

P.S.: This is not the approach I would like to take, more specifically polluting Navigator with `isPinned` and `isInputEmbedded` and then branching logic on updates is not good approach. Instead I would like to allow different kinds of `Navigator`s and let each kind define it's own update / view logic.  But that seems like a larger change which I'd rather do as followup than block necessary fixes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1055)
<!-- Reviewable:end -->