### PR TITLE
Listen for top level events on window.

### DIFF
--- a/src/driver/virtual-dom/index.js
+++ b/src/driver/virtual-dom/index.js
@@ -122,7 +122,7 @@ export const on = (address, decode, options, getTarget) => {
   return address[id]
 }
 
-const getRoot = target => target.ownerDocument
+const getRoot = target => target.ownerDocument.defaultView
 export const onWindow = (address, decode, options) =>
   on(address, decode, options, getRoot)
 


### PR DESCRIPTION
Electron (& WebKit in general) does not dispatch `focus` / `blur` events on the document, it does on `window` instead. We are listening on `document` instead as it used to work in servo (see #1053) but it no longer does. This patch changes code back so we listen for top level events on window again, presumably servo/servo#9482 will fix it so that events are dispatched on window instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1064)
<!-- Reviewable:end -->
