### PR TITLE
Fix link for stackoverflow.com

### DIFF
--- a/src/about/newtab/tiles.json
+++ b/src/about/newtab/tiles.json
@@ -66,7 +66,7 @@
     }
   , "10":
     { "title": "Stack Overflow"
-    , "uri": "https://github.com/browserhtml/browserhtml/issues"
+    , "uri": "https://stackoverflow.com"
     , "src": "./tiles/stackoverflow.com.png"
     }
   , "11":


### PR DESCRIPTION
It was pointing to our issues page instead for some reason.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1078)
<!-- Reviewable:end -->
