### PR TITLE
Fix tile clipping issues on servo

### DIFF
--- a/src/about/newtab/main.css
+++ b/src/about/newtab/main.css
@@ -28,5 +28,4 @@ body {
   font-size: 12px;
   line-height: 1.5;
   overflow: hidden;
-  border-radius: 6px;
 }


### PR DESCRIPTION
There are clipping issue servo/servo#11562 in webrender that occurs when clipping rounder region with in the rounded region. This change removes border-radius on body that was rounder for no apparent reason & there for avoids above mentioned issues in webrender.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1076)
<!-- Reviewable:end -->
