### PR TITLE
Disable wallpaper switcher on about:newtab

### DIFF
--- a/src/about/newtab/newtab.js
+++ b/src/about/newtab/newtab.js
@@ -129,12 +129,6 @@ export const view =
         , forward(address, TilesAction)
         , activeWallpaper.isDark
         )
-      , thunk
-        ( 'wallpaper'
-        , Wallpapers.view
-        , wallpapers
-        , forward(address, WallpapersAction)
-        )
       ]
     )
   )


### PR DESCRIPTION
Doesn't remove any of the wallpapers infrastructure, but removes the switcher.

Fixes #1084.

r? @Gozala

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1085)
<!-- Reviewable:end -->
