### PR TITLE
Zoom in page on mousedown

### DIFF
--- a/src/browser/Navigators/Overlay.js
+++ b/src/browser/Navigators/Overlay.js
@@ -26,7 +26,7 @@ export const render =
         : styleSheet.closed
         )
       )
-    , onClick: forward(address, Click)
+    , onMouseDown: forward(address, Click)
     }
   )
 


### PR DESCRIPTION
This workaround #1038 and servo/servo#11664 that prevents us from cancelling click events when force touch is handled. With this change we react to mousedown event instead of click which fixes our issue since overlay is not displayed when zoomed in & there for we avoid causing zoom-in at the end of force touch. clicks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1087)
<!-- Reviewable:end -->
