### PR TITLE
Mass-reformat all JS files - WIP

### DIFF
--- a/src/about/newtab/main.js
+++ b/src/about/newtab/main.js
@@ -4,19 +4,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import "babel-polyfill";
-import {start, Effects} from "reflex";
-import * as NewTab from "./newtab";
-import {Renderer} from "@driver";
+import 'babel-polyfill'
+import { start, Effects } from 'reflex'
+import * as NewTab from './newtab'
+import { Renderer } from '@driver'
 
 const application = start({
-  flags: void(0),
-  init: NewTab.init,
-  update: NewTab.update,
-  view: NewTab.view
-});
+                            flags: void(0), init: NewTab.init, update: NewTab.update, view: NewTab.view
+                          });
 
-const renderer = new Renderer({target: document.body});
+const renderer = new Renderer({ target: document.body });
 application.view.subscribe(renderer.address);
 application.task.subscribe(Effects.driver(application.address));
 

--- a/src/about/newtab/newtab.js
+++ b/src/about/newtab/newtab.js
@@ -33,7 +33,7 @@ const TilesAction =
   );
 
 export const init =
-  ()/*:[Model, Effects<Action>]*/ =>
+  (): [Model, Effects<Action>] =>
   {
     const [tiles, tilesFx] = Tiles.init();
     const [wallpapers, wallpaperFx] = Wallpapers.init();
@@ -67,7 +67,7 @@ const updateTiles = cursor
   );
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model: Model, action: Action): [Model, Effects<Action>] =>
   ( action.type === 'Wallpapers'
   ? updateWallpapers(model, action.wallpapers)
   : action.type === 'Tiles'
@@ -107,7 +107,7 @@ const readWallpaper = ({src, color}) =>
   );
 
 export const view =
-  ({wallpapers, tiles, help}/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ => {
+  ({wallpapers, tiles, help}: Model, address: Address<Action>): DOM => {
   const activeWallpaper = Wallpapers.active(wallpapers);
   return (
     html.div

--- a/src/about/newtab/newtab.js
+++ b/src/about/newtab/newtab.js
@@ -4,132 +4,92 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {merge, tag, tagged} from "../../common/prelude"
-import {Effects, html, thunk, forward} from "reflex"
-import {Style, StyleSheet} from "../../common/style";
-import {cursor} from "../../common/cursor";
-import * as Unknown from "../../common/unknown";
-
-import * as Tiles from './newtab/tiles';
-import * as Wallpapers from './newtab/wallpapers';
+import { merge } from '../../common/prelude'
+import { Effects, html, thunk, forward } from 'reflex'
+import { Style, StyleSheet } from '../../common/style'
+import { cursor } from '../../common/cursor'
+import * as Unknown from '../../common/unknown'
+import * as Tiles from './newtab/tiles'
+import * as Wallpapers from './newtab/wallpapers'
 
 /*::
-import type {Address, DOM} from "reflex"
-import type {Model, Action} from "./newtab"
-*/
+ import type {Address, DOM} from "reflex"
+ import type {Model, Action} from "./newtab"
+ */
 
-const WallpapersAction =
-  action =>
-  ( { type: 'Wallpapers'
-    , wallpapers: action
-    }
-  );
+const WallpapersAction = action =>( {
+  type: 'Wallpapers', wallpapers: action
+}
+);
 
-const TilesAction =
-  action =>
-  ( { type: 'Tiles'
-    , tiles: action
-    }
-  );
+const TilesAction = action =>( {
+  type: 'Tiles', tiles: action
+}
+);
 
-export const init =
-  (): [Model, Effects<Action>] =>
-  {
-    const [tiles, tilesFx] = Tiles.init();
-    const [wallpapers, wallpaperFx] = Wallpapers.init();
-    return (
+export const init = ():[Model, Effects<Action>] => {
+  const [tiles, tilesFx] = Tiles.init();
+  const [wallpapers, wallpaperFx] = Wallpapers.init();
+  return (
       [
-        { wallpapers
-        , tiles
-        }
-      , Effects.batch
-        ( [ tilesFx.map(TilesAction)
-          , wallpaperFx.map(WallpapersAction)
-          ]
-        )
+        {
+          wallpapers, tiles
+        }, Effects.batch([
+                           tilesFx.map(TilesAction), wallpaperFx.map(WallpapersAction)
+                         ])
       ]
-    );
-  }
+  );
+}
 
 const updateWallpapers = cursor({
-  get: model => model.wallpapers,
-  set: (model, wallpapers) => merge(model, {wallpapers}),
-  update: Wallpapers.update,
-  tag: WallpapersAction
-});
+                                  get: model => model.wallpapers,
+                                  set: (model, wallpapers) => merge(model, { wallpapers }),
+                                  update: Wallpapers.update,
+                                  tag: WallpapersAction
+                                });
 
-const updateTiles = cursor
-  ( { get: model => model.tiles
-    , set: (model, tiles) => merge(model, {tiles})
-    , update: Tiles.update
-    , tag: TilesAction
-    }
-  );
+const updateTiles = cursor({
+                             get: model => model.tiles,
+                             set: (model, tiles) => merge(model, { tiles }),
+                             update: Tiles.update,
+                             tag: TilesAction
+                           });
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] =>
-  ( action.type === 'Wallpapers'
-  ? updateWallpapers(model, action.wallpapers)
-  : action.type === 'Tiles'
-  ? updateTiles(model, action.tiles)
-  : Unknown.update(model, action)
-  );
+export const update = (model:Model, action:Action):[Model, Effects<Action>] =>( action.type === 'Wallpapers'
+        ? updateWallpapers(model, action.wallpapers)
+        : action.type === 'Tiles'
+        ? updateTiles(model, action.tiles)
+        : Unknown.update(model, action)
+);
 
-export const styleSheet =
-  StyleSheet.create
-  ( { base:
-      { backgroundColor: '#fff'
-      , width: '100%'
-      , height: '100%'
-      , position: 'absolute'
-      , minHeight: '580px'
-      }
-    , shown:
-      {}
-    , hidden:
-      { display: 'none'
-      }
-    }
-  );
+export const styleSheet = StyleSheet.create({
+                                              base: {
+                                                backgroundColor: '#fff',
+                                                width: '100%',
+                                                height: '100%',
+                                                position: 'absolute',
+                                                minHeight: '580px'
+                                              }, shown: {}, hidden: {
+    display: 'none'
+  }
+                                            });
 
-const readWallpaper = ({src, color}) =>
-  (
-    { backgroundImage:
-      ( src
-      ? `url(${src})`
-      : 'none'
-      )
-    , backgroundColor: color
-    , backgroundSize: 'cover'
-    , backgroundRepeat: 'no-repeat'
-    , backgroundPosition: 'center center'
-    }
-  );
+const readWallpaper = ({ src, color }) =>(
+{
+  backgroundImage: ( src ? `url(${src})` : 'none'
+  ), backgroundColor: color, backgroundSize: 'cover', backgroundRepeat: 'no-repeat', backgroundPosition: 'center center'
+}
+);
 
-export const view =
-  ({wallpapers, tiles, help}: Model, address: Address<Action>): DOM => {
+export const view = ({ wallpapers, tiles, help }: Model, address:Address<Action>):DOM => {
   const activeWallpaper = Wallpapers.active(wallpapers);
   return (
-    html.div
-    ( { className: 'newtab'
-      , style: Style
-        ( styleSheet.base
-        , readWallpaper(activeWallpaper)
-        )
-      }
-    , [ html.meta
-        ( { name: "theme-color"
-          , content: activeWallpaper.color
-          }
-        )
-      , thunk
-        ( 'tiles'
-        , Tiles.view
-        , tiles
-        , forward(address, TilesAction)
-        , activeWallpaper.isDark
-        )
-      ]
-    )
+      html.div({
+                 className: 'newtab', style: Style(styleSheet.base, readWallpaper(activeWallpaper))
+               }, [
+                 html.meta({
+                             name: "theme-color", content: activeWallpaper.color
+                           }), thunk('tiles', Tiles.view, tiles, forward(address, TilesAction), activeWallpaper.isDark)
+               ])
   )
 }

--- a/src/about/newtab/newtab/tile.js
+++ b/src/about/newtab/newtab/tile.js
@@ -4,97 +4,80 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, Effects} from "reflex";
-import * as Style from "../../../common/style";
-import * as Unknown from "../../../common/unknown";
+import { html, Effects } from 'reflex'
+import * as Style from '../../../common/style'
+import * as Unknown from '../../../common/unknown'
 
 /*::
-import type {Address, DOM} from "reflex";
-import type {URI, Action, Model} from "./tile";
-*/
+ import type {Address, DOM} from "reflex";
+ import type {URI, Action, Model} from "./tile";
+ */
 
 
-export const init =
-  (title: string, uri: URI, src: URI): [Model, Effects<Action>] =>
-  [ { title
-    , uri
-    , src
-    }
-  , Effects.none
-  ]
+export const init = (title:string, uri:URI, src:URI):[Model, Effects<Action>] =>[
+  {
+    title, uri, src
+  }, Effects.none
+]
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] =>
-  Unknown.update(model, action)
+export const update = (model:Model, action:Action):[Model, Effects<Action>] =>Unknown.update(model, action)
 
-const styleSheet = Style.createSheet
-  ( { tile:
-      { cursor: 'pointer'
-      , float: 'left'
-      , margin: '10px 25px 20px'
-      , width: '160px'
-      , textDecoration: 'none'
-      }
-    , image:
-      { backgroundColor: '#fff'
-      , backgroundSize: 'cover'
-      , backgroundPosition: 'center center'
-      , border: '1px solid rgba(0,0,0,0.15)'
-      , borderRadius: '12px'
-      , boxSizing: 'border-box'
-      , height: '100px'
-      , margin: '0 0 10px'
-      , width: '160px'
-      }
-    , title:
-      { fontSize: '14px'
-      , fontWeight: 'medium'
-      , lineHeight: '20px'
-      , overflow: 'hidden'
-      , textAlign: 'center'
-      , textOverflow: 'ellipsis'
-      , whiteSpace: 'nowrap'
-      , width: '100%'
-      }
-    , titleLight:
-      { color: 'rgba(0,0,0,0.8)'
-      }
-    , titleDark:
-      { color: 'rgba(255,255,255,0.7)'
-      }
-    }
-  );
+const styleSheet = Style.createSheet({
+                                       tile: {
+                                         cursor: 'pointer',
+                                         float: 'left',
+                                         margin: '10px 25px 20px',
+                                         width: '160px',
+                                         textDecoration: 'none'
+                                       }, image: {
+    backgroundColor: '#fff',
+    backgroundSize: 'cover',
+    backgroundPosition: 'center center',
+    border: '1px solid rgba(0,0,0,0.15)',
+    borderRadius: '12px',
+    boxSizing: 'border-box',
+    height: '100px',
+    margin: '0 0 10px',
+    width: '160px'
+  }, title: {
+    fontSize: '14px',
+    fontWeight: 'medium',
+    lineHeight: '20px',
+    overflow: 'hidden',
+    textAlign: 'center',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    width: '100%'
+  }, titleLight: {
+    color: 'rgba(0,0,0,0.8)'
+  }, titleDark: {
+    color: 'rgba(255,255,255,0.7)'
+  }
+                                     });
 
-export const view =
-  (model: Model, address: Address<Action>, isDark: boolean): DOM =>
-  html.a
-  ( { className: 'tile'
-    , style: styleSheet.tile
-    , target: '_blank'
-    , rel: 'noopener noreferrer'
-    , href: model.uri
-    }
-  , [ html.div
-      ( { className: 'tile-image'
-        , style: Style.mix
-            ( styleSheet.image,
-              { backgroundImage: `url(${model.src})`
-              }
-            )
-        }
-      )
-    , html.div
-      ( { className: 'tile-title'
-        , style: Style.mix
-          ( styleSheet.title
-          , ( isDark
-            ? styleSheet.titleDark
-            : styleSheet.titleLight
-            )
-          )
-        }
-      , [ model.title
-        ]
-      )
-    ]
-  );
+export const view = (model:Model, address:Address<Action>, isDark:boolean):DOM =>html.a({
+                                                                                          className: 'tile',
+                                                                                          style: styleSheet.tile,
+                                                                                          target: '_blank',
+                                                                                          rel: 'noopener noreferrer',
+                                                                                          href: model.uri
+                                                                                        }, [
+                                                                                          html.div({
+                                                                                                     className: 'tile-image',
+                                                                                                     style: Style.mix(
+                                                                                                         styleSheet.image,
+                                                                                                         {
+                                                                                                           backgroundImage: `url(${model.src})`
+                                                                                                         })
+                                                                                                   }), html.div({
+                                                                                                                  className: 'tile-title',
+                                                                                                                  style: Style.mix(
+                                                                                                                      styleSheet.title,
+                                                                                                                      ( isDark
+                                                                                                                              ? styleSheet.titleDark
+                                                                                                                              : styleSheet.titleLight
+                                                                                                                      ))
+                                                                                                                }, [
+                                                                                                                  model.title
+                                                                                                                ])
+                                                                                        ]);

--- a/src/about/newtab/newtab/tile.js
+++ b/src/about/newtab/newtab/tile.js
@@ -15,7 +15,7 @@ import type {URI, Action, Model} from "./tile";
 
 
 export const init =
-  (title/*:string*/, uri/*:URI*/, src/*:URI*/)/*:[Model, Effects<Action>]*/ =>
+  (title: string, uri: URI, src: URI): [Model, Effects<Action>] =>
   [ { title
     , uri
     , src
@@ -24,7 +24,7 @@ export const init =
   ]
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model: Model, action: Action): [Model, Effects<Action>] =>
   Unknown.update(model, action)
 
 const styleSheet = Style.createSheet
@@ -66,7 +66,7 @@ const styleSheet = Style.createSheet
   );
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/, isDark/*:boolean*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>, isDark: boolean): DOM =>
   html.a
   ( { className: 'tile'
     , style: styleSheet.tile

--- a/src/about/newtab/newtab/tiles.js
+++ b/src/about/newtab/newtab/tiles.js
@@ -22,7 +22,7 @@ import type {Action, Model} from "./tiles"
 
 
 export const init =
-  ()/*:[Model, Effects<Action>]*/ =>
+  (): [Model, Effects<Action>] =>
   [ hardcodedTiles
   , Effects.none
   ];
@@ -30,7 +30,7 @@ export const init =
 const TileAction = tag('Tile')
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model: Model, action: Action): [Model, Effects<Action>] =>
   Unknown.update(model, action)
 
 const styleSheet = StyleSheet.create
@@ -49,7 +49,7 @@ const styleSheet = StyleSheet.create
   );
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/, isDark/*:boolean*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>, isDark: boolean): DOM =>
   html.div
   ( { className: 'tiles'
     , style: styleSheet.tiles

--- a/src/about/newtab/newtab/tiles.js
+++ b/src/about/newtab/newtab/tiles.js
@@ -4,64 +4,47 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {tag} from "../../../common/prelude"
-import {Effects, html, thunk, forward} from "reflex"
-import {Style, StyleSheet} from "../../../common/style";
-import * as Tile from './tile';
+import { tag } from '../../../common/prelude'
+import { Effects, html, thunk, forward } from 'reflex'
+import { StyleSheet } from '../../../common/style'
+import * as Tile from './tile'
+import hardcodedTiles from '../tiles.json'
+import * as Unknown from '../../../common/unknown'
 // @TODO hard-coded until we get history support in Servo.
-import hardcodedTiles from '../tiles.json';
-import * as Unknown from "../../../common/unknown";
-import {cursor} from "../../../common/cursor";
 
 /*::
-import type {Address, DOM} from "reflex"
-import type {Tagged} from "../../../common/prelude"
-import type {Action, Model} from "./tiles"
-*/
+ import type {Address, DOM} from "reflex"
+ import type {Tagged} from "../../../common/prelude"
+ import type {Action, Model} from "./tiles"
+ */
 
 
-
-export const init =
-  (): [Model, Effects<Action>] =>
-  [ hardcodedTiles
-  , Effects.none
-  ];
+export const init = ():[Model, Effects<Action>] =>[
+  hardcodedTiles, Effects.none
+];
 
 const TileAction = tag('Tile')
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] =>
-  Unknown.update(model, action)
+export const update = (model:Model, action:Action):[Model, Effects<Action>] =>Unknown.update(model, action)
 
-const styleSheet = StyleSheet.create
-  ( { tiles:
-      { width: '840px'
-      // Hardcoded until we get flexbox in Servo
-      , height: '480px'
-      , overflow: 'hidden'
-      , position: 'absolute'
-      , left: 'calc(50% - (840px / 2))'
-      // Add offset for visual space taken up by location bar
-      // Then offset by half of the height of the tiles.
-      , top: 'calc(((100% + 60px) / 2) - (480px / 2))'
-      }
-    }
-  );
+const styleSheet = StyleSheet.create({
+                                       tiles: {
+                                         width: '840px'
+                                         // Hardcoded until we get flexbox in Servo
+                                         ,
+                                         height: '480px',
+                                         overflow: 'hidden',
+                                         position: 'absolute',
+                                         left: 'calc(50% - (840px / 2))'
+                                         // Add offset for visual space taken up by location bar
+                                         // Then offset by half of the height of the tiles.
+                                         ,
+                                         top: 'calc(((100% + 60px) / 2) - (480px / 2))'
+                                       }
+                                     });
 
-export const view =
-  (model: Model, address: Address<Action>, isDark: boolean): DOM =>
-  html.div
-  ( { className: 'tiles'
-    , style: styleSheet.tiles
-    }
-  , model.order.map
-    ( id =>
-      thunk
-      ( String(id)
-      , Tile.view
-      , model.entries[String(id)]
-      , forward(address, TileAction)
-      , isDark
-      )
-    )
-  );
+export const view = (model:Model, address:Address<Action>, isDark:boolean):DOM =>html.div({
+                                                                                            className: 'tiles',
+                                                                                            style: styleSheet.tiles
+                                                                                          }, model.order.map(
+    id =>thunk(String(id), Tile.view, model.entries[String(id)], forward(address, TileAction), isDark)));

--- a/src/about/newtab/newtab/wallpaper.js
+++ b/src/about/newtab/newtab/wallpaper.js
@@ -16,7 +16,7 @@ import type {Address, DOM} from "reflex"
 import type {Model, Action, URI, Color} from "./wallpaper"
 */
 
-const Choose/*:Action*/ =
+const Choose: Action =
   { type: 'Choose'
   };
 
@@ -34,7 +34,7 @@ const styleSheet = Style.createSheet
   );
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>): DOM =>
   ( html.div
     ( { className: 'wallpaper-choice'
       , onClick: forward(address, always(Choose))

--- a/src/about/newtab/newtab/wallpaper.js
+++ b/src/about/newtab/newtab/wallpaper.js
@@ -4,45 +4,36 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Effects, html, thunk, forward} from "reflex"
-import {merge, always, tagged} from "../../../common/prelude"
-import * as Style from "../../../common/style";
-import * as Unknown from "../../../common/unknown";
-
-import hardcodedWallpaper from "../wallpaper.json";
+import { html, forward } from 'reflex'
+import { always } from '../../../common/prelude'
+import * as Style from '../../../common/style'
 
 /*::
-import type {Address, DOM} from "reflex"
-import type {Model, Action, URI, Color} from "./wallpaper"
-*/
+ import type {Address, DOM} from "reflex"
+ import type {Model, Action, URI, Color} from "./wallpaper"
+ */
 
-const Choose: Action =
-  { type: 'Choose'
-  };
+const Choose:Action = {
+  type: 'Choose'
+};
 
-const styleSheet = Style.createSheet
-  ( { base:
-      { border: '1px solid rgba(0,0,0,0.15)'
-      , cursor: 'pointer'
-      , borderRadius: '50%'
-      , display: 'inline-block'
-      , width: '10px'
-      , height: '10px'
-      , margin: '0 2px'
-      }
-    }
-  );
+const styleSheet = Style.createSheet({
+                                       base: {
+                                         border: '1px solid rgba(0,0,0,0.15)',
+                                         cursor: 'pointer',
+                                         borderRadius: '50%',
+                                         display: 'inline-block',
+                                         width: '10px',
+                                         height: '10px',
+                                         margin: '0 2px'
+                                       }
+                                     });
 
-export const view =
-  (model: Model, address: Address<Action>): DOM =>
-  ( html.div
-    ( { className: 'wallpaper-choice'
-      , onClick: forward(address, always(Choose))
-      , style: Style.mix
-        ( styleSheet.base
-        , { backgroundColor: model.color
-          }
-        )
-      }
-    )
-  );
+export const view = (model:Model, address:Address<Action>):DOM =>( html.div({
+                                                                              className: 'wallpaper-choice',
+                                                                              onClick: forward(address, always(Choose)),
+                                                                              style: Style.mix(styleSheet.base, {
+                                                                                backgroundColor: model.color
+                                                                              })
+                                                                            })
+);

--- a/src/about/newtab/newtab/wallpapers.js
+++ b/src/about/newtab/newtab/wallpapers.js
@@ -4,104 +4,71 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Effects, html, thunk, forward} from "reflex"
-import {merge, tagged} from "../../../common/prelude"
-import {Style, StyleSheet} from "../../../common/style";
-import * as Unknown from "../../../common/unknown";
-
-import hardcodedWallpaper from "../wallpaper.json";
-import * as Wallpaper from "./wallpaper";
+import { Effects, html, thunk, forward } from 'reflex'
+import { merge } from '../../../common/prelude'
+import { StyleSheet } from '../../../common/style'
+import * as Unknown from '../../../common/unknown'
+import hardcodedWallpaper from '../wallpaper.json'
+import * as Wallpaper from './wallpaper'
 
 /*::
-import type {Address, DOM} from "reflex"
-import type {Model, Action, ID} from "./wallpapers"
-*/
+ import type {Address, DOM} from "reflex"
+ import type {Model, Action, ID} from "./wallpapers"
+ */
 
-export const init =
-  (): [Model, Effects<Action>] =>
-  [ hardcodedWallpaper
-  , Effects.none
-  ];
+export const init = ():[Model, Effects<Action>] =>[
+  hardcodedWallpaper, Effects.none
+];
 
 
-const ByID =
-  id =>
-  action =>
-  WallpaperAction(id, action);
+const ByID = id =>action =>WallpaperAction(id, action);
 
-const WallpaperAction =
-  (id, action) =>
-  ( action.type === 'Choose'
-  ? Choose(id)
-  : { type: "Wallpaper"
-    , id
-    , action
+const WallpaperAction = (id, action) =>( action.type === 'Choose' ? Choose(id) : {
+      type: "Wallpaper", id, action
     }
-  )
+)
 
-const Choose =
-  id =>
-  ( { type: "ChooseWallpaper"
-    , id
-    }
-  )
+const Choose = id =>( {
+  type: "ChooseWallpaper", id
+}
+)
 
 
-const notFound =
-  { src: null
-  , color: '#fff'
-  , isDark: false
-  }
+const notFound = {
+  src: null, color: '#fff', isDark: false
+}
 
-export const active =
-  ({entries, active}: Model): Wallpaper.Model =>
-  ( entries[active] || notFound )
+export const active = ({ entries, active }: Model):Wallpaper.Model =>( entries[active] || notFound )
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] =>
-  ( action.type === 'ChooseWallpaper'
-  ? [ merge(model, {active: action.id})
-    , Effects.none
-    ]
-  : Unknown.update(model, action)
-  );
+export const update = (model:Model, action:Action):[Model, Effects<Action>] =>( action.type === 'ChooseWallpaper' ? [
+      merge(model, { active: action.id }), Effects.none
+    ] : Unknown.update(model, action)
+);
 
-const styleSheet = StyleSheet.create
-  ( { base:
-      { display: 'block'
-      , color: '#999'
-      , fontSize: '12px'
-      , lineHeight: '20px'
-      , position: 'absolute'
-      , bottom: '10px'
-      , left: 0
-      , textAlign: 'center'
-      , width: '100%'
-      }
-    , inner:
-      {}
-    }
-  );
+const styleSheet = StyleSheet.create({
+                                       base: {
+                                         display: 'block',
+                                         color: '#999',
+                                         fontSize: '12px',
+                                         lineHeight: '20px',
+                                         position: 'absolute',
+                                         bottom: '10px',
+                                         left: 0,
+                                         textAlign: 'center',
+                                         width: '100%'
+                                       }, inner: {}
+                                     });
 
-export const view =
-  (model: Model, address: Address<Action>): DOM =>
-  html.div
-  ( { className: 'wallpaper'
-    , style: styleSheet.base
-    }
-  , [ html.div
-      ( { className: 'wallpaper-inner'
-        , style: styleSheet.inner
-        }
-      , model.order.map
-        ( id =>
-          thunk
-          ( String(id)
-          , Wallpaper.view
-          , model.entries[id]
-          , forward(address, ByID(String(id)))
-          )
-        )
-      )
-    ]
-  );
+export const view = (model:Model, address:Address<Action>):DOM =>html.div({
+                                                                            className: 'wallpaper',
+                                                                            style: styleSheet.base
+                                                                          }, [
+                                                                            html.div({
+                                                                                       className: 'wallpaper-inner',
+                                                                                       style: styleSheet.inner
+                                                                                     }, model.order.map(
+                                                                                id =>thunk(String(id), Wallpaper.view,
+                                                                                           model.entries[id],
+                                                                                           forward(address,
+                                                                                                   ByID(String(id))))))
+                                                                          ]);

--- a/src/about/newtab/newtab/wallpapers.js
+++ b/src/about/newtab/newtab/wallpapers.js
@@ -18,7 +18,7 @@ import type {Model, Action, ID} from "./wallpapers"
 */
 
 export const init =
-  ()/*:[Model, Effects<Action>]*/ =>
+  (): [Model, Effects<Action>] =>
   [ hardcodedWallpaper
   , Effects.none
   ];
@@ -54,11 +54,11 @@ const notFound =
   }
 
 export const active =
-  ({entries, active}/*:Model*/)/*:Wallpaper.Model*/ =>
+  ({entries, active}: Model): Wallpaper.Model =>
   ( entries[active] || notFound )
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model: Model, action: Action): [Model, Effects<Action>] =>
   ( action.type === 'ChooseWallpaper'
   ? [ merge(model, {active: action.id})
     , Effects.none
@@ -84,7 +84,7 @@ const styleSheet = StyleSheet.create
   );
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>): DOM =>
   html.div
   ( { className: 'wallpaper'
     , style: styleSheet.base

--- a/src/about/repl/main.js
+++ b/src/about/repl/main.js
@@ -4,32 +4,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import "babel-polyfill";
-import {start, Effects} from "reflex";
-import * as UI from "./repl";
-import {Renderer} from "@driver";
+import 'babel-polyfill'
+import { start, Effects } from 'reflex'
+import * as UI from './repl'
+import { Renderer } from '@driver'
 
 const isReload = window.application != null;
 
-const restore =
-  () =>
-  [ window.application.model.value
-  , Effects.none
-  ]
+const restore = () =>[
+  window.application.model.value, Effects.none
+]
 
 
 const application = start({
-  flags: void(0),
-  init:
-  ( isReload
-  ? restore
-  : UI.init
-  ),
-  update: UI.update,
-  view: UI.view
-});
+                            flags: void(0), init: ( isReload ? restore : UI.init
+  ), update: UI.update, view: UI.view
+                          });
 
-const renderer = new Renderer({target: document.body});
+const renderer = new Renderer({ target: document.body });
 application.view.subscribe(renderer.address);
 application.task.subscribe(Effects.driver(application.address));
 

--- a/src/about/repl/repl.js
+++ b/src/about/repl/repl.js
@@ -4,223 +4,144 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, thunk, forward, Effects} from 'reflex';
-import {merge, always, batch, tag, tagged} from "../../common/prelude";
-import {Style, StyleSheet} from '../../common/style';
-import * as Cell from './repl/cell';
-import * as Settings from '../../common/settings';
-import * as Unknown from '../../common/unknown';
-import * as Host from './repl/host';
-
-import {onWindow} from "@driver";
+import { html, forward, Effects } from 'reflex'
+import { merge, always, batch } from '../../common/prelude'
+import { StyleSheet } from '../../common/style'
+import * as Cell from './repl/cell'
+import * as Unknown from '../../common/unknown'
+import * as Host from './repl/host'
+import { onWindow } from '@driver'
 
 /*::
-import type {Address, DOM} from "reflex"
-import type {Model, Action} from "./repl"
-*/
+ import type {Address, DOM} from "reflex"
+ import type {Model, Action} from "./repl"
+ */
 
 
 // Actions
 
-const CreateCell =
-  ( { type: "CreateCell"
-    }
-  );
+const CreateCell = ( {
+  type: "CreateCell"
+}
+);
 
-const Focus =
-  ( { type: "Focus"
-    }
-  );
+const Focus = ( {
+  type: "Focus"
+}
+);
 
-const Evaluate =
-  (id, input) =>
-  ( { type: "Evaluate"
-    , id
-    , source: input
-    }
-  );
+const Evaluate = (id, input) =>( {
+  type: "Evaluate", id, source: input
+}
+);
 
-const Print =
-  (id, version) =>
-  result =>
-  ( { type: "Print"
-    , id
-    , source:
-      { version
-      , result
-      }
-    }
-  );
-
-
-const ByID =
-  id =>
-  action =>
-  CellAction(id, action);
-
-const CellAction =
-  (id, action) =>
-  ( action.type === "Submit"
-  ? { type: "Evaluate"
-    , id
-    , source: action.source
-    }
-  : { type: "Cell"
-    , id
-    , source: action
-    }
-  );
-
-
-export const init =
-  (): [Model, Effects<Action>] =>
-  createCell
-  ( { nextID: 0
-    , order: []
-    , cells: {}
-    , active: -1
-    }
-  );
-
-const createCell =
-  model => {
-    const id = String(model.nextID);
-    const [cell, fx] = Cell.init(id);
-    const state = merge
-      ( model
-      , { nextID: model.nextID + 1
-        , order: [...model.order, id]
-        , active: id
-        , cells: merge
-          ( model.cells
-          , {[id]: cell}
-          )
-        }
-      );
-
-    return [state, fx.map(ByID(id))];
+const Print = (id, version) =>result =>( {
+  type: "Print", id, source: {
+    version, result
   }
-
-const updateCell =
-  (model, id, action) =>
-  ( model.cells[id] == null
-  ? [ model
-    , Effects.none
-    ]
-  : swapCell(model, id, Cell.update(model.cells[id], action))
-  )
-
-const swapCell =
-  (model, id, [cell, fx]) => {
-    const result =
-      [ merge
-        ( model
-        , { cells
-          : merge
-            ( model.cells
-            , { [id]: cell }
-            )
-          }
-        )
-      , fx.map(ByID(id))
-      ]
-
-    return result
-  }
-
-const focus =
-  model =>
-  updateCell
-  ( model
-  , String(model.active)
-  , Cell.Edit
-  );
-
-const evaluate =
-  (model, {id, source}) =>
-  [ model
-  , Effects
-    .perform(Host.evaluate(id, source.value))
-    .map(Print(id, source.version))
-  ];
-
-const isActive =
-  (model, id) =>
-  model.active === id;
-
-const isLast =
-  (model, id) =>
-  model.order[model.order.length - 1] === id;
-
-const print = (model, action) =>
-  ( (isActive(model, action.id) && isLast(model, action.id))
-  ? batch
-    ( update
-    , model
-    , [ CreateCell
-      , action
-      ]
-    )
-  : updateCell
-    ( model
-    , action.id
-    , Cell.Print(action.source)
-    )
-  );
-
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] =>
-  ( action.type === 'Cell'
-  ? updateCell(model, action.id, action.source)
-  : action.type === 'Evaluate'
-  ? evaluate(model, action)
-  : action.type === 'Print'
-  ? print(model, action)
-  : action.type === 'Focus'
-  ? focus(model)
-  : action.type === 'CreateCell'
-  ? createCell(model)
-  : Unknown.update(model, action)
-  );
+}
+);
 
 
-const styleSheet = StyleSheet.create
-  ( { base:
-      { width: '100%'
-      , height: '100%'
-      , position: 'absolute'
-      , top: '0px'
-      , left: '0px'
-      , color: '#839496'
-      , backgroundColor: '#002b36'
-      , fontSize: '12px'
-      , fontFamily: 'Menlo, Courier, monospace'
-      , lineHeight: '14px'
-      , overflow: 'auto'
-      }
+const ByID = id =>action =>CellAction(id, action);
+
+const CellAction = (id, action) =>( action.type === "Submit" ? {
+      type: "Evaluate", id, source: action.source
+    } : {
+      type: "Cell", id, source: action
     }
-  );
+);
 
-export const view =
-  (model: Model, address: Address<Action>): DOM =>
-  html.div
-  ( { style: styleSheet.base
-    , id: 'repl'
-    , onWindowFocus: onWindow(address, always(Focus))
-    }
-  , [ ...Object
-      .keys(model.cells)
-      .map
-      ( id =>
-        Cell.view
-        ( model.cells[id]
-        , forward(address, ByID(id))
-        )
-      )
-    , html.meta
-      ( { name: 'theme-color'
-        , content: `${styleSheet.base.backgroundColor}|${styleSheet.base.color}`
-        }
-      )
-    ]
-  );
+
+export const init = ():[Model, Effects<Action>] =>createCell({
+                                                               nextID: 0, order: [], cells: {}, active: -1
+                                                             });
+
+const createCell = model => {
+  const id = String(model.nextID);
+  const [cell, fx] = Cell.init(id);
+  const state = merge(model, {
+    nextID: model.nextID + 1, order: [...model.order, id], active: id, cells: merge(model.cells, { [id]: cell })
+  });
+
+  return [state, fx.map(ByID(id))];
+}
+
+const updateCell = (model, id, action) =>( model.cells[id] == null ? [
+      model, Effects.none
+    ] : swapCell(model, id, Cell.update(model.cells[id], action))
+)
+
+const swapCell = (model, id, [cell, fx]) => {
+  const result = [
+    merge(model, {
+      cells: merge(model.cells, { [id]: cell })
+    }), fx.map(ByID(id))
+  ]
+
+  return result
+}
+
+const focus = model =>updateCell(model, String(model.active), Cell.Edit);
+
+const evaluate = (model, { id, source }) =>[
+  model, Effects
+      .perform(Host.evaluate(id, source.value))
+      .map(Print(id, source.version))
+];
+
+const isActive = (model, id) =>model.active === id;
+
+const isLast = (model, id) =>model.order[model.order.length - 1] === id;
+
+const print = (model, action) =>( (isActive(model, action.id) && isLast(model, action.id)) ? batch(update, model, [
+      CreateCell, action
+    ]) : updateCell(model, action.id, Cell.Print(action.source))
+);
+
+export const update = (model:Model, action:Action):[Model, Effects<Action>] =>( action.type === 'Cell'
+        ? updateCell(model, action.id, action.source)
+        : action.type === 'Evaluate'
+        ? evaluate(model, action)
+        : action.type === 'Print'
+        ? print(model, action)
+        : action.type === 'Focus'
+        ? focus(model)
+        : action.type === 'CreateCell'
+        ? createCell(model)
+        : Unknown.update(model, action)
+);
+
+
+const styleSheet = StyleSheet.create({
+                                       base: {
+                                         width: '100%',
+                                         height: '100%',
+                                         position: 'absolute',
+                                         top: '0px',
+                                         left: '0px',
+                                         color: '#839496',
+                                         backgroundColor: '#002b36',
+                                         fontSize: '12px',
+                                         fontFamily: 'Menlo, Courier, monospace',
+                                         lineHeight: '14px',
+                                         overflow: 'auto'
+                                       }
+                                     });
+
+export const view = (model:Model, address:Address<Action>):DOM =>html.div({
+                                                                            style: styleSheet.base,
+                                                                            id: 'repl',
+                                                                            onWindowFocus: onWindow(address,
+                                                                                                    always(Focus))
+                                                                          }, [
+                                                                            ...Object
+                                                                                .keys(model.cells)
+                                                                                .map(id =>Cell.view(model.cells[id],
+                                                                                                    forward(address,
+                                                                                                            ByID(id)))),
+                                                                            html.meta({
+                                                                                        name: 'theme-color',
+                                                                                        content: `${styleSheet.base.backgroundColor}|${styleSheet.base.color}`
+                                                                                      })
+                                                                          ]);

--- a/src/about/repl/repl.js
+++ b/src/about/repl/repl.js
@@ -73,7 +73,7 @@ const CellAction =
 
 
 export const init =
-  ()/*:[Model, Effects<Action>]*/ =>
+  (): [Model, Effects<Action>] =>
   createCell
   ( { nextID: 0
     , order: []
@@ -169,7 +169,7 @@ const print = (model, action) =>
   );
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model: Model, action: Action): [Model, Effects<Action>] =>
   ( action.type === 'Cell'
   ? updateCell(model, action.id, action.source)
   : action.type === 'Evaluate'
@@ -202,7 +202,7 @@ const styleSheet = StyleSheet.create
   );
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>): DOM =>
   html.div
   ( { style: styleSheet.base
     , id: 'repl'

--- a/src/about/repl/repl/cell.js
+++ b/src/about/repl/repl/cell.js
@@ -4,168 +4,125 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, thunk, forward, Effects} from 'reflex';
-import {merge, batch, tag, tagged} from "../../../common/prelude";
-import {Style, StyleSheet} from '../../../common/style';
-import * as Unknown from '../../../common/unknown';
-import {cursor} from '../../../common/cursor';
-import * as Input from './input';
-import * as Output from './output';
+import { html, thunk, forward, Effects } from 'reflex'
+import { merge } from '../../../common/prelude'
+import { Style, StyleSheet } from '../../../common/style'
+import * as Unknown from '../../../common/unknown'
+import { cursor } from '../../../common/cursor'
+import * as Input from './input'
+import * as Output from './output'
 
 /*::
-import type {Address, DOM} from "reflex"
-import type {ID, Model, Action} from "./cell"
-*/
+ import type {Address, DOM} from "reflex"
+ import type {ID, Model, Action} from "./cell"
+ */
 
-export const Print =
-  (output: Output.Model): Action =>
-  ( { type: "Print"
-    , print: output
+export const Print = (output:Output.Model):Action =>( {
+  type: "Print", print: output
+}
+)
+
+export const Remove:Action = {
+  type: "Remove"
+}
+
+const InputAction = (action:Input.Action):Action =>( action.type === "Submit" ? {
+      type: "Submit", source: action.source
+    } : {
+      type: "Input", input: action
     }
-  )
+);
 
-export const Remove: Action =
-  { type: "Remove"
-  }
+const OutputAction = (action:Output.Action):Action =>( {
+  type: "Output", output: action
+}
+);
 
-const InputAction =
-  (action: Input.Action): Action =>
-  ( action.type === "Submit"
-  ? { type: "Submit"
-    , source: action.source
-    }
-  : { type: "Input"
-    , input: action
-    }
-  );
-
-const OutputAction =
-  (action: Output.Action): Action =>
-  ( { type: "Output"
-    , output: action
-    }
-  );
-
-export const Edit: Action =
-  InputAction(Input.Edit);
+export const Edit:Action = InputAction(Input.Edit);
 
 
-export const init =
-  (id: ID): [Model, Effects<Action>] => {
-    const [input, inputFX] = Input.init(0, '', true);
-    const [output, outputFX] = Output.init(0);
-    const model =
-      { id
-      , input
-      , output
-      };
-
-    const fx = Effects.batch
-      ( [ inputFX.map(InputAction)
-        , outputFX.map(OutputAction)
-        ]
-      );
-
-    return [model, fx];
+export const init = (id:ID):[Model, Effects<Action>] => {
+  const [input, inputFX] = Input.init(0, '', true);
+  const [output, outputFX] = Output.init(0);
+  const model = {
+    id, input, output
   };
 
-const updateInput = cursor
-  ( { get: model => model.input
-    , set: (model, input) => merge(model, {input})
-    , tag: InputAction
-    , update: Input.update
-    }
-  );
+  const fx = Effects.batch([
+                             inputFX.map(InputAction), outputFX.map(OutputAction)
+                           ]);
 
-const updateOutput = cursor
-  ( { get: model => model.output
-    , set: (model, output) => merge(model, {output})
-    , tag: OutputAction
-    , update: Output.update
-    }
-  );
+  return [model, fx];
+};
 
-const print =
-  (model, output) =>
-  updateOutput
-  ( model
-  , { type: "Print"
-    , source: output
-    }
-  );
+const updateInput = cursor({
+                             get: model => model.input,
+                             set: (model, input) => merge(model, { input }),
+                             tag: InputAction,
+                             update: Input.update
+                           });
 
-const submit =
-  (model, input) =>
-  updateInput
-  ( model
-  , { type: "Submit"
-    , source: input
-    }
-  );
+const updateOutput = cursor({
+                              get: model => model.output,
+                              set: (model, output) => merge(model, { output }),
+                              tag: OutputAction,
+                              update: Output.update
+                            });
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] =>
-  ( action.type === 'Input'
-  ? updateInput(model, action.input)
-  : action.type === 'Submit'
-  ? submit(model, action.source)
-  : action.type === 'Output'
-  ? updateOutput(model, action.output)
-  : action.type === 'Print'
-  ? print(model, action.print)
-  : Unknown.update(model, action)
-  );
+const print = (model, output) =>updateOutput(model, {
+  type: "Print", source: output
+});
 
-const styleSheet = StyleSheet.create
-  ( { base:
-      { padding: '10px'
-      , whiteSpace: 'pre'
-      , borderLeft: '3px solid'
-      , borderColor: '#073642'
-      , borderLeftColor: '#073642'
-      , borderBottom: '1px dotted #073642'
-      , position: 'relative'
-      }
-    , editing:
-      { borderLeftColor: '#586e75'
-      }
-    , displaying:
-      {
-      }
-    , modified:
-      { borderLeftColor: '#b58900'
-      }
-    , saved:
-      {
-      }
-    }
-  );
+const submit = (model, input) =>updateInput(model, {
+  type: "Submit", source: input
+});
+
+export const update = (model:Model, action:Action):[Model, Effects<Action>] =>( action.type === 'Input'
+        ? updateInput(model, action.input)
+        : action.type === 'Submit'
+        ? submit(model, action.source)
+        : action.type === 'Output'
+        ? updateOutput(model, action.output)
+        : action.type === 'Print'
+        ? print(model, action.print)
+        : Unknown.update(model, action)
+);
+
+const styleSheet = StyleSheet.create({
+                                       base: {
+                                         padding: '10px',
+                                         whiteSpace: 'pre',
+                                         borderLeft: '3px solid',
+                                         borderColor: '#073642',
+                                         borderLeftColor: '#073642',
+                                         borderBottom: '1px dotted #073642',
+                                         position: 'relative'
+                                       }, editing: {
+    borderLeftColor: '#586e75'
+  }, displaying: {}, modified: {
+    borderLeftColor: '#b58900'
+  }, saved: {}
+                                     });
 
 
-export const render =
-  (model: Model, address: Address<Action>): DOM =>
-  html.form
-  ( { id: `cell-${model.id}`
-    , style: Style
-      ( styleSheet.base
-      , ( model.input.isEditing
-        ? styleSheet.editing
-        : styleSheet.displaying
-        )
-      , ( model.input.version !== model.output.version
-        ? styleSheet.modified
-        : styleSheet.saved
-        )
-      )
-    , onSubmit:
-        event =>
-        event.preventDefault()
-    }
-  , [ Input.view(model.input, forward(address, InputAction))
-    , Output.view(model.output, forward(address, OutputAction))
-    ]
-  );
+export const render = (model:Model, address:Address<Action>):DOM =>html.form({
+                                                                               id: `cell-${model.id}`,
+                                                                               style: Style(styleSheet.base,
+                                                                                            ( model.input.isEditing
+                                                                                                    ? styleSheet.editing
+                                                                                                    : styleSheet.displaying
+                                                                                            ),
+                                                                                            ( model.input.version !== model.output.version
+                                                                                                    ? styleSheet.modified
+                                                                                                    : styleSheet.saved
+                                                                                            )),
+                                                                               onSubmit: event =>event.preventDefault()
+                                                                             }, [
+                                                                               Input.view(model.input, forward(address,
+                                                                                                               InputAction)),
+                                                                               Output.view(model.output,
+                                                                                           forward(address,
+                                                                                                   OutputAction))
+                                                                             ]);
 
-export const view =
-  (model: Model, address: Address<Action>): DOM =>
-  thunk(model.id, render, model, address);
+export const view = (model:Model, address:Address<Action>):DOM =>thunk(model.id, render, model, address);

--- a/src/about/repl/repl/cell.js
+++ b/src/about/repl/repl/cell.js
@@ -18,18 +18,18 @@ import type {ID, Model, Action} from "./cell"
 */
 
 export const Print =
-  (output/*:Output.Model*/)/*:Action*/ =>
+  (output: Output.Model): Action =>
   ( { type: "Print"
     , print: output
     }
   )
 
-export const Remove/*:Action*/ =
+export const Remove: Action =
   { type: "Remove"
   }
 
 const InputAction =
-  (action/*:Input.Action*/)/*:Action*/ =>
+  (action: Input.Action): Action =>
   ( action.type === "Submit"
   ? { type: "Submit"
     , source: action.source
@@ -40,18 +40,18 @@ const InputAction =
   );
 
 const OutputAction =
-  (action/*:Output.Action*/)/*:Action*/ =>
+  (action: Output.Action): Action =>
   ( { type: "Output"
     , output: action
     }
   );
 
-export const Edit/*:Action*/ =
+export const Edit: Action =
   InputAction(Input.Edit);
 
 
 export const init =
-  (id/*:ID*/)/*:[Model, Effects<Action>]*/ => {
+  (id: ID): [Model, Effects<Action>] => {
     const [input, inputFX] = Input.init(0, '', true);
     const [output, outputFX] = Output.init(0);
     const model =
@@ -104,7 +104,7 @@ const submit =
   );
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model: Model, action: Action): [Model, Effects<Action>] =>
   ( action.type === 'Input'
   ? updateInput(model, action.input)
   : action.type === 'Submit'
@@ -143,7 +143,7 @@ const styleSheet = StyleSheet.create
 
 
 export const render =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>): DOM =>
   html.form
   ( { id: `cell-${model.id}`
     , style: Style
@@ -167,5 +167,5 @@ export const render =
   );
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>): DOM =>
   thunk(model.id, render, model, address);

--- a/src/about/repl/repl/host.js
+++ b/src/about/repl/repl/host.js
@@ -5,4 +5,4 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-export {evaluate} from "./host/window";
+export { evaluate } from "./host/window";

--- a/src/about/repl/repl/host/window.js
+++ b/src/about/repl/repl/host/window.js
@@ -69,7 +69,7 @@ const evalContext =
   }
 
 export const evaluate =
-  (id/*:ID*/, code/*:string*/)/*:Task<Never, EvaluationResult>*/ =>
+  (id: ID, code: string): Task<Never, EvaluationResult> =>
   new Task((succeed, fail) => void(new Promise((resolve, reject) => {
     try {
       const out = executeWith(evalContext, () => window.eval(code));

--- a/src/about/repl/repl/host/window.js
+++ b/src/about/repl/repl/host/window.js
@@ -4,80 +4,57 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, thunk, forward, Effects, Task} from 'reflex';
-import {merge, batch, tag, tagged} from "../../../../common/prelude";
-import {ok, error} from "../../../../common/result";
+import { html, thunk, forward, Effects, Task } from 'reflex'
+import { merge, batch, tag, tagged } from '../../../../common/prelude'
+import { ok, error } from '../../../../common/result'
 
 /*::
-import type {ID, EvaluationResult} from "../host"
-import type {Never} from "reflex"
-*/
+ import type {ID, EvaluationResult} from "../host"
+ import type {Never} from "reflex"
+ */
 
 const DELETE = new String('delete');
 const executeWith = (context, execute) => {
   const keys = Object.keys(context);
-  const stash =
-    keys
-    .reduce
-    ( (stash, key) => {
-        stash[key] =
-          ( window.hasOwnProperty(key)
-          ? window[key]
-          : DELETE
-          );
+  const stash = keys
+      .reduce((stash, key) => {
+        stash[key] = ( window.hasOwnProperty(key) ? window[key] : DELETE
+        );
 
         window[key] = context[key];
 
         return stash;
-      }
-    , {}
-    );
+      }, {});
 
   try {
     return execute();
-  }
-  finally {
+  } finally {
     keys
-    .forEach
-    ( key => {
-        if (window[key] === context[key]) {
-          if (stash[key] === DELETE) {
-            delete window[key]
+        .forEach(key => {
+          if (window[key] === context[key]) {
+            if (stash[key] === DELETE) {
+              delete window[key]
+            } else {
+              window[key] = stash[key]
+            }
           }
-          else {
-            window[key] = stash[key]
-          }
-        }
-      }
-    )
+        })
   }
 }
 
-const evalContext =
-  { out: {}
-  , html
-  , thunk
-  , forward
-  , Effects
-  , Task
-  , merge
-  , batch
-  , tag
-  , tagged
-  , ok
-  , error
-  }
+const evalContext = {
+  out: {}, html, thunk, forward, Effects, Task, merge, batch, tag, tagged, ok, error
+}
 
-export const evaluate =
-  (id: ID, code: string): Task<Never, EvaluationResult> =>
-  new Task((succeed, fail) => void(new Promise((resolve, reject) => {
-    try {
-      const out = executeWith(evalContext, () => window.eval(code));
-      evalContext.out[id] = out;
-      resolve(ok(out));
-    }
-    catch (exception) {
-      evalContext.out[id] = exception;
-      resolve(error(exception));
-    }
-  }).then(succeed, fail)))
+export const evaluate = (id:ID, code:string):Task<Never, EvaluationResult> =>new Task((succeed,
+                                                                                       fail) => void(new Promise((resolve,
+                                                                                                                  reject) => {
+  try {
+    const out = executeWith(evalContext, () => window.eval(code));
+    evalContext.out[id] = out;
+    resolve(ok(out));
+  } catch (exception) {
+    evalContext.out[id] = exception;
+    resolve(error(exception));
+  }
+}).then(succeed, fail)))

--- a/src/about/repl/repl/input.js
+++ b/src/about/repl/repl/input.js
@@ -17,7 +17,7 @@ import type {Model, Action} from "./input"
 */
 
 export const Change =
-  (value/*:string*/)/*:Action*/ =>
+  (value: string): Action =>
   ( { type: "Change"
     , source: value
     }
@@ -25,22 +25,22 @@ export const Change =
 
 
 export const Submit =
-  (model/*:Model*/)/*:Action*/ =>
+  (model: Model): Action =>
   ( { type: "Submit"
     , source: model
     }
   );
 
-export const Edit/*:Action*/ = { type: "Edit" };
+export const Edit: Action = { type: "Edit" };
 const Enter = { type: "Enter" };
 const Abort = { type: "Abort" };
 
 
 export const init =
-  ( version/*:number*/
-  , value/*:string*/
-  , isEditing/*:boolean*/
-  )/*:[Model, Effects<Action>]*/ =>
+  ( version: number
+  , value: string
+  , isEditing: boolean
+  ): [Model, Effects<Action>] =>
   [ { value
     , isEditing
     , version
@@ -93,7 +93,7 @@ const decodeChange =
   Change(event.target.value);
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model: Model, action: Action): [Model, Effects<Action>] =>
   ( action.type === "Change"
   ? change(model, action.source)
   : action.type === "Edit"
@@ -197,5 +197,5 @@ const render =
   );
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>): DOM =>
   thunk('input', render, model, address);

--- a/src/about/repl/repl/input.js
+++ b/src/about/repl/repl/input.js
@@ -4,198 +4,136 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, thunk, forward, Effects} from 'reflex';
-import {merge, always} from "../../../common/prelude";
-import {Style, StyleSheet} from '../../../common/style';
-import * as Settings from '../../../common/settings';
-import * as Unknown from '../../../common/unknown';
-import {focus} from "@driver";
+import { html, thunk, forward, Effects } from 'reflex'
+import { merge, always } from '../../../common/prelude'
+import { Style, StyleSheet } from '../../../common/style'
+import * as Unknown from '../../../common/unknown'
+import { focus } from '@driver'
 
 /*::
-import type {Address, DOM} from "reflex"
-import type {Model, Action} from "./input"
-*/
+ import type {Address, DOM} from "reflex"
+ import type {Model, Action} from "./input"
+ */
 
-export const Change =
-  (value: string): Action =>
-  ( { type: "Change"
-    , source: value
-    }
-  );
+export const Change = (value:string):Action =>( {
+  type: "Change", source: value
+}
+);
 
 
-export const Submit =
-  (model: Model): Action =>
-  ( { type: "Submit"
-    , source: model
-    }
-  );
+export const Submit = (model:Model):Action =>( {
+  type: "Submit", source: model
+}
+);
 
-export const Edit: Action = { type: "Edit" };
+export const Edit:Action = { type: "Edit" };
 const Enter = { type: "Enter" };
 const Abort = { type: "Abort" };
 
 
-export const init =
-  ( version: number
-  , value: string
-  , isEditing: boolean
-  ): [Model, Effects<Action>] =>
-  [ { value
-    , isEditing
-    , version
-    }
-  , Effects.none
-  ]
+export const init = (version:number, value:string, isEditing:boolean):[Model, Effects<Action>] =>[
+  {
+    value, isEditing, version
+  }, Effects.none
+]
 
-const edit =
-  model =>
-  [ merge
-    ( model
-    , { isEditing: true
-      }
-    )
-  , Effects.none
-  ];
+const edit = model =>[
+  merge(model, {
+    isEditing: true
+  }), Effects.none
+];
 
-const change = (model, value) =>
-  ( model.value !== value
-  ? [ merge
-      ( model
-      , { value
-        , version: model.version + 1
-        }
-      )
-    , Effects.none
-    ]
-  : [ model, Effects.none ]
-  );
+const change = (model, value) =>( model.value !== value ? [
+      merge(model, {
+        value, version: model.version + 1
+      }), Effects.none
+    ] : [model, Effects.none]
+);
 
-const abort = (model, value) =>
-  [ merge
-    ( model
-    , { isEditing: false }
-    )
-  , Effects.none
-  ];
+const abort = (model, value) =>[
+  merge(model, { isEditing: false }), Effects.none
+];
 
-const enter =
-  model =>
-  [ merge
-    ( model
-    , { isEditing: false }
-    )
-  , Effects.receive(Submit(model))
-  ]
+const enter = model =>[
+  merge(model, { isEditing: false }), Effects.receive(Submit(model))
+]
 
-const decodeChange =
-  event =>
-  Change(event.target.value);
+const decodeChange = event =>Change(event.target.value);
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] =>
-  ( action.type === "Change"
-  ? change(model, action.source)
-  : action.type === "Edit"
-  ? edit(model)
-  : action.type === "Abort"
-  ? abort(model)
-  : action.type === "Enter"
-  ? enter(model)
-  : Unknown.update(model, action)
-  );
+export const update = (model:Model, action:Action):[Model, Effects<Action>] =>( action.type === "Change"
+        ? change(model, action.source)
+        : action.type === "Edit"
+        ? edit(model)
+        : action.type === "Abort"
+        ? abort(model)
+        : action.type === "Enter"
+        ? enter(model)
+        : Unknown.update(model, action)
+);
 
-const styleSheet = StyleSheet.create
-  ( { base:
-      { cursor: 'text'
-      , display: 'block'
-      , width: '100%'
-      , position: 'relative'
-      }
-    , entry:
-      { fontSize: 'inherit'
-      , fontFamily: 'inherit'
-      , color: 'inherit'
-      , background: 'inherit'
-      , border: 'none'
-      , display: 'block'
-      , lineHeight: 'inherit'
-      , width: '100%'
-      , resize: 'none'
-      , padding: '0px'
-      , margin: '0px'
-      }
-    , display:
-      { fontSize: 'inherit'
-      , fontFamily: 'inherit'
-      , color: 'inherit'
-      , background: 'inherit'
-      , border: 'none'
-      , display: 'block'
-      , lineHeight: 'inherit'
-      , marginBottom: '6px'
-      }
-    , visible:
-      {
-
-      }
-    // servo$: display none seems to cause bugs in servo.
-    , hidden:
-      { zIndex: -1
-      , position: 'absolute'
-      , opacity: '0'
-      }
-    }
-  );
+const styleSheet = StyleSheet.create({
+                                       base: {
+                                         cursor: 'text', display: 'block', width: '100%', position: 'relative'
+                                       }, entry: {
+    fontSize: 'inherit',
+    fontFamily: 'inherit',
+    color: 'inherit',
+    background: 'inherit',
+    border: 'none',
+    display: 'block',
+    lineHeight: 'inherit',
+    width: '100%',
+    resize: 'none',
+    padding: '0px',
+    margin: '0px'
+  }, display: {
+    fontSize: 'inherit',
+    fontFamily: 'inherit',
+    color: 'inherit',
+    background: 'inherit',
+    border: 'none',
+    display: 'block',
+    lineHeight: 'inherit',
+    marginBottom: '6px'
+  }, visible: {}
+                                       // servo$: display none seems to cause bugs in servo.
+                                       , hidden: {
+    zIndex: -1, position: 'absolute', opacity: '0'
+  }
+                                     });
 
 
-const render =
-  (model, address) =>
-  html.section
-  ( { className: 'input'
-    , style: styleSheet.base
-    , onKeyDown: event =>
-      ( event.key === 'Escape'
-      ? address(Abort)
-      : ( event.key === 'Enter' &&
-          event.metaKey
-        )
-      ? address(Enter)
-      : null
-      )
-    }
-  , [ html.textarea
-      ( { className: 'entry'
-        , style: Style
-          ( styleSheet.entry
-          , ( model.isEditing
-            ? styleSheet.visible
-            : styleSheet.hidden
-            )
-          )
-        , rows: model.value.split(/\n/).length + 1
-        , focus: focus(model.isEditing)
-        , onBlur: forward(address, always(Abort))
-        , onKeyUp: forward(address, decodeChange)
-        , value: model.value
-        }
-      )
-    , html.output
-      ( { className: 'display'
-        , style: Style
-          ( styleSheet.display
-          , ( model.isEditing
-            ? styleSheet.hidden
-            : styleSheet.visible
-            )
-          )
-        , onClick: forward(address, always(Edit))
-        }
-      , [model.value]
-      )
-    ]
-  );
+const render = (model, address) =>html.section({
+                                                 className: 'input',
+                                                 style: styleSheet.base,
+                                                 onKeyDown: event =>( event.key === 'Escape'
+                                                         ? address(Abort)
+                                                         : ( event.key === 'Enter' && event.metaKey
+                                                     )
+                                                         ? address(Enter)
+                                                         : null
+                                                 )
+                                               }, [
+                                                 html.textarea({
+                                                                 className: 'entry',
+                                                                 style: Style(styleSheet.entry, ( model.isEditing
+                                                                         ? styleSheet.visible
+                                                                         : styleSheet.hidden
+                                                                 )),
+                                                                 rows: model.value.split(/\n/).length + 1,
+                                                                 focus: focus(model.isEditing),
+                                                                 onBlur: forward(address, always(Abort)),
+                                                                 onKeyUp: forward(address, decodeChange),
+                                                                 value: model.value
+                                                               }), html.output({
+                                                                                 className: 'display',
+                                                                                 style: Style(styleSheet.display,
+                                                                                              ( model.isEditing
+                                                                                                      ? styleSheet.hidden
+                                                                                                      : styleSheet.visible
+                                                                                              )),
+                                                                                 onClick: forward(address, always(Edit))
+                                                                               }, [model.value])
+                                               ]);
 
-export const view =
-  (model: Model, address: Address<Action>): DOM =>
-  thunk('input', render, model, address);
+export const view = (model:Model, address:Address<Action>):DOM =>thunk('input', render, model, address);

--- a/src/about/repl/repl/output.js
+++ b/src/about/repl/repl/output.js
@@ -20,9 +20,9 @@ import type {Model, Action} from "./output"
 export const Print = tag("Print");
 
 export const init =
-  ( version/*:number*/
-  , result/*:?EvaluationResult*/=null
-  )/*:[Model, Effects<Action>]*/ =>
+  ( version: number
+  , result: ?EvaluationResult=null
+  ): [Model, Effects<Action>] =>
   [ { version
     , result
     }
@@ -40,7 +40,7 @@ const print = (model, output) =>
   ];
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model: Model, action: Action): [Model, Effects<Action>] =>
   ( action.type === 'Print'
   ? print(model, action.source)
   : Unknown.update(model, action)
@@ -113,5 +113,5 @@ const render =
   );
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>): DOM =>
   thunk('output', render, model, address);

--- a/src/about/repl/repl/output.js
+++ b/src/about/repl/repl/output.js
@@ -4,114 +4,76 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, thunk, forward, Effects} from 'reflex';
-import {merge, always, batch, tag, tagged} from "../../../common/prelude";
-import {Style, StyleSheet} from '../../../common/style';
-import * as Settings from '../../../common/settings';
-import * as Unknown from '../../../common/unknown';
-import {focus} from "@driver";
+import { html, thunk, Effects } from 'reflex'
+import { merge, tag } from '../../../common/prelude'
+import { Style, StyleSheet } from '../../../common/style'
+import * as Unknown from '../../../common/unknown'
+import { focus } from '@driver'
 
 /*::
-import type {Address, DOM} from "reflex"
-import type {EvaluationResult} from "./host"
-import type {Model, Action} from "./output"
-*/
+ import type {Address, DOM} from "reflex"
+ import type {EvaluationResult} from "./host"
+ import type {Model, Action} from "./output"
+ */
 
 export const Print = tag("Print");
 
-export const init =
-  ( version: number
-  , result: ?EvaluationResult=null
-  ): [Model, Effects<Action>] =>
-  [ { version
-    , result
-    }
-  , Effects.none
-  ];
+export const init = (version:number, result:?EvaluationResult = null):[Model, Effects<Action>] =>[
+  {
+    version, result
+  }, Effects.none
+];
 
-const print = (model, output) =>
-  [ merge
-    ( model
-    , { version: output.version
-      , result: output.result
-      }
-    )
-  , Effects.none
-  ];
+const print = (model, output) =>[
+  merge(model, {
+    version: output.version, result: output.result
+  }), Effects.none
+];
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] =>
-  ( action.type === 'Print'
-  ? print(model, action.source)
-  : Unknown.update(model, action)
-  );
+export const update = (model:Model, action:Action):[Model, Effects<Action>] =>( action.type === 'Print'
+        ? print(model, action.source)
+        : Unknown.update(model, action)
+);
 
-const styleSheet = StyleSheet.create
-  ( { base:
-      { fontSize: 'inherit'
-      , fontFamily: 'inherit'
-      , color: 'inherit'
-      , background: 'inherit'
-      , border: 'none'
-      , display: 'block'
-      , lineHeight: 'inherit'
-      , paddingTop: '8px'
-      , whiteSpace: 'pre-wrap'
-      }
-    , ok:
-      {
-      }
-    , error:
-      {
-      }
-    , empty:
-      {
-      }
-    }
-  );
+const styleSheet = StyleSheet.create({
+                                       base: {
+                                         fontSize: 'inherit',
+                                         fontFamily: 'inherit',
+                                         color: 'inherit',
+                                         background: 'inherit',
+                                         border: 'none',
+                                         display: 'block',
+                                         lineHeight: 'inherit',
+                                         paddingTop: '8px',
+                                         whiteSpace: 'pre-wrap'
+                                       }, ok: {}, error: {}, empty: {}
+                                     });
 
-const display =
-  value =>
-  ( value == null
-  ? String(value)
-  : typeof(value) === "object"
-  ? ( value.$type === "VirtualText"
-    ? value
-    : value.$type === "VirtualNode"
-    ? value
-    : value.$type === "Thunk"
-    ? value
-    : value.$type === "LazyTree"
-    ? value
-    : value.toString()
-    )
-  : value.toString()
-  );
+const display = value =>( value == null ? String(value) : typeof(value) === "object" ? ( value.$type === "VirtualText"
+            ? value
+            : value.$type === "VirtualNode"
+            ? value
+            : value.$type === "Thunk"
+            ? value
+            : value.$type === "LazyTree"
+            ? value
+            : value.toString()
+    ) : value.toString()
+);
 
 
-const render =
-  (model, address) =>
-  html.output
-  ( { className: 'output'
-    , style: Style
-      ( styleSheet.base
-      , ( model.result == null
-        ? styleSheet.empty
-        : model.result.isOk
-        ? styleSheet.ok
-        : styleSheet.error
-        )
-      )
-    }
-  , [ ( model.result == null
-      ? ''
-      : model.result.isError
-      ? display(model.result.error)
-      : display(model.result.value)
-      )
-    ]
-  );
+const render = (model, address) =>html.output({
+                                                className: 'output',
+                                                style: Style(styleSheet.base, ( model.result == null
+                                                        ? styleSheet.empty
+                                                        : model.result.isOk
+                                                        ? styleSheet.ok
+                                                        : styleSheet.error
+                                                ))
+                                              }, [
+                                                ( model.result == null ? '' : model.result.isError ? display(
+                                                        model.result.error) : display(model.result.value)
+                                                )
+                                              ]);
 
-export const view =
-  (model: Model, address: Address<Action>): DOM =>
-  thunk('output', render, model, address);
+export const view = (model:Model, address:Address<Action>):DOM =>thunk('output', render, model, address);

--- a/src/about/settings/main.js
+++ b/src/about/settings/main.js
@@ -4,32 +4,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import "babel-polyfill";
-import {start, Effects} from "reflex";
-import * as UI from "./settings";
-import {Renderer} from "@driver";
+import 'babel-polyfill'
+import { start, Effects } from 'reflex'
+import * as UI from './settings'
+import { Renderer } from '@driver'
 
 const isReload = window.application != null;
 
-const restore =
-  () =>
-  [ window.application.model.value
-  , Effects.none
-  ]
+const restore = () =>[
+  window.application.model.value, Effects.none
+]
 
 
 const application = start({
-  flags: void(0),
-  init:
-  ( isReload
-  ? restore
-  : UI.init
-  ),
-  update: UI.update,
-  view: UI.view
-});
+                            flags: void(0), init: ( isReload ? restore : UI.init
+  ), update: UI.update, view: UI.view
+                          });
 
-const renderer = new Renderer({target: document.body});
+const renderer = new Renderer({ target: document.body });
 application.view.subscribe(renderer.address);
 application.task.subscribe(Effects.driver(application.address));
 

--- a/src/about/settings/setting.js
+++ b/src/about/settings/setting.js
@@ -4,305 +4,204 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Style, StyleSheet} from '../../common/style';
-import {html, thunk, forward, Effects} from 'reflex';
-import {compose} from '../../lang/functional';
-import {merge, always, tag, tagged, batch} from "../../common/prelude"
-import {cursor} from "../../common/cursor"
-import {ok, error} from "../../common/result";
-import * as Unknown from '../../common/unknown';
-import * as Focusable from '../../common/focusable';
-import * as Editable from '../../common/editable';
-import * as TextInput from '../../common/text-input';
+import { Style, StyleSheet } from '../../common/style'
+import { html, thunk, forward, Effects } from 'reflex'
+import { compose } from '../../lang/functional'
+import { merge, always, tag, batch } from '../../common/prelude'
+import { cursor } from '../../common/cursor'
+import { ok, error } from '../../common/result'
+import * as Unknown from '../../common/unknown'
+import * as TextInput from '../../common/text-input'
 
 /*::
-import type {Address, DOM} from "reflex";
-import type {Value, Model, Action} from "./setting"
-*/
+ import type {Address, DOM} from "reflex";
+ import type {Value, Model, Action} from "./setting"
+ */
 
-const TextInputAction =
-  (action: TextInput.Action): Action =>
-  ( action.type === "Blur"
-  ? Abort
-  : { type: "TextInput"
-    , source: action
+const TextInputAction = (action:TextInput.Action):Action =>( action.type === "Blur" ? Abort : {
+      type: "TextInput", source: action
     }
-  );
+);
 
 
-export const Edit: Action = { type: "Edit" };
-export const Abort: Action = { type: "Abort" };
-export const Submit: Action = { type: "Submit" };
+export const Edit:Action = { type: "Edit" };
+export const Abort:Action = { type: "Abort" };
+export const Submit:Action = { type: "Submit" };
 
 const Save = tag("Save");
 export const Change = tag("Change");
 
-const FocusInput: Action = TextInputAction(TextInput.Focus);
-const DisableInput: Action = TextInputAction(TextInput.Disable);
-const EnableInput: Action = TextInputAction(TextInput.Enable);
+const FocusInput:Action = TextInputAction(TextInput.Focus);
+const DisableInput:Action = TextInputAction(TextInput.Disable);
+const EnableInput:Action = TextInputAction(TextInput.Enable);
 const ChangeInput = compose(TextInputAction, TextInput.Change);
 
 
+export const init = (value:Value):[Model, Effects<Action>] => {
+  const [input, fx] = TextInput.init(( value == null ? '' : JSON.stringify(value)
+                                     ), null, '', true);
 
-export const init =
-  (value: Value): [Model, Effects<Action>] => {
-    const [input, fx] = TextInput.init
-      ( ( value == null
-        ? ''
-        : JSON.stringify(value)
-        )
-      , null
-      , ''
-      , true
-      );
+  const model = {
+    value, input, isValid: true, isEditing: false
+  };
 
-    const model =
-      { value
-      , input
-      , isValid: true
-      , isEditing: false
-      };
+  return [model, fx.map(TextInputAction)];
+}
 
-    return [ model, fx.map(TextInputAction) ];
-  }
+const edit = model =>batch(update, merge(model, { isEditing: true, isValid: true }), [
+  EnableInput, FocusInput
+]);
 
-const edit = model =>
-  batch
-  ( update
-  , merge(model, {isEditing: true, isValid: true})
-  , [ EnableInput
-    , FocusInput
-    ]
-  );
-
-const abort = model =>
-  batch
-  ( update
-  , merge(model, {isEditing: false})
-  , [ DisableInput
-    , ChangeInput
-      ( model.value == null
-      ? ''
-      : JSON.stringify(model.value)
-      )
-    ]
-  );
+const abort = model =>batch(update, merge(model, { isEditing: false }), [
+  DisableInput, ChangeInput(model.value == null ? '' : JSON.stringify(model.value))
+]);
 
 const submit = model => {
   const change = parseInput(model.input.value);
-  const result =
-    ( change.isOk
-    ? [ merge(model, {isEditing: false})
-      , Effects.receive(Save(change.value))
+  const result = ( change.isOk ? [
+        merge(model, { isEditing: false }), Effects.receive(Save(change.value))
+      ] : [
+        merge(model, { isValid: false }), Effects.none
       ]
-    : [ merge(model, {isValid: false})
-      , Effects.none
-      ]
-    );
+  );
 
   return result
 };
 
 
-const change = (model, value) =>
-  batch
-  ( update
-  , ( merge
-      ( model
-      , { value
-        , isEditing: false
-        , isValid: true
-        }
-      )
-    )
-  , [ DisableInput
-    , ChangeInput
-      ( value == null
-      ? `""`
-      : JSON.stringify(value)
-      )
-    ]
-  );
+const change = (model, value) =>batch(update, ( merge(model, {
+      value, isEditing: false, isValid: true
+    })
+), [
+                                        DisableInput, ChangeInput(value == null ? `""` : JSON.stringify(value))
+                                      ]);
 
-const updateTextInput = cursor
-  ( { get: model => model.input
-    , set: (model, input) => merge(model, {input})
-    , tag: TextInputAction
-    , update: TextInput.update
-    }
-  );
+const updateTextInput = cursor({
+                                 get: model => model.input,
+                                 set: (model, input) => merge(model, { input }),
+                                 tag: TextInputAction,
+                                 update: TextInput.update
+                               });
 
-const parseInput =
-  input => {
-    try {
-      return ok(JSON.parse(input));
-    } catch (reason) {
-      return error(reason);
-    }
-  };
+const parseInput = input => {
+  try {
+    return ok(JSON.parse(input));
+  } catch (reason) {
+    return error(reason);
+  }
+};
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] =>
-  ( action.type === 'Edit'
-  ? edit(model)
-  : action.type === 'Abort'
-  ? abort(model)
-  : action.type === 'Submit'
-  ? submit(model)
-  : action.type === 'Save'
-  ? change(model, action.source)
-  : action.type === 'Change'
-  ? change(model, action.source)
-  : action.type === 'TextInput'
-  ? updateTextInput(model, action.source)
-  : Unknown.update(model, action)
-  );
+export const update = (model:Model, action:Action):[Model, Effects<Action>] =>( action.type === 'Edit'
+        ? edit(model)
+        : action.type === 'Abort'
+        ? abort(model)
+        : action.type === 'Submit'
+        ? submit(model)
+        : action.type === 'Save'
+        ? change(model, action.source)
+        : action.type === 'Change'
+        ? change(model, action.source)
+        : action.type === 'TextInput'
+        ? updateTextInput(model, action.source)
+        : Unknown.update(model, action)
+);
 
 
-const styleSheet = StyleSheet.create
-  ( { json: {}
-    , string: {}
-    , number:
-      { border: 'none'
-      , backgroundColor: 'inherit'
-      , color: 'inherit'
-      }
-    , boolean:
-      { cursor: 'pointer'
-      , textDecoration: 'underline'
-      }
-    , hidden:
-      { display: "none"
-      }
-    , visible:
-      {}
-    }
-  );
+const styleSheet = StyleSheet.create({
+                                       json: {}, string: {}, number: {
+    border: 'none', backgroundColor: 'inherit', color: 'inherit'
+  }, boolean: {
+    cursor: 'pointer', textDecoration: 'underline'
+  }, hidden: {
+    display: "none"
+  }, visible: {}
+                                     });
 
 
-const viewNumber = (value, address, contextStyle) =>
-  html.input
-  ( { type: 'number'
-    , style: Style(styleSheet.number, contextStyle)
-    , value
-    , onClick:
-      event =>
-        ( event.altKey
-        ? address(Edit)
-        : null
-        )
-    , onChange:
-      event =>
-        address(Save(event.target.valueAsNumber))
-    }
-  );
+const viewNumber = (value, address, contextStyle) =>html.input({
+                                                                 type: 'number',
+                                                                 style: Style(styleSheet.number, contextStyle),
+                                                                 value,
+                                                                 onClick: event =>( event.altKey ? address(Edit) : null
+                                                                 ),
+                                                                 onChange: event =>address(
+                                                                     Save(event.target.valueAsNumber))
+                                                               });
 
-const viewString = (value, address, contextStyle) =>
-  html.code
-  ( { style: Style(styleSheet.string, contextStyle)
-    , onClick: forward(address, always(Edit))
-    }
-  , [ `"${value}"`
-    ]
-  );
+const viewString = (value, address, contextStyle) =>html.code({
+                                                                style: Style(styleSheet.string, contextStyle),
+                                                                onClick: forward(address, always(Edit))
+                                                              }, [
+                                                                `"${value}"`
+                                                              ]);
 
-const viewBoolean = (value, address, contextStyle) =>
-  html.code
-  ( { style: Style(styleSheet.boolean, contextStyle)
-    , onClick:
-      event =>
-        ( event.altKey
-        ? address(Edit)
-        : address(Save(!value))
-        )
-    }
-  , [ `${value}`
-    ]
-  );
+const viewBoolean = (value, address, contextStyle) =>html.code({
+                                                                 style: Style(styleSheet.boolean, contextStyle),
+                                                                 onClick: event =>( event.altKey
+                                                                         ? address(Edit)
+                                                                         : address(Save(!value))
+                                                                 )
+                                                               }, [
+                                                                 `${value}`
+                                                               ]);
 
-const viewJSON = (value, address, contextStyle) =>
-  html.code
-  ( { style: Style(styleSheet.json, contextStyle)
-    , onClick: forward(address, always(Edit))
-    }
-  , [ JSON.stringify(value)
-    ]
-  );
+const viewJSON = (value, address, contextStyle) =>html.code({
+                                                              style: Style(styleSheet.json, contextStyle),
+                                                              onClick: forward(address, always(Edit))
+                                                            }, [
+                                                              JSON.stringify(value)
+                                                            ]);
 
 const viewValue = (value, address, contextStyle) => {
   const type = typeof(value)
 
-  const view =
-    ( type === "number"
-    ? viewNumber(value, address, contextStyle)
-    : type === "string"
-    ? viewString(value, address, contextStyle)
-    : type === "boolean"
-    ? viewBoolean(value, address, contextStyle)
-    : viewJSON(value, address, contextStyle)
-    );
+  const view = ( type === "number"
+          ? viewNumber(value, address, contextStyle)
+          : type === "string"
+          ? viewString(value, address, contextStyle)
+          : type === "boolean"
+          ? viewBoolean(value, address, contextStyle)
+          : viewJSON(value, address, contextStyle)
+  );
 
   return view
 };
 
-const viewInput = TextInput.view
-  ( "input"
-  , StyleSheet.create
-    ( { base:
-        { fontFamily: 'inherit'
-        , fontSize: 'inherit'
-        , color: 'inherit'
-        , width: 'calc(100% - 10px)'
-        , border: 'none'
-        , backgroundColor: 'rgba(255,255,255,0.2)'
-        , color: 'rgba(255,255,255,0.7)'
-        , borderRadius: '5px 5px 5px 5px'
-        , padding: 5
-        }
-      , enabled:
-        {
-        }
-      , disabled:
-        { display: 'none'
+const viewInput = TextInput.view("input", StyleSheet.create({
+                                                              base: {
+                                                                fontFamily: 'inherit',
+                                                                fontSize: 'inherit',
+                                                                color: 'inherit',
+                                                                width: 'calc(100% - 10px)',
+                                                                border: 'none',
+                                                                backgroundColor: 'rgba(255,255,255,0.2)',
+                                                                color: 'rgba(255,255,255,0.7)',
+                                                                borderRadius: '5px 5px 5px 5px',
+                                                                padding: 5
+                                                              }, enabled: {}, disabled: {
+    display: 'none'
 
-        }
-      }
-    )
-  );
+  }
+                                                            }));
 
 
-export const view =
-  (model: Model, address: Address<Action>): DOM =>
-  html.form
-  ( { onKeyDown:
-      event => {
-        ( event.key === 'Enter'
-        ? address(Submit)
-        : event.key === 'Escape'
-        ? address(Abort)
-        : null
-        )
-      }
-    , onSubmit:
-        event => {
-          event.preventDefault();
-        }
-    }
-  , [ thunk
-      ( 'value'
-      , viewValue
-      , model.value
-      , address
-      , ( model.isEditing
-        ? styleSheet.hidden
-        : styleSheet.visible
-        )
-      )
-    , thunk
-      ( 'input'
-      , viewInput
-      , model.input
-      , forward(address, TextInputAction)
-      )
-    ]
-  )
+export const view = (model:Model, address:Address<Action>):DOM =>html.form({
+                                                                             onKeyDown: event => {
+                                                                               ( event.key === 'Enter'
+                                                                                       ? address(Submit)
+                                                                                       : event.key === 'Escape'
+                                                                                       ? address(Abort)
+                                                                                       : null
+                                                                               )
+                                                                             }, onSubmit: event => {
+    event.preventDefault();
+  }
+                                                                           }, [
+                                                                             thunk('value', viewValue, model.value,
+                                                                                   address, ( model.isEditing
+                                                                                         ? styleSheet.hidden
+                                                                                         : styleSheet.visible
+                                                                                   )),
+                                                                             thunk('input', viewInput, model.input,
+                                                                                   forward(address, TextInputAction))
+                                                                           ])

--- a/src/about/settings/setting.js
+++ b/src/about/settings/setting.js
@@ -21,7 +21,7 @@ import type {Value, Model, Action} from "./setting"
 */
 
 const TextInputAction =
-  (action/*:TextInput.Action*/)/*:Action*/ =>
+  (action: TextInput.Action): Action =>
   ( action.type === "Blur"
   ? Abort
   : { type: "TextInput"
@@ -30,22 +30,22 @@ const TextInputAction =
   );
 
 
-export const Edit/*:Action*/ = { type: "Edit" };
-export const Abort/*:Action*/ = { type: "Abort" };
-export const Submit/*:Action*/ = { type: "Submit" };
+export const Edit: Action = { type: "Edit" };
+export const Abort: Action = { type: "Abort" };
+export const Submit: Action = { type: "Submit" };
 
 const Save = tag("Save");
 export const Change = tag("Change");
 
-const FocusInput/*:Action*/ = TextInputAction(TextInput.Focus);
-const DisableInput/*:Action*/ = TextInputAction(TextInput.Disable);
-const EnableInput/*:Action*/ = TextInputAction(TextInput.Enable);
+const FocusInput: Action = TextInputAction(TextInput.Focus);
+const DisableInput: Action = TextInputAction(TextInput.Disable);
+const EnableInput: Action = TextInputAction(TextInput.Enable);
 const ChangeInput = compose(TextInputAction, TextInput.Change);
 
 
 
 export const init =
-  (value/*:Value*/)/*:[Model, Effects<Action>]*/ => {
+  (value: Value): [Model, Effects<Action>] => {
     const [input, fx] = TextInput.init
       ( ( value == null
         ? ''
@@ -142,7 +142,7 @@ const parseInput =
   };
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model: Model, action: Action): [Model, Effects<Action>] =>
   ( action.type === 'Edit'
   ? edit(model)
   : action.type === 'Abort'
@@ -272,7 +272,7 @@ const viewInput = TextInput.view
 
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>): DOM =>
   html.form
   ( { onKeyDown:
       event => {

--- a/src/about/settings/settings.js
+++ b/src/about/settings/settings.js
@@ -61,7 +61,7 @@ const Changed =
 
 
 const SettingAction =
-  (name/*:Name*/, action/*:Setting.Action*/)/*:Action*/ =>
+  (name: Name, action: Setting.Action): Action =>
   ( action.type === 'Save'
   ? Save
     ( { [name]: action.source
@@ -74,7 +74,7 @@ const SettingAction =
   );
 
 const SettingActionByName =
-  (name/*:Name*/)/*:(action:Setting.Action) => Action*/ =>
+  (name: Name)/*:(action:Setting.Action) => Action*/ =>
   action =>
   SettingAction(name, action);
 
@@ -82,7 +82,7 @@ const ChangeSetting =
   (name, value) =>
   SettingAction(name, Setting.Change(value));
 
-export const init = ()/*:[Model, Effects<Action>]*/ => {
+export const init = (): [Model, Effects<Action>] => {
   const model =
     { settings: {}
     };
@@ -204,7 +204,7 @@ const updateSettingByName = (model, name, action) => {
 }
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model: Model, action: Action): [Model, Effects<Action>] =>
   ( action.type === 'Save'
   ? save(model, action.source)
 
@@ -273,7 +273,7 @@ const styleSheet = StyleSheet.create
 
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>): DOM =>
   html.div
   ( { key: 'settings'
     , style: styleSheet.base

--- a/src/about/settings/settings.js
+++ b/src/about/settings/settings.js
@@ -4,317 +4,230 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, thunk, forward, Effects} from 'reflex';
-import {merge, batch, always, tag, tagged} from "../../common/prelude";
-import {Style, StyleSheet} from '../../common/style';
-import * as Settings from '../../common/settings';
-import * as Unknown from '../../common/unknown';
-import * as Setting from './setting';
+import { html, thunk, forward, Effects } from 'reflex'
+import { merge, batch, always } from '../../common/prelude'
+import { Style, StyleSheet } from '../../common/style'
+import * as Settings from '../../common/settings'
+import * as Unknown from '../../common/unknown'
+import * as Setting from './setting'
 
 /*::
-import type {Address, DOM} from "reflex";
-import type {Name, Value, Model, Action} from "./settings";
-*/
+ import type {Address, DOM} from "reflex";
+ import type {Name, Value, Model, Action} from "./settings";
+ */
 
 // Actions
 
 const NoOp = always({ type: "NoOp" });
 
-const Save =
-  settings =>
-  ( { type: "Save"
-    , source: settings
-    }
-  );
+const Save = settings =>( {
+  type: "Save", source: settings
+}
+);
 
-const Saved =
-  result =>
-  ( { type: "Saved"
-    , source: result
-    }
-  );
+const Saved = result =>( {
+  type: "Saved", source: result
+}
+);
 
-const Observe =
-  { type: "Observe"
+const Observe = {
+  type: "Observe"
+};
+
+const Change = result =>( {
+  type: "Change", source: result
+}
+);
+
+const Fetched = result =>( {
+  type: "Fetched", source: result
+}
+);
+
+const Changed = result =>( {
+  type: "Changed", source: result
+}
+);
+
+
+const SettingAction = (name:Name, action:Setting.Action):Action =>( action.type === 'Save' ? Save({
+                                                                                                    [name]: action.source
+                                                                                                  }) : {
+      type: "Setting", name, source: action
+    }
+);
+
+const SettingActionByName = (name:Name)/*:(action:Setting.Action) => Action*/ =>action =>SettingAction(name, action);
+
+const ChangeSetting = (name, value) =>SettingAction(name, Setting.Change(value));
+
+export const init = ():[Model, Effects<Action>] => {
+  const model = {
+    settings: {}
   };
 
-const Change =
-  result =>
-  ( { type: "Change"
-    , source: result
-    }
-  );
-
-const Fetched =
-  result =>
-  ( { type: "Fetched"
-    , source: result
-    }
-  );
-
-const Changed =
-  result =>
-  ( { type: "Changed"
-    , source: result
-    }
-  );
-
-
-const SettingAction =
-  (name: Name, action: Setting.Action): Action =>
-  ( action.type === 'Save'
-  ? Save
-    ( { [name]: action.source
-      }
-    )
-  : { type: "Setting"
-    , name
-    , source: action
-    }
-  );
-
-const SettingActionByName =
-  (name: Name)/*:(action:Setting.Action) => Action*/ =>
-  action =>
-  SettingAction(name, action);
-
-const ChangeSetting =
-  (name, value) =>
-  SettingAction(name, Setting.Change(value));
-
-export const init = (): [Model, Effects<Action>] => {
-  const model =
-    { settings: {}
-    };
-
-  const fx = Effects.batch
-    ( [ Effects
-        .perform(Settings.fetch(["*"]))
-        .map(Fetched)
-      , Effects
-        .perform(Settings.observe("*"))
-        .map(Changed)
-      ]
-    );
+  const fx = Effects.batch([
+                             Effects
+                                 .perform(Settings.fetch(["*"]))
+                                 .map(Fetched), Effects
+                                 .perform(Settings.observe("*"))
+                                 .map(Changed)
+                           ]);
 
   return [model, fx];
 };
 
-const observe =
-  model =>
-  [ model
-  , Effects
-    .perform(Settings.observe("*"))
-    .map(Changed)
-  ];
+const observe = model =>[
+  model, Effects
+      .perform(Settings.observe("*"))
+      .map(Changed)
+];
 
 
-const change =
-  (model, result) => {
-    if (result.isOk) {
-      const {settings} = model;
-      const changes = result.value;
-      const effects = [];
-      const delta = {};
+const change = (model, result) => {
+  if (result.isOk) {
+    const { settings } = model;
+    const changes = result.value;
+    const effects = [];
+    const delta = {};
 
-      const patch = Object
-      .keys(changes)
-      .reduce
-      ( (patch, name) => {
+    const patch = Object
+        .keys(changes)
+        .reduce((patch, name) => {
           const value = changes[name];
           const [setting, fx] =
-            ( settings[name] == null
-            ? Setting.init(value)
-            : Setting.update
-              ( settings[name]
-              , Setting.Change(value)
-              )
-            );
+              ( settings[name] == null ? Setting.init(value) : Setting.update(settings[name], Setting.Change(value))
+              );
 
           patch.settings[name] = setting;
           patch.fx.push(fx.map(SettingActionByName(name)));
 
           return patch;
-        }
-      , { settings: {}
-        , fx: []
-        }
-      );
+        }, {
+                  settings: {}, fx: []
+                });
 
-      return (
-        [ merge
-          ( model
-          , { settings:
-              merge
-              ( model.settings
-              , patch.settings
-              )
-            }
-          )
-        , Effects.batch(patch.fx)
+    return (
+        [
+          merge(model, {
+            settings: merge(model.settings, patch.settings)
+          }), Effects.batch(patch.fx)
         ]
-      );
-    } else {
-      const output =
-        [ model
-        , Effects.perform
-          (Unknown.error(result.error))
-          .map(NoOp)
-        ];
+    );
+  } else {
+    const output = [
+      model, Effects.perform(Unknown.error(result.error))
+                    .map(NoOp)
+    ];
 
-      return output
-    }
-  };
+    return output
+  }
+};
 
-const save =
-  (model, changes) =>
-  [ model
-  , Effects
-    .perform(Settings.change(changes))
-    .map(Saved)
-  ];
+const save = (model, changes) =>[
+  model, Effects
+      .perform(Settings.change(changes))
+      .map(Saved)
+];
 
 
-const changed =
-  (model, result) =>
-  batch
-  ( update
-  , model
-  , [ Change(result)
-    , Observe
-    ]
-  );
+const changed = (model, result) =>batch(update, model, [
+  Change(result), Observe
+]);
 
 const updateSettingByName = (model, name, action) => {
   const [setting, fx] = Setting.update(model.settings[name], action);
-  const result =
-    [ merge
-      ( model
-      , { settings:
-          merge
-          ( model.settings
-          , {[name]: setting}
-          )
-        }
-      )
-    , fx
-      .map(SettingActionByName(name))
-    ]
+  const result = [
+    merge(model, {
+      settings: merge(model.settings, { [name]: setting })
+    }), fx
+        .map(SettingActionByName(name))
+  ]
   return result
 }
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] =>
-  ( action.type === 'Save'
-  ? save(model, action.source)
+export const update = (model:Model, action:Action):[Model, Effects<Action>] =>( action.type === 'Save' ? save(model,
+                                                                                                              action.source)
 
-  : action.type === 'Saved'
-  ? change(model, action.source)
+        : action.type === 'Saved' ? change(model, action.source)
 
-  : action.type === 'Fetched'
-  ? change(model, action.source)
+        : action.type === 'Fetched' ? change(model, action.source)
 
-  : action.type === 'Changed'
-  ? changed(model, action.source)
+        : action.type === 'Changed' ? changed(model, action.source)
 
-  : action.type === 'Change'
-  ? change(model, action.source)
+        : action.type === 'Change' ? change(model, action.source)
 
-  : action.type === 'Observe'
-  ? observe(model)
+        : action.type === 'Observe' ? observe(model)
 
-  : action.type === 'Setting'
-  ? updateSettingByName(model, action.name, action.source)
+        : action.type === 'Setting' ? updateSettingByName(model, action.name, action.source)
 
-  : Unknown.update(model, action)
-  );
+        : Unknown.update(model, action)
+);
 
 
-const styleSheet = StyleSheet.create
-  ( { invalid:
-      { textDecoration: 'underline wavy red'
-      }
-    , valid:
-      {
-      }
-    , base:
-      { fontSize: '12px'
-      , fontFamily: 'Menlo, Courier, monospace'
-      , color: 'rgba(255,255,255,0.65)'
-      , backgroundColor: '#273340'
-      , position: 'absolute'
-      , top: '0px'
-      , left: '0px'
-      , width: '100%'
-      , overflow: 'auto'
-      }
-    , row:
-      { borderBottom: '1px dotted rgba(255, 255, 255, 0.2)'
-      , lineHeight: '25px'
-      , whiteSpace: 'nowrap'
-      , padding: '0 5px'
-      }
-    , cell:
-      { verticalAlign: 'middle'
-      , display: 'inline-block'
-      , whiteSpace: 'nowrap'
-      , textOverflow: 'ellipsis'
-      , overflow: 'hidden'
-      }
-    , name:
-      { minWidth: '300px'
-      }
-    , value:
-      { width: '100vh'
-      , padding: '0 0 0 0'
-      }
-    }
-  );
+const styleSheet = StyleSheet.create({
+                                       invalid: {
+                                         textDecoration: 'underline wavy red'
+                                       }, valid: {}, base: {
+    fontSize: '12px',
+    fontFamily: 'Menlo, Courier, monospace',
+    color: 'rgba(255,255,255,0.65)',
+    backgroundColor: '#273340',
+    position: 'absolute',
+    top: '0px',
+    left: '0px',
+    width: '100%',
+    overflow: 'auto'
+  }, row: {
+    borderBottom: '1px dotted rgba(255, 255, 255, 0.2)', lineHeight: '25px', whiteSpace: 'nowrap', padding: '0 5px'
+  }, cell: {
+    verticalAlign: 'middle', display: 'inline-block', whiteSpace: 'nowrap', textOverflow: 'ellipsis', overflow: 'hidden'
+  }, name: {
+    minWidth: '300px'
+  }, value: {
+    width: '100vh', padding: '0 0 0 0'
+  }
+                                     });
 
 
-export const view =
-  (model: Model, address: Address<Action>): DOM =>
-  html.div
-  ( { key: 'settings'
-    , style: styleSheet.base
-    }
-  , [ ...Object.keys(model.settings)
-      .map
-      ( name =>
-        html.div
-        ( { style: Style
-            ( styleSheet.row
-            , ( model.settings[name].isValid
-              ? styleSheet.valid
-              : styleSheet.invalid
-              )
-            )
-          }
-        , [ html.code
-            ( { key: 'name'
-              , style: Style(styleSheet.cell, styleSheet.name)
-              }
-            , [name]
-            )
-          , html.code
-            ( { key: 'value'
-              , style: Style(styleSheet.cell, styleSheet.value)
-              }
-            , [ thunk
-                ( name
-                , Setting.view
-                , model.settings[name]
-                , forward(address, SettingActionByName(name))
-                )
-              ]
-            )
-          ]
-        )
-      )
-    , html.meta
-      ( { name: 'theme-color'
-        , content: `${styleSheet.base.backgroundColor}|${styleSheet.base.color}`
-        }
-      )
-    ]
-  );
+export const view = (model:Model, address:Address<Action>):DOM =>html.div({
+                                                                            key: 'settings', style: styleSheet.base
+                                                                          }, [
+                                                                            ...Object.keys(model.settings)
+                                                                                     .map(name =>html.div({
+                                                                                                            style: Style(
+                                                                                                                styleSheet.row,
+                                                                                                                ( model.settings[name].isValid
+                                                                                                                        ? styleSheet.valid
+                                                                                                                        : styleSheet.invalid
+                                                                                                                ))
+                                                                                                          }, [
+                                                                                                            html.code({
+                                                                                                                        key: 'name',
+                                                                                                                        style: Style(
+                                                                                                                            styleSheet.cell,
+                                                                                                                            styleSheet.name)
+                                                                                                                      },
+                                                                                                                      [name]),
+                                                                                                            html.code({
+                                                                                                                        key: 'value',
+                                                                                                                        style: Style(
+                                                                                                                            styleSheet.cell,
+                                                                                                                            styleSheet.value)
+                                                                                                                      },
+                                                                                                                      [
+                                                                                                                        thunk(
+                                                                                                                            name,
+                                                                                                                            Setting.view,
+                                                                                                                            model.settings[name],
+                                                                                                                            forward(
+                                                                                                                                address,
+                                                                                                                                SettingActionByName(
+                                                                                                                                    name)))
+                                                                                                                      ])
+                                                                                                          ])),
+                                                                            html.meta({
+                                                                                        name: 'theme-color',
+                                                                                        content: `${styleSheet.base.backgroundColor}|${styleSheet.base.color}`
+                                                                                      })
+                                                                          ]);

--- a/src/browser.js
+++ b/src/browser.js
@@ -100,11 +100,11 @@ export class Model {
   devtools: Devtools.Model;
   */
   constructor(
-    version/*:Version*/=Package.version
-  , shell/*:Shell.Model*/
-  , navigators/*:Navigators.Model*/
-  , sidebar/*:Sidebar.Model*/
-  , devtools/*:Devtools.Model*/
+    version: Version=Package.version
+  , shell: Shell.Model
+  , navigators: Navigators.Model
+  , sidebar: Sidebar.Model
+  , devtools: Devtools.Model
   ) {
     this.version = version
     this.shell = shell
@@ -123,7 +123,7 @@ const Modify =
     }
   )
 
-export const init = ()/*:[Model, Effects<Action>]*/ => {
+export const init = (): [Model, Effects<Action>] => {
   const [devtools, devtoolsFx] = Devtools.init({isActive: Config.devtools});
   const [shell, shellFx] = Shell.init();
   const [sidebar, sidebarFx] = Sidebar.init();
@@ -170,7 +170,7 @@ const SidebarAction = action =>
 
 
 const NavigatorsAction =
-  (action/*:Navigators.Action*/)/*:Action*/ => {
+  (action: Navigators.Action): Action => {
     switch (action.type) {
       case "ShowTabs":
         return ShowTabs
@@ -261,7 +261,7 @@ const updateSidebar = cursor({
   update: Sidebar.update
 });
 
-const Reloaded/*:Action*/ =
+const Reloaded: Action =
   { type: "Reloaded"
   };
 
@@ -275,56 +275,56 @@ const Failure = error =>
 // ### Mode changes
 
 
-export const OpenNewTab/*:Action*/ =
+export const OpenNewTab: Action =
   { type: 'OpenNewTab'
   };
 
-export const EditWebView/*:Action*/ =
+export const EditWebView: Action =
   { type: 'EditWebView'
   };
 
-export const ShowWebView/*:Action*/ =
+export const ShowWebView: Action =
   { type: 'ShowWebView'
   };
 
-export const ShowTabs/*:Action*/ =
+export const ShowTabs: Action =
   { type: 'ShowTabs'
   };
 
-export const SelectWebView/*:Action*/ =
+export const SelectWebView: Action =
   { type: 'SelectWebView'
   };
 
 // ### Actions that affect multilpe sub-components
 
-export const OpenWebView/*:Action*/ =
+export const OpenWebView: Action =
   { type: 'OpenWebView'
   };
 
-export const AttachSidebar/*:Action*/ =
+export const AttachSidebar: Action =
   { type: "AttachSidebar"
   , source: Sidebar.Attach
   };
 
-export const DetachSidebar/*:Action*/ =
+export const DetachSidebar: Action =
   { type: "DetachSidebar"
   , source: Sidebar.Detach
   };
 
-export const Escape/*:Action*/ =
+export const Escape: Action =
   { type: 'Escape'
   };
 
 
-export const Unload/*:Action*/ =
+export const Unload: Action =
   { type: 'Unload'
   };
 
-export const ReloadRuntime/*:Action*/ =
+export const ReloadRuntime: Action =
   { type: 'ReloadRuntime'
   };
 
-export const BlurInput/*:Action*/ =
+export const BlurInput: Action =
   { type: 'BlurInput'
   };
 
@@ -608,7 +608,7 @@ const reloadRuntime = model =>
 
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ => {
+  (model: Model, action: Action): [Model, Effects<Action>] => {
     switch (action.type) {
       case 'GoBack':
         return goBack(model);
@@ -704,7 +704,7 @@ const styleSheet = StyleSheet.create({
 });
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>): DOM =>
   html.main
   ( { className: 'root'
     , style: styleSheet.root

--- a/src/browser.js
+++ b/src/browser.js
@@ -5,107 +5,95 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import * as Package from "../package.json";
-import * as Config from "../browserhtml.json";
-import {Effects, html, forward, thunk} from "reflex";
-
-import * as Shell from "./browser/shell";
-import * as Sidebar from './browser/Sidebar';
-import * as Devtools from "./common/devtools";
-import * as Runtime from "./common/runtime";
-import * as URL from './common/url-helper';
-import * as Unknown from "./common/unknown";
-import * as Focusable from "./common/focusable";
-import * as OS from './common/os';
-import * as Keyboard from './common/keyboard';
-import * as Stopwatch from "./common/stopwatch";
-import * as Easing from "eased";
-import {always, batch, tag, tagged} from "./common/prelude";
-import {cursor} from "./common/cursor";
-import {Style, StyleSheet} from './common/style';
-
-import {identity, compose} from "./lang/functional";
-
-import {onWindow, on} from "@driver";
-import * as Navigators from "./browser/Navigators";
+import * as Package from '../package.json'
+import * as Config from '../browserhtml.json'
+import { Effects, html, forward } from 'reflex'
+import * as Shell from './browser/shell'
+import * as Sidebar from './browser/Sidebar'
+import * as Devtools from './common/devtools'
+import * as Runtime from './common/runtime'
+import * as Unknown from './common/unknown'
+import * as OS from './common/os'
+import * as Keyboard from './common/keyboard'
+import { always, batch } from './common/prelude'
+import { cursor } from './common/cursor'
+import { StyleSheet } from './common/style'
+import { onWindow, on } from '@driver'
+import * as Navigators from './browser/Navigators'
 
 
 /*::
 
-import type {ID} from "./common/prelude"
-import * as Tabs from "./browser/Sidebar/Tabs"
+ import type {ID} from "./common/prelude"
+ import * as Tabs from "./browser/Sidebar/Tabs"
 
-export type Version = string
+ export type Version = string
 
-export type Action =
-  | { type: "NoOp" }
-  | { type: "GoBack" }
-  | { type: "GoForward" }
-  | { type: "Reload" }
-  | { type: "ZoomIn" }
-  | { type: "ZoomOut" }
-  | { type: "ResetZoom" }
-  | { type: "CloseSelected" }
-  | { type: "SelectNext" }
-  | { type: "SelectPrevious" }
-  | { type: "EndSelection" }
-  | { type: "Focus" }
-  | { type: "Blur" }
-  | { type: "OpenNewTab" }
-  | { type: "EditWebView" }
-  | { type: "ShowWebView" }
-  | { type: "ShowTabs" }
-  | { type: "SelectWebView" }
-  | { type: "OpenWebView" }
-  | { type: "AttachSidebar" }
-  | { type: "DetachSidebar" }
-  | { type: "OverlayClicked" }
-  | { type: "SubmitInput" }
-  | { type: "BlurInput" }
-  | { type: "ExitInput" }
-  | { type: "Escape" }
-  | { type: "Unload" }
-  | { type: "ReloadRuntime" }
-  | { type: "PrintSnapshot" }
-  | { type: "PublishSnapshot" }
-  | { type: "Sidebar", action: Sidebar.Action }
-  | { type: "Navigators", navigators: Navigators.Action }
-  | { type: "Shell", source: Shell.Action }
-  | { type: "Devtools", action: Devtools.Action }
-  | { type: "Expand" }
-  | { type: "Expanded" }
-  | { type: "Shrink" }
-  | { type: "Shrinked" }
-  | { type: "ReceiveOpenURLNotification" }
-  | { type: "LiveReload" }
-  | { type: "Reloaded" }
-  | { type: "OpenURL", uri: URI }
-  | { type: "Close" }
-  // @TODO: Do not use any here.
-  | { type: "Modify", modify: ID, action: any }
-  | { type: "Open" }
-  | { type: "Tabs", tabs: Tabs.Action }
+ export type Action =
+ | { type: "NoOp" }
+ | { type: "GoBack" }
+ | { type: "GoForward" }
+ | { type: "Reload" }
+ | { type: "ZoomIn" }
+ | { type: "ZoomOut" }
+ | { type: "ResetZoom" }
+ | { type: "CloseSelected" }
+ | { type: "SelectNext" }
+ | { type: "SelectPrevious" }
+ | { type: "EndSelection" }
+ | { type: "Focus" }
+ | { type: "Blur" }
+ | { type: "OpenNewTab" }
+ | { type: "EditWebView" }
+ | { type: "ShowWebView" }
+ | { type: "ShowTabs" }
+ | { type: "SelectWebView" }
+ | { type: "OpenWebView" }
+ | { type: "AttachSidebar" }
+ | { type: "DetachSidebar" }
+ | { type: "OverlayClicked" }
+ | { type: "SubmitInput" }
+ | { type: "BlurInput" }
+ | { type: "ExitInput" }
+ | { type: "Escape" }
+ | { type: "Unload" }
+ | { type: "ReloadRuntime" }
+ | { type: "PrintSnapshot" }
+ | { type: "PublishSnapshot" }
+ | { type: "Sidebar", action: Sidebar.Action }
+ | { type: "Navigators", navigators: Navigators.Action }
+ | { type: "Shell", source: Shell.Action }
+ | { type: "Devtools", action: Devtools.Action }
+ | { type: "Expand" }
+ | { type: "Expanded" }
+ | { type: "Shrink" }
+ | { type: "Shrinked" }
+ | { type: "ReceiveOpenURLNotification" }
+ | { type: "LiveReload" }
+ | { type: "Reloaded" }
+ | { type: "OpenURL", uri: URI }
+ | { type: "Close" }
+ // @TODO: Do not use any here.
+ | { type: "Modify", modify: ID, action: any }
+ | { type: "Open" }
+ | { type: "Tabs", tabs: Tabs.Action }
 
 
-import type {Address, DOM} from "reflex"
-import type {URI} from "./common/prelude"
-*/
+ import type {Address, DOM} from "reflex"
+ import type {URI} from "./common/prelude"
+ */
 
 export class Model {
   /*::
-  version: Version;
-  shell: Shell.Model;
-  navigators: Navigators.Model;
-  sidebar: Sidebar.Model;
-  devtools: Devtools.Model;
-  */
-  constructor(
-    version: Version=Package.version
-  , shell: Shell.Model
-  , navigators: Navigators.Model
-  , sidebar: Sidebar.Model
-  , devtools: Devtools.Model
-  ) {
+   version: Version;
+   shell: Shell.Model;
+   navigators: Navigators.Model;
+   sidebar: Sidebar.Model;
+   devtools: Devtools.Model;
+   */
+  constructor(version:Version = Package.version, shell:Shell.Model, navigators:Navigators.Model, sidebar:Sidebar.Model,
+              devtools:Devtools.Model)
+  {
     this.version = version
     this.shell = shell
     this.navigators = navigators
@@ -115,218 +103,171 @@ export class Model {
 }
 
 
-const Modify =
-  (id, action) =>
-  ( { type: "Modify"
-    , modify: id
-    , action
-    }
-  )
+const Modify = (id, action) =>( {
+  type: "Modify", modify: id, action
+}
+)
 
-export const init = (): [Model, Effects<Action>] => {
-  const [devtools, devtoolsFx] = Devtools.init({isActive: Config.devtools});
+export const init = ():[Model, Effects<Action>] => {
+  const [devtools, devtoolsFx] = Devtools.init({ isActive: Config.devtools });
   const [shell, shellFx] = Shell.init();
   const [sidebar, sidebarFx] = Sidebar.init();
   const [navigators, navigatorsFx] = Navigators.init();
 
-  const model = new Model
-    ( Package.version
-    , shell
-    , navigators
-    , sidebar
-    , devtools
-    );
+  const model = new Model(Package.version, shell, navigators, sidebar, devtools);
 
-  const fx =
-    Effects.batch
-    ( [ devtoolsFx.map(DevtoolsAction)
-      , shellFx.map(ShellAction)
-      , sidebarFx.map(SidebarAction)
-      , navigatorsFx.map(NavigatorsAction)
-      , Effects
-        .perform(Runtime.receive('mozbrowseropenwindow'))
-        .map(OpenURL)
-      ]
-    );
+  const fx = Effects.batch([
+                             devtoolsFx.map(DevtoolsAction),
+                             shellFx.map(ShellAction),
+                             sidebarFx.map(SidebarAction),
+                             navigatorsFx.map(NavigatorsAction),
+                             Effects
+                                 .perform(Runtime.receive('mozbrowseropenwindow'))
+                                 .map(OpenURL)
+                           ]);
 
   return [model, fx];
 }
 
 const NoOp = always({ type: "NoOp" });
 
-const SidebarAction = action =>
-  ( action.type === "OpenNewTab"
-  ? OpenNewTab
-  : action.type === "Tabs"
-  ? action
-  : action.type === "Attach"
-  ? AttachSidebar
-  : action.type === "Detach"
-  ? DetachSidebar
-  : { type: "Sidebar"
-    , action
+const SidebarAction = action =>( action.type === "OpenNewTab"
+        ? OpenNewTab
+        : action.type === "Tabs"
+        ? action
+        : action.type === "Attach"
+        ? AttachSidebar
+        : action.type === "Detach"
+        ? DetachSidebar
+        : {
+      type: "Sidebar",
+      action
     }
-  );
+);
 
 
-const NavigatorsAction =
-  (action: Navigators.Action): Action => {
-    switch (action.type) {
-      case "ShowTabs":
-        return ShowTabs
-      case "ShowWebView":
-        return ShowWebView
-      case "OpenNewTab":
-        return OpenNewTab
-      default:
-        return { type: 'Navigators', navigators: action }
-    }
-  };
+const NavigatorsAction = (action:Navigators.Action):Action => {
+  switch (action.type) {
+    case "ShowTabs":
+      return ShowTabs
+    case "ShowWebView":
+      return ShowWebView
+    case "OpenNewTab":
+      return OpenNewTab
+    default:
+      return { type: 'Navigators', navigators: action }
+  }
+};
 
 
-const ShellAction = action =>
-  ( action.type === 'Focus'
-  ? { type: 'Focus'
-    , source: action
+const ShellAction = action =>( action.type === 'Focus' ? {
+      type: 'Focus', source: action
+    } : {
+      type: 'Shell', source: action
     }
-  : { type: 'Shell'
-    , source: action
-    }
-  );
+);
 
-const DevtoolsAction = action =>
-  ( { type: 'Devtools'
-    , action
-    }
-  );
+const DevtoolsAction = action =>( {
+  type: 'Devtools', action
+}
+);
 
 
 const updateNavigators = cursor({
-  get: model => model.navigators,
-  set:
-    (model, navigators) =>
-    new Model
-    ( model.version
-    , model.shell
-    , navigators
-    , model.sidebar
-    , model.devtools
-    ),
-  update: Navigators.update,
-  tag: NavigatorsAction
-});
+                                  get: model => model.navigators,
+                                  set: (model,
+                                        navigators) =>new Model(model.version, model.shell, navigators, model.sidebar, model.devtools),
+                                  update: Navigators.update,
+                                  tag: NavigatorsAction
+                                });
 
 const updateShell = cursor({
-  get: model => model.shell,
-  set:
-    (model, shell) =>
-    new Model
-    ( model.version
-    , shell
-    , model.navigators
-    , model.sidebar
-    , model.devtools
-    ),
-  update: Shell.update,
-  tag: ShellAction
-});
+                             get: model => model.shell,
+                             set: (model,
+                                   shell) =>new Model(model.version, shell, model.navigators, model.sidebar, model.devtools),
+                             update: Shell.update,
+                             tag: ShellAction
+                           });
 
 const updateDevtools = cursor({
-  get: model => model.devtools,
-  set:
-    (model, devtools) =>
-    new Model
-    ( model.version
-    , model.shell
-    , model.navigators
-    , model.sidebar
-    , devtools
-    ),
-  update: Devtools.update,
-  tag: DevtoolsAction
-});
+                                get: model => model.devtools,
+                                set: (model,
+                                      devtools) =>new Model(model.version, model.shell, model.navigators, model.sidebar, devtools),
+                                update: Devtools.update,
+                                tag: DevtoolsAction
+                              });
 
 const updateSidebar = cursor({
-  get: model => model.sidebar,
-  set:
-    (model, sidebar) =>
-    new Model
-    ( model.version
-    , model.shell
-    , model.navigators
-    , sidebar
-    , model.devtools
-    ),
-  tag: SidebarAction,
-  update: Sidebar.update
-});
+                               get: model => model.sidebar,
+                               set: (model,
+                                     sidebar) =>new Model(model.version, model.shell, model.navigators, sidebar, model.devtools),
+                               tag: SidebarAction,
+                               update: Sidebar.update
+                             });
 
-const Reloaded: Action =
-  { type: "Reloaded"
-  };
+const Reloaded:Action = {
+  type: "Reloaded"
+};
 
-const Failure = error =>
-  ( { type: "Failure"
-    , error: error
-    }
-  );
+const Failure = error =>( {
+  type: "Failure", error: error
+}
+);
 
 
 // ### Mode changes
 
 
-export const OpenNewTab: Action =
-  { type: 'OpenNewTab'
-  };
+export const OpenNewTab:Action = {
+  type: 'OpenNewTab'
+};
 
-export const EditWebView: Action =
-  { type: 'EditWebView'
-  };
+export const EditWebView:Action = {
+  type: 'EditWebView'
+};
 
-export const ShowWebView: Action =
-  { type: 'ShowWebView'
-  };
+export const ShowWebView:Action = {
+  type: 'ShowWebView'
+};
 
-export const ShowTabs: Action =
-  { type: 'ShowTabs'
-  };
+export const ShowTabs:Action = {
+  type: 'ShowTabs'
+};
 
-export const SelectWebView: Action =
-  { type: 'SelectWebView'
-  };
+export const SelectWebView:Action = {
+  type: 'SelectWebView'
+};
 
 // ### Actions that affect multilpe sub-components
 
-export const OpenWebView: Action =
-  { type: 'OpenWebView'
-  };
+export const OpenWebView:Action = {
+  type: 'OpenWebView'
+};
 
-export const AttachSidebar: Action =
-  { type: "AttachSidebar"
-  , source: Sidebar.Attach
-  };
+export const AttachSidebar:Action = {
+  type: "AttachSidebar", source: Sidebar.Attach
+};
 
-export const DetachSidebar: Action =
-  { type: "DetachSidebar"
-  , source: Sidebar.Detach
-  };
+export const DetachSidebar:Action = {
+  type: "DetachSidebar", source: Sidebar.Detach
+};
 
-export const Escape: Action =
-  { type: 'Escape'
-  };
+export const Escape:Action = {
+  type: 'Escape'
+};
 
 
-export const Unload: Action =
-  { type: 'Unload'
-  };
+export const Unload:Action = {
+  type: 'Unload'
+};
 
-export const ReloadRuntime: Action =
-  { type: 'ReloadRuntime'
-  };
+export const ReloadRuntime:Action = {
+  type: 'ReloadRuntime'
+};
 
-export const BlurInput: Action =
-  { type: 'BlurInput'
-  };
+export const BlurInput:Action = {
+  type: 'BlurInput'
+};
 
 
 // Following Browser actions directly delegate to a `WebViews` module, there for
@@ -343,15 +284,14 @@ export const SelectNext = { type: "SelectNext" };
 export const SelectPrevious = { type: "SelectPrevious" }
 export const EndSelection = { type: "EndSelection" }
 
-const ReceiveOpenURLNotification =
-  { type: "ReceiveOpenURLNotification"
-  };
+const ReceiveOpenURLNotification = {
+  type: "ReceiveOpenURLNotification"
+};
 
-const OpenURL = ({url}) =>
-  ( { type: "OpenURL"
-    , uri: url
-    }
-  );
+const OpenURL = ({ url }) =>( {
+  type: "OpenURL", uri: url
+}
+);
 // Following browser actions directly delegate to one of the existing modules
 // there for we define them by just wrapping actions from that module to avoid
 // additional wiring (which is implementation detail that may change).
@@ -370,372 +310,268 @@ const ShrinkNavigators = NavigatorsAction(Navigators.Shrink);
 const ExpandNavigators = NavigatorsAction(Navigators.Expand);
 const EditNivagatorInput = NavigatorsAction(Navigators.EditInput);
 
-const DockSidebar =
-  { type: "Sidebar"
-  , action: Sidebar.Attach
-  };
+const DockSidebar = {
+  type: "Sidebar", action: Sidebar.Attach
+};
 
-const UndockSidebar =
-  { type: "Sidebar"
-  , action: Sidebar.Detach
-  };
+const UndockSidebar = {
+  type: "Sidebar", action: Sidebar.Detach
+};
 
-export const LiveReload =
-  { type: 'LiveReload'
-  };
+export const LiveReload = {
+  type: 'LiveReload'
+};
 
 const modifier = OS.platform() == 'linux' ? 'alt' : 'accel';
 const decodeKeyDown = Keyboard.bindings({
-  'accel l': always(EditWebView),
-  'accel t': always(OpenNewTab),
-  'accel 0': always(ResetZoom),
-  'accel -': always(ZoomOut),
-  'accel =': always(ZoomIn),
-  'accel shift =': always(ZoomIn),
-  'accel w': always(Close),
-  'accel shift ]': always(SelectNext),
-  'accel shift [': always(SelectPrevious),
-  'control tab': always(SelectNext),
-  'control shift tab': always(SelectPrevious),
-  // 'accel shift backspace':  always(ResetBrowserSession),
-  // 'accel shift s': always(SaveBrowserSession),
-  'accel r': always(Reload),
-  'escape': always(Escape),
-  [`${modifier} left`]: always(GoBack),
-  [`${modifier} right`]: always(GoForward),
+                                          'accel l': always(EditWebView),
+                                          'accel t': always(OpenNewTab),
+                                          'accel 0': always(ResetZoom),
+                                          'accel -': always(ZoomOut),
+                                          'accel =': always(ZoomIn),
+                                          'accel shift =': always(ZoomIn),
+                                          'accel w': always(Close),
+                                          'accel shift ]': always(SelectNext),
+                                          'accel shift [': always(SelectPrevious),
+                                          'control tab': always(SelectNext),
+                                          'control shift tab': always(
+                                              SelectPrevious), // 'accel shift backspace':  always(ResetBrowserSession),
+                                          // 'accel shift s': always(SaveBrowserSession),
+                                          'accel r': always(Reload),
+                                          'escape': always(Escape),
+                                          [`${modifier} left`]: always(GoBack),
+                                          [`${modifier} right`]: always(GoForward),
 
-  // TODO: `meta alt i` generates `accel alt i` on OSX we need to look
-  // more closely into this but so declaring both shortcuts should do it.
-  'accel alt i': always(ToggleDevtools),
-  'accel alt ˆ': always(ToggleDevtools),
-  'F12': always(ToggleDevtools),
-  'F5': always(ReloadRuntime),
-  'meta control r': always(ReloadRuntime),
-  'meta alt 3': always(PrintSnapshot),
-  'meta alt 4': always(PublishSnapshot)
-});
+                                          // TODO: `meta alt i` generates `accel alt i` on OSX we need to look
+                                          // more closely into this but so declaring both shortcuts should do it.
+                                          'accel alt i': always(ToggleDevtools),
+                                          'accel alt ˆ': always(ToggleDevtools),
+                                          'F12': always(ToggleDevtools),
+                                          'F5': always(ReloadRuntime),
+                                          'meta control r': always(ReloadRuntime),
+                                          'meta alt 3': always(PrintSnapshot),
+                                          'meta alt 4': always(PublishSnapshot)
+                                        });
 
 const decodeKeyUp = Keyboard.bindings({
-  'control': always(EndSelection),
-  'accel': always(EndSelection)
-});
+                                        'control': always(EndSelection), 'accel': always(EndSelection)
+                                      });
 
-const showWebView = model =>
-  batch
-  ( update
-  , model
-  , [ CollapseSidebar
-    , FocusNavigators
-    ]
-  );
+const showWebView = model =>batch(update, model, [
+  CollapseSidebar, FocusNavigators
+]);
 
-const openNewTab =
-  model => {
-    const [sidebar, $sidebar] =
+const openNewTab = model => {
+  const [sidebar, $sidebar] =
       Sidebar.update(model.sidebar, Sidebar.Collapse);
 
-    const [navigators, $navigators] =
+  const [navigators, $navigators] =
       Navigators.update(model.navigators, Navigators.OpenNewTab);
 
-    const next = new Model
-      ( model.version
-      , model.shell
-      , navigators
-      , sidebar
-      , model.devtools
-      )
+  const next = new Model(model.version, model.shell, navigators, sidebar, model.devtools)
 
-    const fx = Effects.batch
-      ( [ $sidebar.map(SidebarAction)
-        , $navigators.map(NavigatorsAction)
-        ]
-      )
+  const fx = Effects.batch([
+                             $sidebar.map(SidebarAction), $navigators.map(NavigatorsAction)
+                           ])
 
-    return [next, fx]
-  }
+  return [next, fx]
+}
 
 
-const editWebView = model =>
-  batch
-  ( update
-  , model
-  , [ /*ShowInput
-    , OpenAssistant
-    , */CollapseSidebar
-    // , ShowOverlay
-    // , FoldWebViews
-    /*, EnterInputSelection(WebViews.getActiveURI(model.webViews, ''))*/
-    , FocusNavigators
-    , EditNivagatorInput
-    ]
-  );
+const editWebView = model =>batch(update, model, [
+  /*ShowInput
+   , OpenAssistant
+   , */CollapseSidebar
+  // , ShowOverlay
+  // , FoldWebViews
+  /*, EnterInputSelection(WebViews.getActiveURI(model.webViews, ''))*/, FocusNavigators, EditNivagatorInput
+]);
 
-const showTabs = model =>
-  batch
-  ( update
-  , model
-  , [ ExpandSidebar
-    , ExposeNavigators
-    ]
-  );
+const showTabs = model =>batch(update, model, [
+  ExpandSidebar, ExposeNavigators
+]);
 
-const toggleTabs =
-  model =>
-  ( model.sidebar.isExpanded
-  ? showWebView(model)
-  : showTabs(model)
-  );
+const toggleTabs = model =>( model.sidebar.isExpanded ? showWebView(model) : showTabs(model)
+);
 
 
-const goBack =
-  model =>
-  updateNavigators
-  ( model
-  , Navigators.GoBack
-  )
+const goBack = model =>updateNavigators(model, Navigators.GoBack)
 
-const goForward =
-  model =>
-  updateNavigators
-  ( model
-  , Navigators.GoForward
-  )
+const goForward = model =>updateNavigators(model, Navigators.GoForward)
 
 
-const reload =
-  model =>
-  updateNavigators
-  ( model
-  , Navigators.Reload
-  )
+const reload = model =>updateNavigators(model, Navigators.Reload)
 
-const zoomIn =
-  model =>
-  updateNavigators
-  ( model
-  , Navigators.ZoomIn
-  )
+const zoomIn = model =>updateNavigators(model, Navigators.ZoomIn)
 
-const zoomOut =
-  model =>
-  updateNavigators
-  ( model
-  , Navigators.ZoomOut
-  )
+const zoomOut = model =>updateNavigators(model, Navigators.ZoomOut)
 
 
-const resetZoom =
-  model =>
-  updateNavigators
-  ( model
-  , Navigators.ResetZoom
-  )
+const resetZoom = model =>updateNavigators(model, Navigators.ResetZoom)
 
-const close =
-  model =>
-  updateNavigators
-  ( model
-  , Navigators.Close
-  )
+const close = model =>updateNavigators(model, Navigators.Close)
 
-const SelectNextNavigator =
-  { type: "Navigators"
-  , navigators: Navigators.SelectNext
-  }
+const SelectNextNavigator = {
+  type: "Navigators", navigators: Navigators.SelectNext
+}
 
-const selectNext =
-  model =>
-  batch
-  ( update
-  , model
-  , [ ExpandSidebar
-    , ExposeNavigators
-    , SelectNextNavigator
-    ]
-  )
+const selectNext = model =>batch(update, model, [
+  ExpandSidebar, ExposeNavigators, SelectNextNavigator
+])
 
-const SelectPreviousNavigator =
-  { type: "Navigators"
-  , navigators: Navigators.SelectPrevious
-  }
+const SelectPreviousNavigator = {
+  type: "Navigators", navigators: Navigators.SelectPrevious
+}
 
-const selectPrevious =
-  model =>
-  batch
-  ( update
-  , model
-  , [ ExpandSidebar
-    , ExposeNavigators
-    , SelectPreviousNavigator
-    ]
-  )
+const selectPrevious = model =>batch(update, model, [
+  ExpandSidebar, ExposeNavigators, SelectPreviousNavigator
+])
 
 const endSelection = showWebView
 
-const reciveOpenURLNotification = model =>
-  [ model
-  , Effects
-    .perform(Runtime.receive('mozbrowseropenwindow'))
-    .map(OpenURL)
-  ];
+const reciveOpenURLNotification = model =>[
+  model, Effects
+      .perform(Runtime.receive('mozbrowseropenwindow'))
+      .map(OpenURL)
+];
 
-const attachSidebar = model =>
-  batch
-  ( update
-  , model
-  , [ DockSidebar
-    , ShrinkNavigators
-    ]
-  );
+const attachSidebar = model =>batch(update, model, [
+  DockSidebar, ShrinkNavigators
+]);
 
-const detachSidebar = model =>
-  batch
-  ( update
-  , model
-  , [ UndockSidebar
-    , ExpandNavigators
-    ]
-  );
+const detachSidebar = model =>batch(update, model, [
+  UndockSidebar, ExpandNavigators
+]);
 
-const reloadRuntime = model =>
-  [ model
-  , Effects
-    .perform(Runtime.reload)
-    .map(always(Reloaded))
-  ];
+const reloadRuntime = model =>[
+  model, Effects
+      .perform(Runtime.reload)
+      .map(always(Reloaded))
+];
 
 
-
-
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] => {
-    switch (action.type) {
-      case 'GoBack':
-        return goBack(model);
-      case 'GoForward':
-        return goForward(model);
-      case 'Reload':
-        return reload(model);
-      case 'ZoomIn':
-        return zoomIn(model);
-      case 'ZoomOut':
-        return zoomOut(model);
-      case 'ResetZoom':
-        return resetZoom(model);
-      case 'Close':
-        return close(model);
-      case 'OpenNewTab':
-        return openNewTab(model);
-      case 'EditWebView':
-        return editWebView(model);
-      case 'ShowWebView':
-        return showWebView(model);
-      case 'ShowTabs':
-        return showTabs(model);
-      case 'Escape':
-        return toggleTabs(model);
-      case 'AttachSidebar':
-        return attachSidebar(model);
-      case 'DetachSidebar':
-        return detachSidebar(model);
-      case 'ReloadRuntime':
-        return reloadRuntime(model);
-      case 'SelectNext':
-        return selectNext(model);
-      case 'SelectPrevious':
-        return selectPrevious(model);
-      case 'EndSelection':
-        return endSelection(model);
-      case 'Shell':
-        return updateShell(model, action.source);
-      case 'Focus':
-        return updateShell(model, Shell.Focus);
-      case 'Devtools':
-        return updateDevtools(model, action.action);
-      case 'Sidebar':
-        return updateSidebar(model, action.action);
-      case 'Tabs':
-        return updateNavigators(model, action);
-      case 'Navigators':
-        return updateNavigators(model, action.navigators);
-      case 'Failure':
-        return [
-           model
-        , Effects
-          .perform(Unknown.error(action.error))
-          .map(NoOp)
-        ];
+export const update = (model:Model, action:Action):[Model, Effects<Action>] => {
+  switch (action.type) {
+    case 'GoBack':
+      return goBack(model);
+    case 'GoForward':
+      return goForward(model);
+    case 'Reload':
+      return reload(model);
+    case 'ZoomIn':
+      return zoomIn(model);
+    case 'ZoomOut':
+      return zoomOut(model);
+    case 'ResetZoom':
+      return resetZoom(model);
+    case 'Close':
+      return close(model);
+    case 'OpenNewTab':
+      return openNewTab(model);
+    case 'EditWebView':
+      return editWebView(model);
+    case 'ShowWebView':
+      return showWebView(model);
+    case 'ShowTabs':
+      return showTabs(model);
+    case 'Escape':
+      return toggleTabs(model);
+    case 'AttachSidebar':
+      return attachSidebar(model);
+    case 'DetachSidebar':
+      return detachSidebar(model);
+    case 'ReloadRuntime':
+      return reloadRuntime(model);
+    case 'SelectNext':
+      return selectNext(model);
+    case 'SelectPrevious':
+      return selectPrevious(model);
+    case 'EndSelection':
+      return endSelection(model);
+    case 'Shell':
+      return updateShell(model, action.source);
+    case 'Focus':
+      return updateShell(model, Shell.Focus);
+    case 'Devtools':
+      return updateDevtools(model, action.action);
+    case 'Sidebar':
+      return updateSidebar(model, action.action);
+    case 'Tabs':
+      return updateNavigators(model, action);
+    case 'Navigators':
+      return updateNavigators(model, action.navigators);
+    case 'Failure':
+      return [
+        model, Effects
+            .perform(Unknown.error(action.error))
+            .map(NoOp)
+      ];
 
       // Ignore some actions.
-      case 'Reloaded':
-        return [ model, Effects.none ]
-      case 'PrintSnapshot':
-        return [model, Effects.none];
-      case 'UploadSnapshot':
-        return [model, Effects.none];
+    case 'Reloaded':
+      return [model, Effects.none]
+    case 'PrintSnapshot':
+      return [model, Effects.none];
+    case 'UploadSnapshot':
+      return [model, Effects.none];
       // TODO: Delegate to modules that need to do cleanup.
-      case 'LiveReload':
-        return [model, Effects.none];
+    case 'LiveReload':
+      return [model, Effects.none];
 
-      default:
-        return Unknown.update(model, action);
-    }
-  };
+    default:
+      return Unknown.update(model, action);
+  }
+};
 
 const styleSheet = StyleSheet.create({
-  root: {
-    background: '#171814',
-    perspective: '1000px',
-    // These styles prevent scrolling with the arrow keys in the root window
-    // when elements move outside of viewport.
-    width: '100vw',
-    height: '100vh',
-    overflow: 'hidden',
-    position: 'absolute',
-    MozWindowDragging: 'drag',
-    WebkitAppRegion: 'drag'
-  },
-  content: {
-    position: 'absolute',
-    perspective: '1000px',
-    height: '100vh',
-    width: '100vw'
+                                       root: {
+                                         background: '#171814',
+                                         perspective: '1000px', // These styles prevent scrolling with the arrow keys
+                                                                // in the root window
+                                         // when elements move outside of viewport.
+                                         width: '100vw',
+                                         height: '100vh',
+                                         overflow: 'hidden',
+                                         position: 'absolute',
+                                         MozWindowDragging: 'drag',
+                                         WebkitAppRegion: 'drag'
+                                       }, content: {
+    position: 'absolute', perspective: '1000px', height: '100vh', width: '100vw'
   }
-});
+                                     });
 
-export const view =
-  (model: Model, address: Address<Action>): DOM =>
-  html.main
-  ( { className: 'root'
-    , style: styleSheet.root
-    , tabIndex: 1
-    , onKeyDown: onWindow(address, decodeKeyDown)
-    , onKeyUp: onWindow(address, decodeKeyUp)
-    , onBlur: onWindow(address, always(Blur))
-    , onFocus: onWindow(address, always(Focus))
-    , onUnload: onWindow(address, always(Unload))
-    , onServoMouseForceDown: on(address, always(ShowTabs))
-    , onWebkitMouseForceDown: on(address, always(ShowTabs))
-    }
-  , [ Navigators.view
-      ( model.navigators
-      , forward(address, NavigatorsAction)
-      )
+export const view = (model:Model, address:Address<Action>):DOM =>html.main({
+                                                                             className: 'root',
+                                                                             style: styleSheet.root,
+                                                                             tabIndex: 1,
+                                                                             onKeyDown: onWindow(address,
+                                                                                                 decodeKeyDown),
+                                                                             onKeyUp: onWindow(address, decodeKeyUp),
+                                                                             onBlur: onWindow(address, always(Blur)),
+                                                                             onFocus: onWindow(address, always(Focus)),
+                                                                             onUnload: onWindow(address,
+                                                                                                always(Unload)),
+                                                                             onServoMouseForceDown: on(address, always(
+                                                                                 ShowTabs)),
+                                                                             onWebkitMouseForceDown: on(address, always(
+                                                                                 ShowTabs))
+                                                                           }, [
+                                                                             Navigators.view(model.navigators,
+                                                                                             forward(address,
+                                                                                                     NavigatorsAction))
 
-    , Sidebar.view
-      ( model.sidebar
-      , model.navigators.deck
-      , forward(address, SidebarAction)
-      )
+                                                                             ,
+                                                                             Sidebar.view(model.sidebar,
+                                                                                          model.navigators.deck,
+                                                                                          forward(address,
+                                                                                                  SidebarAction))
 
-    , Shell.view
-      ( model.shell
-      , forward(address, ShellAction)
-      )
+                                                                             ,
+                                                                             Shell.view(model.shell,
+                                                                                        forward(address, ShellAction))
 
-    , Devtools.view
-      ( model.devtools
-      , forward(address, DevtoolsAction)
-      )
-    ]
-  );
+                                                                             ,
+                                                                             Devtools.view(model.devtools,
+                                                                                           forward(address,
+                                                                                                   DevtoolsAction))
+                                                                           ]);

--- a/src/browser/Navigators.js
+++ b/src/browser/Navigators.js
@@ -1,44 +1,44 @@
 /* @flow */
 
-import * as Deck from "../common/Deck"
-import * as Animation from "../common/Animation"
-import * as Unknown from "../common/unknown"
-import * as Display from "./Navigators/Display"
-import {Effects, html, forward, thunk} from "reflex"
-import {cursor} from "../common/cursor"
-import {always} from "../common/prelude"
-import * as Style from "../common/style"
-import * as Easing from "eased"
-import * as Overlay from "./Navigators/Overlay"
-import * as Navigator from "./Navigators/Navigator"
-import * as URI from "../common/url-helper";
-import * as Tabs from "./Sidebar/Tabs";
+import * as Deck from '../common/Deck'
+import * as Animation from '../common/Animation'
+import * as Unknown from '../common/unknown'
+import * as Display from './Navigators/Display'
+import { Effects, html, forward, thunk } from 'reflex'
+import { cursor } from '../common/cursor'
+import { always } from '../common/prelude'
+import * as Style from '../common/style'
+import * as Easing from 'eased'
+import * as Overlay from './Navigators/Overlay'
+import * as Navigator from './Navigators/Navigator'
+import * as URI from '../common/url-helper'
+import * as Tabs from './Sidebar/Tabs'
 
 /*::
-import type {Address, DOM} from "reflex"
+ import type {Address, DOM} from "reflex"
 
-export type Action =
-  | { type: "Expose" }
-  | { type: "Focus" }
-  | { type: "Shrink" }
-  | { type: "Expand" }
-  | { type: "ShowTabs" }
-  | { type: "ShowWebView" }
-  | { type: "GoBack" }
-  | { type: "GoForward" }
-  | { type: "Reload" }
-  | { type: "ZoomIn" }
-  | { type: "ZoomOut" }
-  | { type: "ResetZoom" }
-  | { type: "Close" }
-  | { type: "EditInput" }
-  | { type: "OpenNewTab" }
-  | { type: "SelectNext" }
-  | { type: "SelectPrevious" }
-  | { type: "Animation", animation: Animation.Action }
-  | { type: "Tabs", tabs: Tabs.Action }
-  | { type: "Deck", deck: Deck.Action<Navigator.Action, Navigator.Flags> }
-*/
+ export type Action =
+ | { type: "Expose" }
+ | { type: "Focus" }
+ | { type: "Shrink" }
+ | { type: "Expand" }
+ | { type: "ShowTabs" }
+ | { type: "ShowWebView" }
+ | { type: "GoBack" }
+ | { type: "GoForward" }
+ | { type: "Reload" }
+ | { type: "ZoomIn" }
+ | { type: "ZoomOut" }
+ | { type: "ResetZoom" }
+ | { type: "Close" }
+ | { type: "EditInput" }
+ | { type: "OpenNewTab" }
+ | { type: "SelectNext" }
+ | { type: "SelectPrevious" }
+ | { type: "Animation", animation: Animation.Action }
+ | { type: "Tabs", tabs: Tabs.Action }
+ | { type: "Deck", deck: Deck.Action<Navigator.Action, Navigator.Flags> }
+ */
 
 export const Expose = { type: "Expose" }
 export const Focus = { type: "Focus" }
@@ -61,17 +61,12 @@ export const Close = { type: "Close" }
 
 export class Model {
   /*::
-  zoom: boolean;
-  shrink: boolean;
-  deck: Deck.Model;
-  animation: Animation.Model<Display.Model>;
-  */
-  constructor(
-    zoom: boolean
-  , shrink: boolean
-  , deck: Deck.Model
-  , animation: Animation.Model<Display.Model>
-  ) {
+   zoom: boolean;
+   shrink: boolean;
+   deck: Deck.Model;
+   animation: Animation.Model<Display.Model>;
+   */
+  constructor(zoom:boolean, shrink:boolean, deck:Deck.Model, animation:Animation.Model<Display.Model>) {
     this.zoom = zoom;
     this.shrink = shrink;
     this.deck = deck;
@@ -79,407 +74,238 @@ export class Model {
   }
 }
 
-const nofx =
-  model =>
-  [ model
-  , Effects.none
-  ]
+const nofx = model =>[
+  model, Effects.none
+]
 
-const Card =
-  { init: Navigator.init
-  , update: Navigator.update
-  , close: Navigator.close
-  , select: Navigator.select
-  , deselect: Navigator.deselect
+const Card = {
+  init: Navigator.init,
+  update: Navigator.update,
+  close: Navigator.close,
+  select: Navigator.select,
+  deselect: Navigator.deselect
+}
+
+
+const tagDeck = (action:Deck.Action<Navigator.Action, Navigator.Flags>):Action => {
+  switch (action.type) {
+    case "Modify":
+      switch (action.modify.type) {
+        case "ShowTabs":
+          return ShowTabs;
+        case "OpenNewTab":
+          return OpenNewTab;
+        case "Open":
+          return {
+            type: "Deck", deck: action.modify
+          }
+        case "Select":
+          return {
+            type: "Deck", deck: {
+              type: "Select", id: action.id
+            }
+          }
+        case "Closed":
+          return {
+            type: "Deck", deck: {
+              type: "Remove", id: action.id
+            }
+          }
+      }
+    default:
+      return {
+        type: "Deck", deck: action
+      };
   }
+}
 
-
-const tagDeck =
-  (action: Deck.Action<Navigator.Action, Navigator.Flags>): Action => {
-    switch (action.type) {
-      case "Modify":
-        switch (action.modify.type) {
-          case "ShowTabs":
-            return ShowTabs;
-          case "OpenNewTab":
-            return OpenNewTab;
-          case "Open":
-            return {
-              type: "Deck"
-            , deck: action.modify
-            }
-          case "Select":
-            return {
-              type: "Deck"
-            , deck:
-              { type: "Select"
-              , id: action.id
-              }
-            }
-          case "Closed":
-            return {
-              type: "Deck"
-            , deck:
-              { type: "Remove"
-              , id: action.id
-              }
-            }
-        }
-      default:
-        return {
-          type: "Deck"
-        , deck: action
-        };
-    }
-  }
-
-const tagAnimation =
-  action =>
-  ( { type: "Animation"
-    , animation: action
-    }
-  );
+const tagAnimation = action =>( {
+  type: "Animation", animation: action
+}
+);
 
 const tagOverlay = always(ShowWebView);
 
 
-export const init =
-  ( zoom: boolean=true
-  , shrink: boolean=false
-  ): [Model, Effects<Action>] => {
-    const flags =
-      { input:
-        { value: ''
-        , isVisible: true
-        , isFocused: true
-        }
+export const init = (zoom:boolean = true, shrink:boolean = false):[Model, Effects<Action>] => {
+  const flags = {
+    input: {
+      value: '', isVisible: true, isFocused: true
+    }
 
-        , output:
-        { uri: URI.read('about:newtab')
-        , disposition: 'default'
-        , name: 'about:newtab'
-        , features: ''
-        , ref: null
-        , guestInstanceId: null
-        }
-      , assistant: true
-      , overlay: true
-      , isPinned: true
-      , isInputEmbedded: true
-      }
-
-    const [deck, $deck] = Deck.init();
-    const [deck2, $deck2] = Deck.open
-      ( Card
-      , deck
-      , flags
-      )
-
-    const display =
-      ( shrink
-      ? Display.shrinked
-      : zoom
-      ? Display.normal
-      : Display.expose
-      )
-
-    const [animation, $animation] = Animation.init(display);
-    const model = new Model(zoom, shrink, deck2, animation);
-    const fx = Effects.batch
-      ( [ $deck.map(tagDeck)
-        , $deck2.map(tagDeck)
-        , $animation.map(tagAnimation)
-        ]
-      )
-    return [model, fx]
+    , output: {
+      uri: URI.read('about:newtab'),
+      disposition: 'default',
+      name: 'about:newtab',
+      features: '',
+      ref: null,
+      guestInstanceId: null
+    }, assistant: true, overlay: true, isPinned: true, isInputEmbedded: true
   }
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] => {
-    switch (action.type) {
-      case "Animation":
-        return updateAnimation(model, action.animation);
-      case "Deck":
-        return updateDeck(model, action.deck);
-      case "SelectNext":
-        return selectNext(model);
-      case "SelectPrevious":
-        return selectPrevious(model);
-      case "Close":
-        return close(model);
-      case "ShowTabs":
-        return nofx(model);
-      case "OpenNewTab":
-        return openNewTab(model);
-      case "GoBack":
-        return updateSelected(model, Navigator.GoBack);
-      case "GoForward":
-        return updateSelected(model, Navigator.GoForward);
-      case "Reload":
-        return updateSelected(model, Navigator.Reload);
-      case "ZoomIn":
-        return updateSelected(model, Navigator.ZoomIn);
-      case "ZoomOut":
-        return updateSelected(model, Navigator.ZoomOut);
-      case "ResetZoom":
-        return updateSelected(model, Navigator.ResetZoom);
-      case "EditInput":
-        return updateSelected(model, Navigator.EditInput);
-      case "Focus":
-        return focus(model);
-      case "Expose":
-        return expose(model);
-      case "Shrink":
-        return shrink(model);
-      case "Expand":
-        return expand(model);
-      case "Tabs":
-        return updateTabs(model, action.tabs);
-      default:
-        return Unknown.update(model, action);
-    }
+  const [deck, $deck] = Deck.init();
+  const [deck2, $deck2] = Deck.open(Card, deck, flags)
+
+  const display = ( shrink ? Display.shrinked : zoom ? Display.normal : Display.expose
+  )
+
+  const [animation, $animation] = Animation.init(display);
+  const model = new Model(zoom, shrink, deck2, animation);
+  const fx = Effects.batch([
+                             $deck.map(tagDeck), $deck2.map(tagDeck), $animation.map(tagAnimation)
+                           ])
+  return [model, fx]
+}
+
+export const update = (model:Model, action:Action):[Model, Effects<Action>] => {
+  switch (action.type) {
+    case "Animation":
+      return updateAnimation(model, action.animation);
+    case "Deck":
+      return updateDeck(model, action.deck);
+    case "SelectNext":
+      return selectNext(model);
+    case "SelectPrevious":
+      return selectPrevious(model);
+    case "Close":
+      return close(model);
+    case "ShowTabs":
+      return nofx(model);
+    case "OpenNewTab":
+      return openNewTab(model);
+    case "GoBack":
+      return updateSelected(model, Navigator.GoBack);
+    case "GoForward":
+      return updateSelected(model, Navigator.GoForward);
+    case "Reload":
+      return updateSelected(model, Navigator.Reload);
+    case "ZoomIn":
+      return updateSelected(model, Navigator.ZoomIn);
+    case "ZoomOut":
+      return updateSelected(model, Navigator.ZoomOut);
+    case "ResetZoom":
+      return updateSelected(model, Navigator.ResetZoom);
+    case "EditInput":
+      return updateSelected(model, Navigator.EditInput);
+    case "Focus":
+      return focus(model);
+    case "Expose":
+      return expose(model);
+    case "Shrink":
+      return shrink(model);
+    case "Expand":
+      return expand(model);
+    case "Tabs":
+      return updateTabs(model, action.tabs);
+    default:
+      return Unknown.update(model, action);
   }
+}
 
-const animate =
-  (animation, action) =>
-  Animation.updateWith
-  ( Easing.easeOutCubic
-  , Display.interpolate
-  , animation
-  , action
-  )
+const animate = (animation, action) =>Animation.updateWith(Easing.easeOutCubic, Display.interpolate, animation, action)
 
-const updateAnimation = cursor
-  ( { get: model => model.animation
-    , set:
-      (model, animation) =>
-      new Model
-      ( model.zoom
-      , model.shrink
-      , model.deck
-      , animation
-      )
-    , tag: tagAnimation
-    , update: animate
-    }
-  )
+const updateAnimation = cursor({
+                                 get: model => model.animation,
+                                 set: (model, animation) =>new Model(model.zoom, model.shrink, model.deck, animation),
+                                 tag: tagAnimation,
+                                 update: animate
+                               })
 
-const openNewTab =
-  model =>
-  updateDeck
-  ( model
-  , SelectNewTab
-  )
+const openNewTab = model =>updateDeck(model, SelectNewTab)
 
-const updateDeck = cursor
-  ( { get: model => model.deck
-    , set:
-      (model, deck) =>
-      new Model
-      ( model.zoom
-      , model.shrink
-      , deck
-      , model.animation
-      )
-    , tag: tagDeck
-    , update:
-        (model, action) =>
-        Deck.update(Card, model, action)
-    }
-  )
+const updateDeck = cursor({
+                            get: model => model.deck,
+                            set: (model, deck) =>new Model(model.zoom, model.shrink, deck, model.animation),
+                            tag: tagDeck,
+                            update: (model, action) =>Deck.update(Card, model, action)
+                          })
 
-const updateTabs =
-  (model, action) =>
-  // Flow inference seems to fail here, so we just make it believe
-  // that we restructured action so it will suceed inferring.
-  (/*::
-    action.type === "Modify"
-  ? updateDeck
-    ( model
-    , { type: "Modify"
-      , id: action.id
-      , modify:
-        { type: "Tab"
-        , tab: action.modify.tab
-        }
-      }
+const updateTabs = (model, action) =>// Flow inference seems to fail here, so we just make it believe
+    // that we restructured action so it will suceed inferring.
+    (/*::
+         action.type === "Modify"
+         ? updateDeck
+         ( model
+         , { type: "Modify"
+         , id: action.id
+         , modify:
+         { type: "Tab"
+         , tab: action.modify.tab
+         }
+         }
+         )
+         :*/updateDeck(model, action)
     )
-  :*/updateDeck(model, action)
-  )
 
-const selectNext =
-  model =>
-  updateDeck(model, SelectNext)
+const selectNext = model =>updateDeck(model, SelectNext)
 
-const selectPrevious =
-  model =>
-  updateDeck(model, SelectPrevious)
+const selectPrevious = model =>updateDeck(model, SelectPrevious)
 
-const updateSelected =
-  (model, action) =>
-  ( model.deck.selected == null
-  ? nofx(model)
-  : updateDeck
-    ( model
-    , { type: "Modify"
-      , id: model.deck.selected
-      , modify: action
-      }
-    )
-  )
+const updateSelected = (model, action) =>( model.deck.selected == null ? nofx(model) : updateDeck(model, {
+      type: "Modify", id: model.deck.selected, modify: action
+    })
+)
 
-const close =
-  (model, action) =>
-  ( model.deck.selected == null
-  ? nofx(model)
-  : updateDeck
-    ( model
-    , { type: "Close"
-      , id: model.deck.selected
-      }
-    )
-  )
+const close = (model, action) =>( model.deck.selected == null ? nofx(model) : updateDeck(model, {
+      type: "Close", id: model.deck.selected
+    })
+)
 
-const focus =
-  ( model ) =>
-  ( model.zoom
-  ? nofx(model)
-  : startAnimation
-    ( true
-    , model.shrink
-    , model.deck
-    , Animation.transition
-      ( model.animation
-      , ( model.shrink
-        ? Display.shrinked
-        : Display.normal
-        )
-      , 200
-      )
-    )
-  )
+const focus = (model) =>( model.zoom ? nofx(model) : startAnimation(true, model.shrink, model.deck,
+                                                                    Animation.transition(model.animation, ( model.shrink
+                                                                            ? Display.shrinked
+                                                                            : Display.normal
+                                                                    ), 200))
+)
 
-const expose =
-  ( model ) =>
-  ( model.zoom
-  ? startAnimation
-    ( false
-    , model.shrink
-    , model.deck
-    , Animation.transition
-      ( model.animation
-      , ( model.shrink
-        ? Display.exposeShrinked
-        : Display.expose
-        )
-      , 500
-      )
-    )
-  : nofx(model)
-  )
+const expose = (model) =>( model.zoom ? startAnimation(false, model.shrink, model.deck,
+                                                       Animation.transition(model.animation, ( model.shrink
+                                                               ? Display.exposeShrinked
+                                                               : Display.expose
+                                                       ), 500)) : nofx(model)
+)
 
-const shrink =
-  ( model ) =>
-  ( model.shrink
-  ? nofx(model)
-  : startAnimation
-    ( true
-    , true
-    , model.deck
-    , Animation.transition
-      ( model.animation
-      , Display.shrinked
-      , 200
-      )
-    )
-  )
+const shrink = (model) =>( model.shrink ? nofx(model) : startAnimation(true, true, model.deck,
+                                                                       Animation.transition(model.animation,
+                                                                                            Display.shrinked, 200))
+)
 
-const expand =
-  ( model ) =>
-  ( !model.shrink
-  ? nofx(model)
-  : model.zoom
-  ? startAnimation
-    ( model.zoom
-    , false
-    , model.deck
-    , Animation.transition
-      ( model.animation
-      , Display.normal
-      , 200
-      )
-    )
-  : nofx
-    ( new Model
-      ( model.zoom
-      , false
-      , model.deck
-      , model.animation
-      )
-    )
-  )
+const expand = (model) =>( !model.shrink ? nofx(model) : model.zoom ? startAnimation(model.zoom, false, model.deck,
+                                                                                     Animation.transition(
+                                                                                         model.animation,
+                                                                                         Display.normal, 200)) : nofx(
+        new Model(model.zoom, false, model.deck, model.animation))
+)
 
-const startAnimation =
-  (zoom, shrink, deck, [animation, fx]) =>
-  [ new Model
-    ( zoom
-    , shrink
-    , deck
-    , animation
-    )
-  , fx.map(tagAnimation)
-  ]
+const startAnimation = (zoom, shrink, deck, [animation, fx]) =>[
+  new Model(zoom, shrink, deck, animation), fx.map(tagAnimation)
+]
 
 
-export const render =
-  ( model: Model
-  , address: Address<Action>
-  ): DOM =>
-  html.div
-  ( { className: 'navigator-deck'
-    , style:
-        Style.mix
-        ( styleSheet.base
-        , { borderRight: `solid transparent ${model.animation.state.rightOffset}px`
-          , transform: `translate3d(0, 0, ${model.animation.state.depth}px)`
-          }
-        )
-    }
-  , [ Overlay.view
-      ( model.zoom === false
-      , forward(address, tagOverlay)
-      )
-    ].concat
-    ( Deck.renderCards
-      ( Navigator.render
-      , model.deck
-      , forward(address, tagDeck)
-      )
-    )
-  )
+export const render = (model:Model, address:Address<Action>):DOM =>html.div({
+                                                                              className: 'navigator-deck',
+                                                                              style: Style.mix(styleSheet.base, {
+                                                                                borderRight: `solid transparent ${model.animation.state.rightOffset}px`,
+                                                                                transform: `translate3d(0, 0, ${model.animation.state.depth}px)`
+                                                                              })
+                                                                            }, [
+                                                                              Overlay.view(model.zoom === false,
+                                                                                           forward(address, tagOverlay))
+                                                                            ].concat(
+    Deck.renderCards(Navigator.render, model.deck, forward(address, tagDeck))))
 
-export const view =
-  ( model: Model
-  , address: Address<Action>
-  ): DOM =>
-  thunk
-  ( 'Browser/NavigatorDeck'
-  , render
-  , model
-  , address
-  )
+export const view = (model:Model, address:Address<Action>):DOM =>thunk('Browser/NavigatorDeck', render, model, address)
 
-const styleSheet = Style.createSheet
-  ( { base:
-      { position: 'absolute'
-      , height: '100%'
-      , width: '100%'
-      , willChange: 'transform, border-right'
-      , top: 0
-      , left: 0
-      , overflow: 'hidden'
-      , transformOrigin: 'left center'
-      , boxSizing: 'border-box'
-      }
-    }
-  )
+const styleSheet = Style.createSheet({
+                                       base: {
+                                         position: 'absolute',
+                                         height: '100%',
+                                         width: '100%',
+                                         willChange: 'transform, border-right',
+                                         top: 0,
+                                         left: 0,
+                                         overflow: 'hidden',
+                                         transformOrigin: 'left center',
+                                         boxSizing: 'border-box'
+                                       }
+                                     })

--- a/src/browser/Navigators.js
+++ b/src/browser/Navigators.js
@@ -67,10 +67,10 @@ export class Model {
   animation: Animation.Model<Display.Model>;
   */
   constructor(
-    zoom/*:boolean*/
-  , shrink/*:boolean*/
-  , deck/*:Deck.Model*/
-  , animation/*:Animation.Model<Display.Model>*/
+    zoom: boolean
+  , shrink: boolean
+  , deck: Deck.Model
+  , animation: Animation.Model<Display.Model>
   ) {
     this.zoom = zoom;
     this.shrink = shrink;
@@ -95,7 +95,7 @@ const Card =
 
 
 const tagDeck =
-  (action/*:Deck.Action<Navigator.Action, Navigator.Flags>*/)/*:Action*/ => {
+  (action: Deck.Action<Navigator.Action, Navigator.Flags>): Action => {
     switch (action.type) {
       case "Modify":
         switch (action.modify.type) {
@@ -144,9 +144,9 @@ const tagOverlay = always(ShowWebView);
 
 
 export const init =
-  ( zoom/*:boolean*/=true
-  , shrink/*:boolean*/=false
-  )/*:[Model, Effects<Action>]*/ => {
+  ( zoom: boolean=true
+  , shrink: boolean=false
+  ): [Model, Effects<Action>] => {
     const flags =
       { input:
         { value: ''
@@ -195,7 +195,7 @@ export const init =
   }
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ => {
+  (model: Model, action: Action): [Model, Effects<Action>] => {
     switch (action.type) {
       case "Animation":
         return updateAnimation(model, action.animation);
@@ -432,9 +432,9 @@ const startAnimation =
 
 
 export const render =
-  ( model/*:Model*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  ( model: Model
+  , address: Address<Action>
+  ): DOM =>
   html.div
   ( { className: 'navigator-deck'
     , style:
@@ -459,9 +459,9 @@ export const render =
   )
 
 export const view =
-  ( model/*:Model*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  ( model: Model
+  , address: Address<Action>
+  ): DOM =>
   thunk
   ( 'Browser/NavigatorDeck'
   , render

--- a/src/browser/Navigators/Display.js
+++ b/src/browser/Navigators/Display.js
@@ -4,19 +4,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import * as Easing from "eased";
+import * as Easing from 'eased'
 
 export class Model {
   /*::
-  rightOffset: number;
-  depth: number;
-  */
-  constructor(depth: number, rightOffset: number=0) {
+   rightOffset: number;
+   depth: number;
+   */
+  constructor(depth:number, rightOffset:number = 0) {
     this.depth = depth
     this.rightOffset = rightOffset
   }
 }
-
 
 
 export const normal = new Model(0, 0)
@@ -24,12 +23,6 @@ export const shrinked = new Model(0, 50)
 export const expose = new Model(-200, 0)
 export const exposeShrinked = new Model(-200, 50)
 
-export const interpolate =
-  ( from: Model
-  , to: Model
-  , progress: number
-  ): Model =>
-  new Model
-  ( Easing.float(from.depth, to.depth, progress)
-  , Easing.float(from.rightOffset, to.rightOffset, progress)
-  )
+export const interpolate = (from:Model, to:Model, progress:number):Model =>new Model(Easing.float(from.depth, to.depth,
+                                                                                                  progress), Easing.float(
+    from.rightOffset, to.rightOffset, progress))

--- a/src/browser/Navigators/Display.js
+++ b/src/browser/Navigators/Display.js
@@ -11,7 +11,7 @@ export class Model {
   rightOffset: number;
   depth: number;
   */
-  constructor(depth/*:number*/, rightOffset/*:number*/=0) {
+  constructor(depth: number, rightOffset: number=0) {
     this.depth = depth
     this.rightOffset = rightOffset
   }
@@ -25,10 +25,10 @@ export const expose = new Model(-200, 0)
 export const exposeShrinked = new Model(-200, 50)
 
 export const interpolate =
-  ( from/*:Model*/
-  , to/*:Model*/
-  , progress/*:number*/
-  )/*:Model*/ =>
+  ( from: Model
+  , to: Model
+  , progress: number
+  ): Model =>
   new Model
   ( Easing.float(from.depth, to.depth, progress)
   , Easing.float(from.rightOffset, to.rightOffset, progress)

--- a/src/browser/Navigators/Navigator.js
+++ b/src/browser/Navigators/Navigator.js
@@ -4,109 +4,107 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Effects, html, forward, thunk} from "reflex"
-import {merge, always, batch} from "../../common/prelude";
-import {cursor} from "../../common/cursor";
-import * as Style from "../../common/style";
-
-import * as Assistant from "./Navigator/Assistant";
-import * as Overlay from "./Navigator/Overlay";
-import * as Input from "./Navigator/Input";
-import * as Output from "./Navigator/WebView";
-import * as Unknown from "../../common/unknown";
-import * as URL from '../../common/url-helper';
-import * as Header from './Navigator/Header';
-import * as Title from './Navigator/Title';
-import * as Progress from './Navigator/Progress';
-import * as Display from './Navigator/Display';
-import * as Animation from "../../common/Animation";
-import * as Easing from "eased";
-import * as Tab from "../Sidebar/Tab";
-
-import {readTitle, isSecure, isDark, canGoBack} from './Navigator/WebView/Util';
+import { Effects, html, forward, thunk } from 'reflex'
+import { always, batch } from '../../common/prelude'
+import { cursor } from '../../common/cursor'
+import * as Style from '../../common/style'
+import * as Assistant from './Navigator/Assistant'
+import * as Overlay from './Navigator/Overlay'
+import * as Input from './Navigator/Input'
+import * as Output from './Navigator/WebView'
+import * as Unknown from '../../common/unknown'
+import * as URL from '../../common/url-helper'
+import * as Header from './Navigator/Header'
+import * as Title from './Navigator/Title'
+import * as Progress from './Navigator/Progress'
+import * as Display from './Navigator/Display'
+import * as Animation from '../../common/Animation'
+import * as Easing from 'eased'
+import * as Tab from '../Sidebar/Tab'
+import { readTitle, isSecure, isDark, canGoBack } from './Navigator/WebView/Util'
 
 /*::
-import type {Address, DOM} from "reflex"
-import type {URI, Time} from "./Navigator/WebView"
+ import type {Address, DOM} from "reflex"
+ import type {URI, Time} from "./Navigator/WebView"
 
-export type Flags =
-  { output: Output.Flags
-  , isPinned?: boolean
-  , isInputEmbedded?: boolean
-  , input?: Input.Flags
-  , overlay?: Overlay.Flags
-  , assistant?: Assistant.Flags
-  }
+ export type Flags =
+ { output: Output.Flags
+ , isPinned?: boolean
+ , isInputEmbedded?: boolean
+ , input?: Input.Flags
+ , overlay?: Overlay.Flags
+ , assistant?: Assistant.Flags
+ }
 
-export type Action =
-  | { type: "NoOp" }
+ export type Action =
+ | { type: "NoOp" }
 
-  // Card
-  | { type: "Deselect" }
-  | { type: "Select" }
-  | { type: "Close" }
-  | { type: "Closed" }
+ // Card
+ | { type: "Deselect" }
+ | { type: "Select" }
+ | { type: "Close" }
+ | { type: "Closed" }
 
-  // Title
-  | { type: "EditInput" }
+ // Title
+ | { type: "EditInput" }
 
-  // Input
-  | { type: "CommitInput" }
-  | { type: "SubmitInput" }
-  | { type: "EscapeInput" }
-  | { type: "ActivateInput" }
-  | { type: "AbortInput" }
-  | { type: "SuggestNext" }
-  | { type: "SuggestPrevious" }
-  | { type: "Input", input: Input.Action }
+ // Input
+ | { type: "CommitInput" }
+ | { type: "SubmitInput" }
+ | { type: "EscapeInput" }
+ | { type: "ActivateInput" }
+ | { type: "AbortInput" }
+ | { type: "SuggestNext" }
+ | { type: "SuggestPrevious" }
+ | { type: "Input", input: Input.Action }
 
-  // Output
-  | { type: "GoBack" }
-  | { type: "GoForward" }
-  | { type: "Reload" }
-  | { type: "ZoomIn" }
-  | { type: "ZoomOut" }
-  | { type: "ResetZoom" }
-  | { type: "ActivateOutput" }
-  | { type: "LoadStart", time: Time }
-  | { type: "Connect", time: Time }
-  | { type: "LoadEnd", time: Time }
+ // Output
+ | { type: "GoBack" }
+ | { type: "GoForward" }
+ | { type: "Reload" }
+ | { type: "ZoomIn" }
+ | { type: "ZoomOut" }
+ | { type: "ResetZoom" }
+ | { type: "ActivateOutput" }
+ | { type: "LoadStart", time: Time }
+ | { type: "Connect", time: Time }
+ | { type: "LoadEnd", time: Time }
 
-  | { type: "Output", output: Output.Action }
+ | { type: "Output", output: Output.Action }
 
-  // Assistant
-  | { type: "Suggest", suggest: Assistant.Suggestion }
-  | { type: "Assistant", assistant: Assistant.Action }
+ // Assistant
+ | { type: "Suggest", suggest: Assistant.Suggestion }
+ | { type: "Assistant", assistant: Assistant.Action }
 
-  // Overlay
-  | { type: "Overlay", overlay: Overlay.Action }
-  | { type: "HideOverlay" }
-  | { type: "ShowOverlay" }
+ // Overlay
+ | { type: "Overlay", overlay: Overlay.Action }
+ | { type: "HideOverlay" }
+ | { type: "ShowOverlay" }
 
-  // Progress
-  | { type: "Progress", progress: Progress.Action }
+ // Progress
+ | { type: "Progress", progress: Progress.Action }
 
-  // Header
-  | { type: "ShowTabs" }
-  | { type: "OpenNewTab" }
-  | { type: "EditInput" }
-  | { type: "Header", header: Header.Action }
+ // Header
+ | { type: "ShowTabs" }
+ | { type: "OpenNewTab" }
+ | { type: "EditInput" }
+ | { type: "Header", header: Header.Action }
 
-  // Internal
-  | { type: "ActivateAssistant"}
-  | { type: "DeactivateAssistant" }
-  | { type: "SetSelectedInputValue", value: string }
+ // Internal
+ | { type: "ActivateAssistant"}
+ | { type: "DeactivateAssistant" }
+ | { type: "SetSelectedInputValue", value: string }
 
-  // Embedder
-  | { type: "Navigate", uri: URI }
-  | { type: "Open", open: Flags }
+ // Embedder
+ | { type: "Navigate", uri: URI }
+ | { type: "Open", open: Flags }
 
-  | { type: "Tab", tab: Tab.Action }
+ | { type: "Tab", tab: Tab.Action }
 
-  // Animation
-  | { type: "Animation", animation: Animation.Action }
-  | { type: "AnimationEnd" }
-*/
+ // Animation
+ | { type: "Animation", animation: Animation.Action }
+ | { type: "AnimationEnd" }
+ */
 
 const SubmitInput = { type: "SubmitInput" }
 const EscapeInput = { type: "EscapeInput" }
@@ -122,7 +120,7 @@ export const ZoomIn = { type: "ZoomIn" }
 export const ResetZoom = { type: "ResetZoom" }
 
 const ShowTabs = { type: "ShowTabs" };
-const OpenNewTab = { type: "OpenNewTab"};
+const OpenNewTab = { type: "OpenNewTab" };
 export const EditInput = { type: "EditInput" };
 const ActivateOutput = { type: "ActivateOutput" };
 const AbortInput = { type: "AbortInput" };
@@ -138,161 +136,135 @@ export const Select = { type: "Select" }
 export const FocusInput = { type: "Input", input: Input.Focus }
 export const HideInput = { type: "Input", input: Input.Hide }
 export const FocusOutput = { type: "Output", output: Output.Focus }
-export const ClearInput =
-  { type: "Input"
-  , input:
-    { type: "Change"
-    , value: ""
-    , selection:
-      { start: 0
-      , end: 0
-      , direction: "none"
-      }
+export const ClearInput = {
+  type: "Input", input: {
+    type: "Change", value: "", selection: {
+      start: 0, end: 0, direction: "none"
     }
   }
+}
 
-const tagInput =
-  action => {
-    switch (action.type) {
-      case "Submit":
-        return SubmitInput
-      case "Abort":
-        return EscapeInput
-      case "Focus":
-        return ActivateInput
-      case "Query":
-        return CommitInput
-      case "SuggestNext":
-        return SuggestNext
-      case "SuggestPrevious":
-        return SuggestPrevious
-      default:
-        return { type: 'Input', input: action }
-    }
+const tagInput = action => {
+  switch (action.type) {
+    case "Submit":
+      return SubmitInput
+    case "Abort":
+      return EscapeInput
+    case "Focus":
+      return ActivateInput
+    case "Query":
+      return CommitInput
+    case "SuggestNext":
+      return SuggestNext
+    case "SuggestPrevious":
+      return SuggestPrevious
+    default:
+      return { type: 'Input', input: action }
   }
+}
 
-const tagAssistant =
-  action => {
-    switch (action.type) {
-      case "Suggest":
-        return { type: "Suggest", suggest: action.suggest }
-      default:
-        return { type: "Assistant", assistant: action }
-    }
+const tagAssistant = action => {
+  switch (action.type) {
+    case "Suggest":
+      return { type: "Suggest", suggest: action.suggest }
+    default:
+      return { type: "Assistant", assistant: action }
   }
+}
 
-const tagOverlay =
-  action => {
-    switch (action.type) {
-      case "Click":
-        return EscapeInput
-      default:
-        return { type: "Overlay", overlay: action }
-    }
+const tagOverlay = action => {
+  switch (action.type) {
+    case "Click":
+      return EscapeInput
+    default:
+      return { type: "Overlay", overlay: action }
   }
+}
 
 
-const tagOutput =
-  action => {
-    switch (action.type) {
-      case "Create":
-        return OpenNewTab
-      case "Focus":
-        return ActivateOutput
-      case "Close":
-        return Close;
-      case "Open":
-        return { type: "Open", open: { output: action.options } }
-      case "LoadStart":
-        return action
-      case "Connect":
-        return action
-      case "LoadEnd":
-        return action
-      default:
-        return { type: "Output", output: action }
-    }
-  };
-
-const tagHeader =
-  action => {
-    switch (action.type) {
-      case "EditInput":
-        return EditInput
-      case "ShowTabs":
-        return ShowTabs
-      case "OpenNewTab":
-        return OpenNewTab
-      case "GoBack":
-        return GoBack
-      default:
-        return { type: "Header", header: action }
-    }
+const tagOutput = action => {
+  switch (action.type) {
+    case "Create":
+      return OpenNewTab
+    case "Focus":
+      return ActivateOutput
+    case "Close":
+      return Close;
+    case "Open":
+      return { type: "Open", open: { output: action.options } }
+    case "LoadStart":
+      return action
+    case "Connect":
+      return action
+    case "LoadEnd":
+      return action
+    default:
+      return { type: "Output", output: action }
   }
+};
 
-const tagTitle =
-  always({ type: "EditInput" });
+const tagHeader = action => {
+  switch (action.type) {
+    case "EditInput":
+      return EditInput
+    case "ShowTabs":
+      return ShowTabs
+    case "OpenNewTab":
+      return OpenNewTab
+    case "GoBack":
+      return GoBack
+    default:
+      return { type: "Header", header: action }
+  }
+}
 
-const tagProgress =
-  action =>
-  ( { type: "Progress"
-    , progress: action
-    }
-  )
+const tagTitle = always({ type: "EditInput" });
+
+const tagProgress = action =>( {
+  type: "Progress", progress: action
+}
+)
 
 
-const tagAnimation =
-  action => {
-    switch (action.type) {
-      case "End":
-        return { type: "AnimationEnd" };
-      default:
-        return { type: "Animation", animation: action }
-    }
-  };
+const tagAnimation = action => {
+  switch (action.type) {
+    case "End":
+      return { type: "AnimationEnd" };
+    default:
+      return { type: "Animation", animation: action }
+  }
+};
 
-export const Navigate =
-  ( destination: string): Action =>
-  ( { type: "Navigate"
-    , uri: URL.read(destination)
-    }
-  )
+export const Navigate = (destination:string):Action =>( {
+  type: "Navigate", uri: URL.read(destination)
+}
+)
 
 const ActivateAssistant = { type: "ActivateAssistant" }
 const DeactivateAssistant = { type: "DeactivateAssistant" }
 
-const SetSelectedInputValue =
-  value =>
-  ( { type: "SetSelectedInputValue"
-    , value
-    }
-  )
+const SetSelectedInputValue = value =>( {
+  type: "SetSelectedInputValue", value
+}
+)
 
 export class Model {
   /*::
-  isSelected: boolean;
-  isClosed: boolean;
-  isPinned: boolean;
-  isInputEmbedded: boolean;
-  output: Output.Model;
-  input: Input.Model;
-  overlay: Overlay.Model;
-  assistant: Assistant.Model;
-  progress: Progress.Model;
-  animation: Animation.Model<Display.Model>;
-  */
-  constructor(
-    isSelected: boolean
-  , isClosed: boolean
-  , isPinned: boolean
-  , isInputEmbedded: boolean
-  , input: Input.Model
-  , output: Output.Model
-  , assistant: Assistant.Model
-  , overlay: Overlay.Model
-  , progress: Progress.Model
-  , animation: Animation.Model<Display.Model>
-  ) {
+   isSelected: boolean;
+   isClosed: boolean;
+   isPinned: boolean;
+   isInputEmbedded: boolean;
+   output: Output.Model;
+   input: Input.Model;
+   overlay: Overlay.Model;
+   assistant: Assistant.Model;
+   progress: Progress.Model;
+   animation: Animation.Model<Display.Model>;
+   */
+  constructor(isSelected:boolean, isClosed:boolean, isPinned:boolean, isInputEmbedded:boolean, input:Input.Model,
+              output:Output.Model, assistant:Assistant.Model, overlay:Overlay.Model, progress:Progress.Model,
+              animation:Animation.Model<Display.Model>)
+  {
     this.isSelected = isSelected
     this.isClosed = isClosed
     this.isPinned = isPinned
@@ -306,677 +278,379 @@ export class Model {
   }
 }
 
-const assemble =
-  ( isSelected
-  , isClosed
-  , isPinned
-  , isInputEmbedded
-  , [input, $input]
-  , [output, $output]
-  , [assistant, $assistant]
-  , [overlay, $overlay]
-  , [progress, $progress]
-  , [animation, $animation]
-  ) => {
-    const model = new Model
-      ( isSelected
-      , isClosed
-      , isPinned
-      , isInputEmbedded
-      , input
-      , output
-      , assistant
-      , overlay
-      , progress
-      , animation
-      )
+const assemble = (isSelected, isClosed, isPinned, isInputEmbedded, [input, $input], [output, $output],
+    [assistant, $assistant], [overlay, $overlay], [progress, $progress], [animation, $animation]) => {
+  const model = new Model(isSelected, isClosed, isPinned, isInputEmbedded, input, output, assistant, overlay, progress, animation)
 
-    const fx = Effects.batch
-      ( [ $input.map(tagInput)
-        , $output.map(tagOutput)
-        , $overlay.map(tagOverlay)
-        , $assistant.map(tagAssistant)
-        , $progress.map(tagProgress)
-        , $animation.map(tagAnimation)
-        ]
-      )
+  const fx = Effects.batch([
+                             $input.map(tagInput),
+                             $output.map(tagOutput),
+                             $overlay.map(tagOverlay),
+                             $assistant.map(tagAssistant),
+                             $progress.map(tagProgress),
+                             $animation.map(tagAnimation)
+                           ])
 
-    return [model, fx]
-  }
+  return [model, fx]
+}
 
 
-export const init =
-  (options: Flags): [Model, Effects<Action>] =>
-  assemble
-  ( options.output.disposition != 'background-tab'
-  , false
-  , options.isPinned === true
-  , options.isInputEmbedded === true
-  , Input.init(options.input)
-  , Output.init(options.output)
-  , Assistant.init(options.assistant)
-  , Overlay.init(options.overlay && !options.isInputEmbedded)
-  , Progress.init()
-  , Animation.init
-    ( options.output.disposition != 'background-tab'
-    ? Display.selected
-    : Display.deselected
-    )
-  )
+export const init = (options:Flags):[Model, Effects<Action>] =>assemble(options.output.disposition != 'background-tab',
+                                                                        false, options.isPinned === true,
+                                                                        options.isInputEmbedded === true,
+                                                                        Input.init(options.input),
+                                                                        Output.init(options.output),
+                                                                        Assistant.init(options.assistant), Overlay.init(
+        options.overlay && !options.isInputEmbedded), Progress.init(), Animation.init(
+        options.output.disposition != 'background-tab' ? Display.selected : Display.deselected))
 
-export const update =
-  ( model: Model
-  , action: Action
-  ): [Model, Effects<Action>] => {
-    // console.log(action)
-    switch (action.type) {
-      case 'NoOp':
-        return nofx(model);
+export const update = (model:Model, action:Action):[Model, Effects<Action>] => {
+  // console.log(action)
+  switch (action.type) {
+    case 'NoOp':
+      return nofx(model);
 
-      case 'Navigate':
-        return navigate(model, action.uri);
+    case 'Navigate':
+      return navigate(model, action.uri);
 
-      case 'Select':
-        return select(model);
-      case 'Deselect':
-        return deselect(model);
-      case 'Close':
-        return close(model);
+    case 'Select':
+      return select(model);
+    case 'Deselect':
+      return deselect(model);
+    case 'Close':
+      return close(model);
 
       // Input
-      case 'CommitInput':
-        return commitInput(model);
-      case 'SubmitInput':
-        return submitInput(model);
-      case 'EscapeInput':
-        return escapeInput(model);
-      case 'ActivateInput':
-        return activateInput(model);
-      case 'AbortInput':
-        return abortInput(model);
-      case 'SuggestNext':
-        return suggestNext(model);
-      case 'SuggestPrevious':
-        return suggestPrevious(model);
-      case 'Input':
-        return updateInput(model, action.input);
-      case 'Tab':
-        return updateOutput(model, action);
+    case 'CommitInput':
+      return commitInput(model);
+    case 'SubmitInput':
+      return submitInput(model);
+    case 'EscapeInput':
+      return escapeInput(model);
+    case 'ActivateInput':
+      return activateInput(model);
+    case 'AbortInput':
+      return abortInput(model);
+    case 'SuggestNext':
+      return suggestNext(model);
+    case 'SuggestPrevious':
+      return suggestPrevious(model);
+    case 'Input':
+      return updateInput(model, action.input);
+    case 'Tab':
+      return updateOutput(model, action);
 
       // Output
-      case "GoBack":
-        return updateOutput(model, Output.GoBack);
-      case "GoForward":
-        return updateOutput(model, Output.GoForward);
-      case "Reload":
-        return updateOutput(model, Output.Reload);
-      case "ZoomIn":
-        return updateOutput(model, Output.ZoomIn);
-      case "ZoomOut":
-        return updateOutput(model, Output.ZoomOut);
-      case "ResetZoom":
-        return updateOutput(model, Output.ResetZoom);
+    case "GoBack":
+      return updateOutput(model, Output.GoBack);
+    case "GoForward":
+      return updateOutput(model, Output.GoForward);
+    case "Reload":
+      return updateOutput(model, Output.Reload);
+    case "ZoomIn":
+      return updateOutput(model, Output.ZoomIn);
+    case "ZoomOut":
+      return updateOutput(model, Output.ZoomOut);
+    case "ResetZoom":
+      return updateOutput(model, Output.ResetZoom);
 
-      case 'ActivateOutput':
-        return activateOutput(model);
-      case 'EditInput':
-        return editInput(model);
-      case "LoadStart":
-        return updateLoadProgress(model, action);
-      case "Connect":
-        return updateLoadProgress(model, action);
-      case "LoadEnd":
-        return updateLoadProgress(model, action);
-      case 'Output':
-        return updateOutput(model, action.output);
+    case 'ActivateOutput':
+      return activateOutput(model);
+    case 'EditInput':
+      return editInput(model);
+    case "LoadStart":
+      return updateLoadProgress(model, action);
+    case "Connect":
+      return updateLoadProgress(model, action);
+    case "LoadEnd":
+      return updateLoadProgress(model, action);
+    case 'Output':
+      return updateOutput(model, action.output);
 
       // Progress
-      case 'Progress':
-        return updateProgress(model, action.progress);
+    case 'Progress':
+      return updateProgress(model, action.progress);
 
       // Assistant
-      case 'Suggest':
-        return suggest(model, action.suggest);
-      case 'Assistant':
-        return updateAssistant(model, action.assistant);
+    case 'Suggest':
+      return suggest(model, action.suggest);
+    case 'Assistant':
+      return updateAssistant(model, action.assistant);
 
-      case 'Overlay':
-        return updateOverlay(model, action.overlay);
-      case 'HideOverlay':
-        return updateOverlay(model, Overlay.Hide);
-      case 'ShowOverlay':
-        return updateOverlay(model, Overlay.Show);
+    case 'Overlay':
+      return updateOverlay(model, action.overlay);
+    case 'HideOverlay':
+      return updateOverlay(model, Overlay.Hide);
+    case 'ShowOverlay':
+      return updateOverlay(model, Overlay.Show);
 
       // Internal
-      case 'ActivateAssistant':
-        return activateAssistant(model);
-      case 'DeactivateAssistant':
-        return deactivateAssistant(model);
-      case 'SetSelectedInputValue':
-        return setSelectedInputValue(model, action.value);
+    case 'ActivateAssistant':
+      return activateAssistant(model);
+    case 'DeactivateAssistant':
+      return deactivateAssistant(model);
+    case 'SetSelectedInputValue':
+      return setSelectedInputValue(model, action.value);
 
-      case 'Animation':
-        return updateAnimation(model, action.animation);
-      case 'AnimationEnd':
-        return endAnimation(model);
+    case 'Animation':
+      return updateAnimation(model, action.animation);
+    case 'AnimationEnd':
+      return endAnimation(model);
 
-      default:
-        return Unknown.update(model, action);
-    }
-  };
-
-const nofx =
-  (model: Model): [Model, Effects<Action>] =>
-  [ model
-  , Effects.none
-  ];
-
-export const select =
-  ( model: Model
-  ): [Model, Effects<Action>] =>
-  ( model.isSelected
-  ? nofx(model)
-  : startAnimation
-    ( model
-    , true
-    , model.isClosed
-    , Animation.transition
-      ( model.animation
-      , Display.selected
-      , 80
-      )
-    )
-  )
-
-export const deselect =
-  ( model: Model
-  ): [Model, Effects<Action>] =>
-  ( model.isSelected
-  ? startAnimation
-    ( model
-    , false
-    , model.isClosed
-    , Animation.transition
-      ( model.animation
-      , Display.deselected
-      , 80
-      )
-    )
-  : nofx(model)
-  )
-
-export const close =
-  ( model: Model
-  ): [Model, Effects<Action>] =>
-  ( model.isPinned
-  ? [ model
-    , Effects.receive(Select)
-    ]
-  : model.isSelected
-  ? startAnimation
-    ( model
-    , false
-    , true
-    , Animation.transition
-      ( model.animation
-      , Display.closed
-      , 80
-      )
-    )
-  : [ model
-    , Effects.receive(Closed)
-    ]
-  )
-
-const navigate =
-  (model, uri) =>
-  ( model.isPinned
-  ? open(model, uri)
-  : updateOutput
-    ( model
-    , Output.Load(uri)
-    )
-  )
-
-const open =
-  (model, uri) => {
-    const [next, fx1] = escapeInput(model)
-    const fx2 = Effects.receive
-      ( { type: "Open"
-        , open:
-          { output:
-            { uri
-            , disposition: 'default'
-            , name: ''
-            , features: ''
-            , ref: null
-            , guestInstanceId: null
-            }
-          }
-        }
-      )
-
-    const fx = Effects.batch
-      ( [ fx1
-        , fx2
-        ]
-      )
-
-    return [next, fx]
+    default:
+      return Unknown.update(model, action);
   }
+};
 
+const nofx = (model:Model):[Model, Effects<Action>] =>[
+  model, Effects.none
+];
 
-const commitInput =
-  model =>
-  updateAssistant
-  ( model
-  , Assistant.Query(model.input.value)
-  )
+export const select = (model:Model):[Model, Effects<Action>] =>( model.isSelected ? nofx(model) : startAnimation(model,
+                                                                                                                 true,
+                                                                                                                 model.isClosed,
+                                                                                                                 Animation.transition(
+                                                                                                                     model.animation,
+                                                                                                                     Display.selected,
+                                                                                                                     80))
+)
 
-const submitInput =
-  model =>
-  batch
-  ( update
-  , model
-  , [ FocusOutput
-    , Navigate(model.input.value)
+export const deselect = (model:Model):[Model, Effects<Action>] =>( model.isSelected ? startAnimation(model, false,
+                                                                                                     model.isClosed,
+                                                                                                     Animation.transition(
+                                                                                                         model.animation,
+                                                                                                         Display.deselected,
+                                                                                                         80)) : nofx(
+        model)
+)
+
+export const close = (model:Model):[Model, Effects<Action>] =>( model.isPinned
+        ? [
+      model,
+      Effects.receive(Select)
     ]
-  );
-
-const escapeInput =
-  model =>
-  ( model.isInputEmbedded
-  ? batch
-    ( update
-    , model
-    , [ DeactivateAssistant
-      , FocusOutput
-      , HideOverlay
-      , ClearInput
-      ]
-    )
-  : batch
-    ( update
-    , model
-    , [ DeactivateAssistant
-      , AbortInput
-      , FocusOutput
-      , HideOverlay
-      , ClearInput
-      ]
-    )
-  );
-
-
-const activateInput =
-  model =>
-  ( model.isInputEmbedded
-  ? batch
-    ( update
-    , model
-    , [ FocusInput
-      , ActivateAssistant
-      ]
-    )
-  : batch
-    ( update
-    , model
-    , [ FocusInput
-      , ActivateAssistant
-      , ShowOverlay
-      ]
-    )
-  )
-
-const abortInput =
-  model =>
-  updateInput(model, Input.Abort);
-
-
-const suggestNext =
-  model =>
-  updateAssistant(model, Assistant.SuggestNext);
-
-const suggestPrevious =
-  model =>
-  updateAssistant(model, Assistant.SuggestPrevious);
-
-const activateOutput =
-  model =>
-  batch
-  ( update
-  , model
-  , [ FocusOutput
-    , EscapeInput
+        : model.isSelected
+        ? startAnimation(model, false, true, Animation.transition(model.animation, Display.closed, 80))
+        : [
+      model,
+      Effects.receive(Closed)
     ]
+)
+
+const navigate = (model, uri) =>( model.isPinned ? open(model, uri) : updateOutput(model, Output.Load(uri))
+)
+
+const open = (model, uri) => {
+  const [next, fx1] = escapeInput(model)
+  const fx2 = Effects.receive({
+                                type: "Open", open: {
+      output: {
+        uri, disposition: 'default', name: '', features: '', ref: null, guestInstanceId: null
+      }
+    }
+                              })
+
+  const fx = Effects.batch([
+                             fx1, fx2
+                           ])
+
+  return [next, fx]
+}
+
+
+const commitInput = model =>updateAssistant(model, Assistant.Query(model.input.value))
+
+const submitInput = model =>batch(update, model, [
+  FocusOutput, Navigate(model.input.value)
+]);
+
+const escapeInput = model =>( model.isInputEmbedded ? batch(update, model, [
+      DeactivateAssistant, FocusOutput, HideOverlay, ClearInput
+    ]) : batch(update, model, [
+      DeactivateAssistant, AbortInput, FocusOutput, HideOverlay, ClearInput
+    ])
+);
+
+
+const activateInput = model =>( model.isInputEmbedded ? batch(update, model, [
+      FocusInput, ActivateAssistant
+    ]) : batch(update, model, [
+      FocusInput, ActivateAssistant, ShowOverlay
+    ])
+)
+
+const abortInput = model =>updateInput(model, Input.Abort);
+
+
+const suggestNext = model =>updateAssistant(model, Assistant.SuggestNext);
+
+const suggestPrevious = model =>updateAssistant(model, Assistant.SuggestPrevious);
+
+const activateOutput = model =>batch(update, model, [
+  FocusOutput, EscapeInput
+])
+
+const goBack = model =>updateOutput(model, Output.GoBack);
+
+const updateLoadProgress = (source, action) => {
+  const [output, output$] = Output.update(source.output, action)
+  const [progress, progress$] = Progress.update(source.progress, action)
+  const model = new Model(source.isSelected, source.isClosed, source.isPinned, source.isInputEmbedded, source.input, output, source.assistant, source.overlay, progress, source.animation)
+  const fx = Effects.batch([
+                             output$.map(tagOutput), progress$.map(tagProgress)
+                           ])
+
+  return [model, fx]
+}
+
+
+const editInput = model =>batch(update, model, [
+  ActivateInput
+  // @TODO: Do not use `model.output.navigation.currentURI` as it ties it
+  // to webView API too much.
+  , ( model.isInputEmbedded ? SetSelectedInputValue('') : SetSelectedInputValue(model.output.navigation.currentURI)
   )
+])
 
-const goBack =
-  model =>
-  updateOutput(model, Output.GoBack);
+const suggest = (model, suggestion) =>updateInput(model, Input.Suggest({
+                                                                         query: model.assistant.query,
+                                                                         match: suggestion.match,
+                                                                         hint: suggestion.hint
+                                                                       }))
 
-const updateLoadProgress =
-  (source, action) => {
-    const [output, output$] = Output.update(source.output, action)
-    const [progress, progress$] = Progress.update(source.progress, action)
-    const model = new Model
-    ( source.isSelected
-    , source.isClosed
-    , source.isPinned
-    , source.isInputEmbedded
-    , source.input
-    , output
-    , source.assistant
-    , source.overlay
-    , progress
-    , source.animation
-    )
-    const fx = Effects.batch
-    ( [ output$.map(tagOutput)
-      , progress$.map(tagProgress)
-      ]
-    )
+const activateAssistant = model =>updateAssistant(model, Assistant.Open)
 
-    return [model, fx]
+const deactivateAssistant = model =>updateAssistant(model, Assistant.Close)
+
+const setSelectedInputValue = (model, value) =>updateInput(model, Input.EnterSelection(value))
+
+const updateInput = cursor({
+                             get: model => model.input,
+                             set: (model,
+                                   input) =>new Model(model.isSelected, model.isClosed, model.isPinned, model.isInputEmbedded, input, model.output, model.assistant, model.overlay, model.progress, model.animation),
+                             update: Input.update,
+                             tag: tagInput
+                           });
+
+const updateOutput = cursor({
+                              get: model => model.output,
+                              set: (model,
+                                    output) =>new Model(model.isSelected, model.isClosed, model.isPinned, model.isInputEmbedded, model.input, output, model.assistant, model.overlay, model.progress, model.animation),
+                              update: Output.update,
+                              tag: tagOutput
+                            });
+
+const updateProgress = cursor({
+                                get: model => model.progress,
+                                set: (model,
+                                      progress) =>new Model(model.isSelected, model.isClosed, model.isPinned, model.isInputEmbedded, model.input, model.output, model.assistant, model.overlay, progress, model.animation),
+                                update: Progress.update,
+                                tag: tagProgress
+                              });
+
+const updateAssistant = cursor({
+                                 get: model => model.assistant,
+                                 set: (model,
+                                       assistant) =>new Model(model.isSelected, model.isClosed, model.isPinned, model.isInputEmbedded, model.input, model.output, assistant, model.overlay, model.progress, model.animation),
+                                 update: Assistant.update,
+                                 tag: tagAssistant
+                               });
+
+const updateOverlay = cursor({
+                               get: model => model.overlay,
+                               set: (model,
+                                     overlay) =>new Model(model.isSelected, model.isClosed, model.isPinned, model.isInputEmbedded, model.input, model.output, model.assistant, overlay, model.progress, model.animation),
+                               update: Overlay.update,
+                               tag: tagOverlay
+                             });
+
+const animate = (animation, action) =>Animation.updateWith(Easing.easeOutCubic, Display.interpolate, animation, action)
+
+const updateAnimation = cursor({
+                                 get: model => model.animation,
+                                 set: (model,
+                                       animation) =>new Model(model.isSelected, model.isClosed, model.isPinned, model.isInputEmbedded, model.input, model.output, model.assistant, model.overlay, model.progress, animation),
+                                 tag: tagAnimation,
+                                 update: animate
+                               })
+
+const startAnimation = (model, isSelected, isClosed, [animation, fx]) =>[
+  new Model(isSelected, isClosed, model.isPinned, model.isInputEmbedded, model.input, model.output, model.assistant, model.overlay, model.progress, animation),
+  fx.map(tagAnimation)
+]
+
+const endAnimation = model =>( model.isClosed ? [
+      model, Effects.receive(Closed)
+    ] : nofx(model)
+)
+
+export const render = (model:Model, address:Address<Action>):DOM =>html.dialog({
+                                                                                 className: `navigator ${mode(
+                                                                                     model.output)}`,
+                                                                                 open: true,
+                                                                                 style: Style.mix(styleSheet.base,
+                                                                                                  ( isDark(model.output)
+                                                                                                          ? styleSheet.dark
+                                                                                                          : styleSheet.bright
+                                                                                                  ), ( model.isSelected
+                                                                                             ? styleSheet.selected
+                                                                                             : styleSheet.unselected
+                                                                                                  ),
+                                                                                                  model.animation.state,
+                                                                                                  styleBackground(
+                                                                                                      model.output))
+                                                                               }, [
+                                                                                 Output.view(model.output,
+                                                                                             forward(address,
+                                                                                                     tagOutput)),
+                                                                                 Overlay.view(model.overlay,
+                                                                                              forward(address,
+                                                                                                      tagOverlay)),
+                                                                                 Assistant.view(model.assistant,
+                                                                                                forward(address,
+                                                                                                        tagAssistant)),
+                                                                                 Header.view(canGoBack(model.output),
+                                                                                             forward(address,
+                                                                                                     tagHeader)),
+                                                                                 Title.view(model.input.isVisible,
+                                                                                            readTitle(model.output,
+                                                                                                      'Untitled'),
+                                                                                            isSecure(model.output),
+                                                                                            forward(address, tagTitle)),
+                                                                                 Progress.view(model.progress,
+                                                                                               forward(address,
+                                                                                                       tagProgress)),
+                                                                                 Input.view(model.input,
+                                                                                            forward(address, tagInput))
+                                                                               ])
+
+export const view = (model:Model, address:Address<Action>):DOM =>thunk(model.output.ref.value, render, model, address)
+
+const styleSheet = Style.createSheet({
+                                       base: {
+                                         width: '100%',
+                                         height: '100%',
+                                         position: 'absolute',
+                                         top: 0,
+                                         left: 0,
+                                         overflow: 'hidden',
+                                         backgroundColor: 'white',
+                                         display: 'block',
+                                         borderRadius: '4px',
+                                         transitionProperty: 'background-color, color, border-color',
+                                         transitionTimingFunction: 'ease-in, ease-out, ease',
+                                         transitionDuration: '300ms'
+                                       }, selected: { zIndex: 2 }, unselected: { zIndex: 1 }, dark: {
+    color: 'rgba(255, 255, 255, 0.8)', borderColor: 'rgba(255, 255, 255, 0.2)'
+  }, bright: {
+    color: 'rgba(0, 0, 0, 0.8)', borderColor: 'rgba(0, 0, 0, 0.2)'
   }
+                                     });
 
+const styleBackground = model =>( model.page.pallet.background ? {
+      backgroundColor: model.page.pallet.background
+    } : null
+)
 
-const editInput =
-  model =>
-  batch
-  ( update
-  , model
-  , [ ActivateInput
-      // @TODO: Do not use `model.output.navigation.currentURI` as it ties it
-      // to webView API too much.
-    , ( model.isInputEmbedded
-      ? SetSelectedInputValue('')
-      : SetSelectedInputValue(model.output.navigation.currentURI)
-      )
-    ]
-  )
-
-const suggest =
-  (model, suggestion) =>
-  updateInput
-  ( model
-  , Input.Suggest
-    ( { query: model.assistant.query
-      , match: suggestion.match
-      , hint: suggestion.hint
-      }
-    )
-  )
-
-const activateAssistant =
-  model =>
-  updateAssistant
-  ( model
-  , Assistant.Open
-  )
-
-const deactivateAssistant =
-  model =>
-  updateAssistant
-  ( model
-  , Assistant.Close
-  )
-
-const setSelectedInputValue =
-  (model, value) =>
-  updateInput
-  ( model
-  , Input.EnterSelection(value)
-  )
-
-const updateInput = cursor
-  ( { get: model => model.input
-    , set:
-      (model, input) =>
-      new Model
-      ( model.isSelected
-      , model.isClosed
-      , model.isPinned
-      , model.isInputEmbedded
-      , input
-      , model.output
-      , model.assistant
-      , model.overlay
-      , model.progress
-      , model.animation
-      )
-    , update: Input.update
-    , tag: tagInput
-    }
-  );
-
-const updateOutput = cursor
-  ( { get: model => model.output
-    , set:
-      (model, output) =>
-      new Model
-      ( model.isSelected
-      , model.isClosed
-      , model.isPinned
-      , model.isInputEmbedded
-      , model.input
-      , output
-      , model.assistant
-      , model.overlay
-      , model.progress
-      , model.animation
-      )
-    , update: Output.update
-    , tag: tagOutput
-    }
-  );
-
-const updateProgress = cursor
-  ( { get: model => model.progress
-    , set:
-      (model, progress) =>
-      new Model
-      ( model.isSelected
-      , model.isClosed
-      , model.isPinned
-      , model.isInputEmbedded
-      , model.input
-      , model.output
-      , model.assistant
-      , model.overlay
-      , progress
-      , model.animation
-      )
-    , update: Progress.update
-    , tag: tagProgress
-    }
-  );
-
-const updateAssistant = cursor
-  ( { get: model => model.assistant
-    , set:
-      (model, assistant) =>
-      new Model
-      ( model.isSelected
-      , model.isClosed
-      , model.isPinned
-      , model.isInputEmbedded
-      , model.input
-      , model.output
-      , assistant
-      , model.overlay
-      , model.progress
-      , model.animation
-      )
-    , update: Assistant.update
-    , tag: tagAssistant
-    }
-  );
-
-const updateOverlay = cursor
-  ( { get: model => model.overlay
-    , set:
-      (model, overlay) =>
-      new Model
-      ( model.isSelected
-      , model.isClosed
-      , model.isPinned
-      , model.isInputEmbedded
-      , model.input
-      , model.output
-      , model.assistant
-      , overlay
-      , model.progress
-      , model.animation
-      )
-    , update: Overlay.update
-    , tag: tagOverlay
-    }
-  );
-
-const animate =
-  (animation, action) =>
-  Animation.updateWith
-  ( Easing.easeOutCubic
-  , Display.interpolate
-  , animation
-  , action
-  )
-
-const updateAnimation = cursor
-  ( { get: model => model.animation
-    , set:
-      (model, animation) =>
-        new Model
-        ( model.isSelected
-        , model.isClosed
-        , model.isPinned
-        , model.isInputEmbedded
-        , model.input
-        , model.output
-        , model.assistant
-        , model.overlay
-        , model.progress
-        , animation
-        )
-    , tag: tagAnimation
-    , update: animate
-    }
-  )
-
-const startAnimation =
-  (model, isSelected, isClosed, [animation, fx]) =>
-  [ new Model
-    ( isSelected
-    , isClosed
-    , model.isPinned
-    , model.isInputEmbedded
-    , model.input
-    , model.output
-    , model.assistant
-    , model.overlay
-    , model.progress
-    , animation
-    )
-  , fx.map(tagAnimation)
-  ]
-
-const endAnimation =
-  model =>
-  ( model.isClosed
-  ? [ model
-    , Effects.receive(Closed)
-    ]
-  : nofx(model)
-  )
-
-export const render =
-  (model: Model, address: Address<Action>): DOM =>
-  html.dialog
-  ( { className: `navigator ${mode(model.output)}`
-    , open: true
-    , style: Style.mix
-      ( styleSheet.base
-      , ( isDark(model.output)
-        ? styleSheet.dark
-        : styleSheet.bright
-        )
-      , ( model.isSelected
-        ? styleSheet.selected
-        : styleSheet.unselected
-        )
-      , model.animation.state
-      , styleBackground(model.output)
-      )
-    }
-  , [ Output.view(model.output, forward(address, tagOutput))
-    , Overlay.view(model.overlay, forward(address, tagOverlay))
-    , Assistant.view(model.assistant, forward(address, tagAssistant))
-    , Header.view
-      ( canGoBack(model.output)
-      , forward(address, tagHeader)
-      )
-    , Title.view
-      ( model.input.isVisible
-      , readTitle(model.output, 'Untitled')
-      , isSecure(model.output)
-      , forward(address, tagTitle)
-      )
-    , Progress.view(model.progress, forward(address, tagProgress))
-    , Input.view(model.input, forward(address, tagInput))
-    ]
-  )
-
-export const view =
-  (model: Model, address: Address<Action>): DOM =>
-  thunk
-  ( model.output.ref.value
-  , render
-  , model
-  , address
-  )
-
-const styleSheet = Style.createSheet
-  ( { base:
-      { width: '100%'
-      , height: '100%'
-      , position: 'absolute'
-      , top: 0
-      , left: 0
-      , overflow: 'hidden'
-      , backgroundColor: 'white'
-      , display: 'block'
-      , borderRadius: '4px'
-      , transitionProperty: 'background-color, color, border-color'
-      , transitionTimingFunction: 'ease-in, ease-out, ease'
-      , transitionDuration: '300ms'
-      }
-    , selected:
-      { zIndex: 2 }
-    , unselected:
-      { zIndex: 1 }
-    , dark:
-      { color: 'rgba(255, 255, 255, 0.8)'
-      , borderColor: 'rgba(255, 255, 255, 0.2)'
-      }
-    , bright:
-      { color: 'rgba(0, 0, 0, 0.8)'
-      , borderColor: 'rgba(0, 0, 0, 0.2)'
-      }
-    }
-  );
-
-const styleBackground =
-  model =>
-  ( model.page.pallet.background
-  ? { backgroundColor: model.page.pallet.background
-    }
-  : null
-  )
-
-const mode =
-  model =>
-  ( isDark(model)
-  ? 'dark'
-  : 'bright'
-  )
+const mode = model =>( isDark(model) ? 'dark' : 'bright'
+)

--- a/src/browser/Navigators/Navigator.js
+++ b/src/browser/Navigators/Navigator.js
@@ -252,7 +252,7 @@ const tagAnimation =
   };
 
 export const Navigate =
-  ( destination/*:string*/)/*:Action*/ =>
+  ( destination: string): Action =>
   ( { type: "Navigate"
     , uri: URL.read(destination)
     }
@@ -282,16 +282,16 @@ export class Model {
   animation: Animation.Model<Display.Model>;
   */
   constructor(
-    isSelected/*:boolean*/
-  , isClosed/*:boolean*/
-  , isPinned/*:boolean*/
-  , isInputEmbedded/*:boolean*/
-  , input/*:Input.Model*/
-  , output/*:Output.Model*/
-  , assistant/*:Assistant.Model*/
-  , overlay/*:Overlay.Model*/
-  , progress/*:Progress.Model*/
-  , animation/*:Animation.Model<Display.Model>*/
+    isSelected: boolean
+  , isClosed: boolean
+  , isPinned: boolean
+  , isInputEmbedded: boolean
+  , input: Input.Model
+  , output: Output.Model
+  , assistant: Assistant.Model
+  , overlay: Overlay.Model
+  , progress: Progress.Model
+  , animation: Animation.Model<Display.Model>
   ) {
     this.isSelected = isSelected
     this.isClosed = isClosed
@@ -346,7 +346,7 @@ const assemble =
 
 
 export const init =
-  (options/*:Flags*/)/*:[Model, Effects<Action>]*/ =>
+  (options: Flags): [Model, Effects<Action>] =>
   assemble
   ( options.output.disposition != 'background-tab'
   , false
@@ -365,9 +365,9 @@ export const init =
   )
 
 export const update =
-  ( model/*:Model*/
-  , action/*:Action*/
-  )/*:[Model, Effects<Action>]*/ => {
+  ( model: Model
+  , action: Action
+  ): [Model, Effects<Action>] => {
     // console.log(action)
     switch (action.type) {
       case 'NoOp':
@@ -466,14 +466,14 @@ export const update =
   };
 
 const nofx =
-  (model/*:Model*/)/*:[Model, Effects<Action>]*/ =>
+  (model: Model): [Model, Effects<Action>] =>
   [ model
   , Effects.none
   ];
 
 export const select =
-  ( model/*:Model*/
-  )/*:[Model, Effects<Action>]*/ =>
+  ( model: Model
+  ): [Model, Effects<Action>] =>
   ( model.isSelected
   ? nofx(model)
   : startAnimation
@@ -489,8 +489,8 @@ export const select =
   )
 
 export const deselect =
-  ( model/*:Model*/
-  )/*:[Model, Effects<Action>]*/ =>
+  ( model: Model
+  ): [Model, Effects<Action>] =>
   ( model.isSelected
   ? startAnimation
     ( model
@@ -506,8 +506,8 @@ export const deselect =
   )
 
 export const close =
-  ( model/*:Model*/
-  )/*:[Model, Effects<Action>]*/ =>
+  ( model: Model
+  ): [Model, Effects<Action>] =>
   ( model.isPinned
   ? [ model
     , Effects.receive(Select)
@@ -891,7 +891,7 @@ const endAnimation =
   )
 
 export const render =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>): DOM =>
   html.dialog
   ( { className: `navigator ${mode(model.output)}`
     , open: true
@@ -928,7 +928,7 @@ export const render =
   )
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>): DOM =>
   thunk
   ( model.output.ref.value
   , render

--- a/src/browser/Navigators/Navigator/Assistant.js
+++ b/src/browser/Navigators/Navigator/Assistant.js
@@ -46,22 +46,22 @@ export type Action =
 */
 
 
-export const Open/*:Action*/ = { type: "Open" };
-export const Close/*:Action*/ = { type: "Close" };
-export const Expand/*:Action*/ = { type: "Expand" };
-export const Unselect/*:Action*/ = { type: "Unselect" };
-export const Reset/*:Action*/ = { type: "Reset" };
-export const SuggestNext/*:Action*/ = { type: "SuggestNext" };
-export const SuggestPrevious/*:Action*/ = { type: "SuggestPrevious" };
+export const Open: Action = { type: "Open" };
+export const Close: Action = { type: "Close" };
+export const Expand: Action = { type: "Expand" };
+export const Unselect: Action = { type: "Unselect" };
+export const Reset: Action = { type: "Reset" };
+export const SuggestNext: Action = { type: "SuggestNext" };
+export const SuggestPrevious: Action = { type: "SuggestPrevious" };
 export const Suggest =
-  (suggestion/*:Suggestion*/)/*:Action*/ =>
+  (suggestion: Suggestion): Action =>
   ( { type: "Suggest"
     , suggest: suggestion
     }
   )
 
 export const Query =
-  (input/*:string*/)/*:Action*/ =>
+  (input: string): Action =>
   ( { type: "Query"
     , query: input
     }
@@ -85,9 +85,9 @@ const HistoryAction =
   );
 
 export const init =
-  ( isOpen/*:boolean*/=false
-  , isExpanded/*:boolean*/=false
-  )/*:[Model, Effects<Action>]*/ => {
+  ( isOpen: boolean=false
+  , isExpanded: boolean=false
+  ): [Model, Effects<Action>] => {
     const query = ''
     const [search, fx1] = Search.init(query, 5);
     const [history, fx2] = History.init(query, 5);
@@ -203,9 +203,9 @@ const suggestPrevious =
   updateSearch(model, Search.SelectPrevious);
 
 export const update =
-  ( model/*:Model*/
-  , action/*:Action*/
-  )/*:[Model, Effects<Action>]*/ => {
+  ( model: Model
+  , action: Action
+  ): [Model, Effects<Action>] => {
     switch (action.type) {
       case "Open":
         return open(model)
@@ -269,7 +269,7 @@ const styleSheet = StyleSheet.create
   );
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>): DOM =>
   html.div
   ( { className: 'assistant'
     , style: Style

--- a/src/browser/Navigators/Navigator/Assistant.js
+++ b/src/browser/Navigators/Navigator/Assistant.js
@@ -4,299 +4,218 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {always, batch, merge, take, move} from "../../../common/prelude"
-import {Effects, html, thunk, forward} from "reflex"
-import * as History from "./Assistant/history"
-import * as Search from "./Assistant/search"
-import {StyleSheet, Style} from '../../../common/style';
-import {cursor} from '../../../common/cursor';
-import * as Unknown from '../../../common/unknown';
+import { batch, merge } from '../../../common/prelude'
+import { Effects, html, forward } from 'reflex'
+import * as History from './Assistant/history'
+import * as Search from './Assistant/search'
+import { StyleSheet, Style } from '../../../common/style'
+import { cursor } from '../../../common/cursor'
+import * as Unknown from '../../../common/unknown'
 
 /*::
-import type {Address, DOM} from "reflex";
+ import type {Address, DOM} from "reflex";
 
-export type Flags = boolean
+ export type Flags = boolean
 
-export type Suggestion =
-  { match: string
-  , hint: string
-  }
+ export type Suggestion =
+ { match: string
+ , hint: string
+ }
 
-export type Model =
-  { isOpen: boolean
-  , isExpanded: boolean
-  , query: string
-  , selected: number
-  , search: Search.Model
-  , history: History.Model
-  }
+ export type Model =
+ { isOpen: boolean
+ , isExpanded: boolean
+ , query: string
+ , selected: number
+ , search: Search.Model
+ , history: History.Model
+ }
 
-export type Action =
-  | { type: "Open" }
-  | { type: "Close" }
-  | { type: "Expand" }
-  | { type: "Reset" }
-  | { type: "Unselect" }
-  | { type: "SuggestNext" }
-  | { type: "SuggestPrevious" }
-  | { type: "Query", query: string }
-  | { type: "Suggest", suggest: Suggestion }
-  | { type: "Search", search: Search.Action }
-  | { type: "History", history: History.Action }
-*/
+ export type Action =
+ | { type: "Open" }
+ | { type: "Close" }
+ | { type: "Expand" }
+ | { type: "Reset" }
+ | { type: "Unselect" }
+ | { type: "SuggestNext" }
+ | { type: "SuggestPrevious" }
+ | { type: "Query", query: string }
+ | { type: "Suggest", suggest: Suggestion }
+ | { type: "Search", search: Search.Action }
+ | { type: "History", history: History.Action }
+ */
 
 
-export const Open: Action = { type: "Open" };
-export const Close: Action = { type: "Close" };
-export const Expand: Action = { type: "Expand" };
-export const Unselect: Action = { type: "Unselect" };
-export const Reset: Action = { type: "Reset" };
-export const SuggestNext: Action = { type: "SuggestNext" };
-export const SuggestPrevious: Action = { type: "SuggestPrevious" };
-export const Suggest =
-  (suggestion: Suggestion): Action =>
-  ( { type: "Suggest"
-    , suggest: suggestion
+export const Open:Action = { type: "Open" };
+export const Close:Action = { type: "Close" };
+export const Expand:Action = { type: "Expand" };
+export const Unselect:Action = { type: "Unselect" };
+export const Reset:Action = { type: "Reset" };
+export const SuggestNext:Action = { type: "SuggestNext" };
+export const SuggestPrevious:Action = { type: "SuggestPrevious" };
+export const Suggest = (suggestion:Suggestion):Action =>( {
+  type: "Suggest", suggest: suggestion
+}
+)
+
+export const Query = (input:string):Action =>( {
+  type: "Query", query: input
+}
+);
+
+
+const SearchAction = action =>( action.type === "Suggest" ? Suggest(action.source) : {
+      type: "Search", search: action
     }
-  )
+);
 
-export const Query =
-  (input: string): Action =>
-  ( { type: "Query"
-    , query: input
-    }
-  );
+const HistoryAction = action =>( {
+  type: "History", history: action
+}
+);
 
+export const init = (isOpen:boolean = false, isExpanded:boolean = false):[Model, Effects<Action>] => {
+  const query = ''
+  const [search, fx1] = Search.init(query, 5);
+  const [history, fx2] = History.init(query, 5);
+  const fx = Effects.batch([
+                             fx1.map(SearchAction), fx2.map(HistoryAction)
+                           ]);
 
-const SearchAction =
-  action =>
-  ( action.type === "Suggest"
-  ? Suggest(action.source)
-  : { type: "Search"
-    , search: action
-    }
-  );
-
-const HistoryAction =
-  action =>
-  ( { type: "History"
-    , history: action
-    }
-  );
-
-export const init =
-  ( isOpen: boolean=false
-  , isExpanded: boolean=false
-  ): [Model, Effects<Action>] => {
-    const query = ''
-    const [search, fx1] = Search.init(query, 5);
-    const [history, fx2] = History.init(query, 5);
-    const fx = Effects.batch
-      ( [ fx1.map(SearchAction)
-        , fx2.map(HistoryAction)
-        ]
-      );
-
-    const model =
-      { isOpen
-      , isExpanded
-      , query
-      , search
-      , history
-      , selected: -1
-    };
-
-    return [model, fx]
+  const model = {
+    isOpen, isExpanded, query, search, history, selected: -1
   };
 
-const reset =
-  model =>
-  init();
+  return [model, fx]
+};
 
-const clear =
-  model =>
-  init(model.isOpen, model.isExpanded);
+const reset = model =>init();
 
-const expand =
-  model =>
-  [ merge
-    ( model
-    , { isOpen: true
-      , isExpanded: true
-      }
-    )
-  , Effects.none
-  ];
+const clear = model =>init(model.isOpen, model.isExpanded);
 
-const open =
-  model =>
-  [ merge
-    ( model
-    , { isOpen: true
-      , isExpanded: false
-      }
-    )
-  , Effects.none
-  ];
+const expand = model =>[
+  merge(model, {
+    isOpen: true, isExpanded: true
+  }), Effects.none
+];
 
-const close =
-  model =>
-  clear
-  ( merge
-    ( model
-    , { isOpen: false
-      , isExpanded: false
-      }
-    )
-  );
+const open = model =>[
+  merge(model, {
+    isOpen: true, isExpanded: false
+  }), Effects.none
+];
 
-const unselect =
-  model =>
-  [ merge
-    ( model
-    , { selected: -1
-      }
-    )
-  , Effects.none
-  ];
+const close = model =>clear(merge(model, {
+  isOpen: false, isExpanded: false
+}));
 
-const query = (model, query) =>
-  ( model.query === query
-  ? [ model
-    , Effects.none
-    ]
-  : batch
-    ( update
-    , merge(model, {query})
-    , [ SearchAction(Search.Query(query))
-      , HistoryAction(History.Query(query))
-      ]
-    )
-  )
+const unselect = model =>[
+  merge(model, {
+    selected: -1
+  }), Effects.none
+];
 
-const updateSearch =
-  cursor
-  ( { get: model => model.search
-    , set: (model, search) => merge(model, {search})
-    , update: Search.update
-    , tag: SearchAction
-    }
-  );
+const query = (model, query) =>( model.query === query ? [
+      model, Effects.none
+    ] : batch(update, merge(model, { query }), [
+      SearchAction(Search.Query(query)), HistoryAction(History.Query(query))
+    ])
+)
 
-const updateHistory =
-  cursor
-  ( { get: model => model.history
-    , set: (model, history) => merge(model, {history})
-    , update: History.update
-    , tag: HistoryAction
-    }
-  );
+const updateSearch = cursor({
+                              get: model => model.search,
+                              set: (model, search) => merge(model, { search }),
+                              update: Search.update,
+                              tag: SearchAction
+                            });
+
+const updateHistory = cursor({
+                               get: model => model.history,
+                               set: (model, history) => merge(model, { history }),
+                               update: History.update,
+                               tag: HistoryAction
+                             });
 
 // TODO: This actually should work across the suggestion
 // groups.
-const suggestNext =
-  model =>
-  updateSearch(model, Search.SelectNext);
+const suggestNext = model =>updateSearch(model, Search.SelectNext);
 
-const suggestPrevious =
-  model =>
-  updateSearch(model, Search.SelectPrevious);
+const suggestPrevious = model =>updateSearch(model, Search.SelectPrevious);
 
-export const update =
-  ( model: Model
-  , action: Action
-  ): [Model, Effects<Action>] => {
-    switch (action.type) {
-      case "Open":
-        return open(model)
-      case "Close":
-        return close(model)
-      case "Expand":
-        return expand(model)
-      case "Reset":
-        return reset(model)
-      case "Unselect":
-        return unselect(model)
-      case "SuggestNext":
-        return suggestNext(model)
-      case "SuggestPrevious":
-        return suggestPrevious(model)
-      case "Query":
-        return query(model, action.query)
-      case "History":
-        return updateHistory(model, action.history)
-      case "Search":
-        return updateSearch(model, action.search)
-      case "Suggest":
-        return [model, Effects.none]
-      default:
-        return Unknown.update(model, action)
-    }
-  };
+export const update = (model:Model, action:Action):[Model, Effects<Action>] => {
+  switch (action.type) {
+    case "Open":
+      return open(model)
+    case "Close":
+      return close(model)
+    case "Expand":
+      return expand(model)
+    case "Reset":
+      return reset(model)
+    case "Unselect":
+      return unselect(model)
+    case "SuggestNext":
+      return suggestNext(model)
+    case "SuggestPrevious":
+      return suggestPrevious(model)
+    case "Query":
+      return query(model, action.query)
+    case "History":
+      return updateHistory(model, action.history)
+    case "Search":
+      return updateSearch(model, action.search)
+    case "Suggest":
+      return [model, Effects.none]
+    default:
+      return Unknown.update(model, action)
+  }
+};
 
-const styleSheet = StyleSheet.create
-  ( { base:
-      { background: 'inherit'
-      , borderColor: 'inherit'
-      , left: '0px'
-      , position: 'absolute'
-      , top: '0px'
-      , width: '100%'
-      }
-    , expanded:
-      { height: '100%'
-      }
-    , shrinked:
-      { minHeight: '110px'
-      }
+const styleSheet = StyleSheet.create({
+                                       base: {
+                                         background: 'inherit',
+                                         borderColor: 'inherit',
+                                         left: '0px',
+                                         position: 'absolute',
+                                         top: '0px',
+                                         width: '100%'
+                                       }, expanded: {
+    height: '100%'
+  }, shrinked: {
+    minHeight: '110px'
+  }
 
-    , open:
-      {
-      }
+                                       , open: {}
 
-    , closed:
-      { display: 'none'
-      }
+                                       , closed: {
+    display: 'none'
+  }
 
-    , results:
-      { listStyle: 'none'
-      , borderColor: 'inherit'
-      , margin: '90px auto 40px'
-      , padding: '0px'
-      , width: '480px'
-      }
-    }
-  );
+                                       , results: {
+    listStyle: 'none', borderColor: 'inherit', margin: '90px auto 40px', padding: '0px', width: '480px'
+  }
+                                     });
 
-export const view =
-  (model: Model, address: Address<Action>): DOM =>
-  html.div
-  ( { className: 'assistant'
-    , style: Style
-      ( styleSheet.base
-      , ( model.isExpanded
-        ? styleSheet.expanded
-        : styleSheet.shrinked
-        )
-      , ( model.isOpen
-        ? styleSheet.open
-        : styleSheet.closed
-        )
-      )
-    }
-  , [ html.ol
-      ( { className: 'assistant-results'
-        , style: styleSheet.results
-        }
-      , [ History.view
-          ( model.history
-          , forward(address, HistoryAction)
-          )
-        , Search.view
-          ( model.search
-          , forward(address, SearchAction)
-          )
-        ]
-      )
-    ]
-  );
+export const view = (model:Model, address:Address<Action>):DOM =>html.div({
+                                                                            className: 'assistant',
+                                                                            style: Style(styleSheet.base,
+                                                                                         ( model.isExpanded
+                                                                                                 ? styleSheet.expanded
+                                                                                                 : styleSheet.shrinked
+                                                                                         ), ( model.isOpen
+                                                                                        ? styleSheet.open
+                                                                                        : styleSheet.closed
+                                                                                         ))
+                                                                          }, [
+                                                                            html.ol({
+                                                                                      className: 'assistant-results',
+                                                                                      style: styleSheet.results
+                                                                                    }, [
+                                                                                      History.view(model.history,
+                                                                                                   forward(address,
+                                                                                                           HistoryAction)),
+                                                                                      Search.view(model.search,
+                                                                                                  forward(address,
+                                                                                                          SearchAction))
+                                                                                    ])
+                                                                          ]);

--- a/src/browser/Navigators/Navigator/Assistant/history.js
+++ b/src/browser/Navigators/Navigator/Assistant/history.js
@@ -5,162 +5,112 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {Effects, Task, html, forward, thunk} from "reflex";
-import {merge, always, batch} from "../../../../common/prelude";
-import {Style, StyleSheet} from '../../../../common/style';
-import {ok, error} from '../../../../common/result';
-
-import * as Title from "./title";
-import * as URL from "./url";
-import * as Icon from "./icon";
-import * as Suggestion from "./suggestion";
-import * as Unknown from '../../../../common/unknown';
+import { Effects, Task, html, forward, thunk } from 'reflex'
+import { merge, always } from '../../../../common/prelude'
+import * as Title from './title'
+import * as URL from './url'
+import * as Icon from './icon'
+import * as Suggestion from './suggestion'
+import * as Unknown from '../../../../common/unknown'
 
 /*::
-import type {Address, DOM, Never} from "reflex";
-import type {Result} from "../../../../common/result";
-import type {Completion, Match, Model, Action} from "./history";
-*/
+ import type {Address, DOM, Never} from "reflex";
+ import type {Result} from "../../../../common/result";
+ import type {Completion, Match, Model, Action} from "./history";
+ */
 
-const NoOp = always({type: "NoOp"});
+const NoOp = always({ type: "NoOp" });
 
-const Abort =
-  queryID =>
-  ( { type: "Abort"
-    , queryID: queryID
-    }
-  );
+const Abort = queryID =>( {
+  type: "Abort", queryID: queryID
+}
+);
 
-export const Query =
-  (input: string): Action =>
-  ( { type: "Query"
-    , source: input
-    }
-  );
+export const Query = (input:string):Action =>( {
+  type: "Query", source: input
+}
+);
 
-const UpdateMatches =
-  (result: Result<Error, Array<Match>>): Action =>
-  ( { type: "UpdateMatches"
-    , source: result
-    }
-  );
+const UpdateMatches = (result:Result<Error, Array<Match>>):Action =>( {
+  type: "UpdateMatches", source: result
+}
+);
 
-const byURI =
-  uri =>
-  action =>
-  ( { type: "ByURI"
-    , source:
-      { uri
-      , action
-      }
-    }
-  );
+const byURI = uri =>action =>( {
+  type: "ByURI", source: {
+    uri, action
+  }
+}
+);
 
 
 const pendingRequests = Object.create(null);
 
-const abort =
-  (id: number): Task<Never, number> =>
-  new Task(succeed => void(0))
+const abort = (id:number):Task<Never, number> =>new Task(succeed => void(0))
 
-const search =
-  ( id: number
-  , input: string
-  , limit: number
-  ): Task<Never, Result<Error, Array<Match>>> =>
-  new Task(succeed => void(0))
+const search = (id:number, input:string, limit:number):Task<Never, Result<Error, Array<Match>>> =>new Task(
+    succeed => void(0))
 
 
-export const init =
-  (query: string, limit: number): [Model, Effects<Action>] =>
-  [ { query
-    , size: 0
-    , queryID: 0
-    , limit
-    , selected: -1
-    , matches: {}
-    , items: []
-    }
-  , Effects.none
-  ]
+export const init = (query:string, limit:number):[Model, Effects<Action>] =>[
+  {
+    query, size: 0, queryID: 0, limit, selected: -1, matches: {}, items: []
+  }, Effects.none
+]
 
-const unselect =
-  model =>
-  [ merge(model, {selected: null})
-  , Effects.none
-  ]
+const unselect = model =>[
+  merge(model, { selected: null }), Effects.none
+]
 
-const selectNext =
-  model =>
-  ( model.selected == null
-  ? [ ( model.size === 0
-      ? model
-      : merge(model, {selected: 0})
-      )
-    , Effects.none
+const selectNext = model =>( model.selected == null ? [
+      ( model.size === 0 ? model : merge(model, { selected: 0 })
+      ), Effects.none
+    ] : model.selected === model.size - 1 ? unselect(model) : [
+      merge(model, { selected: model.selected + 1 }), Effects.none
     ]
-  : model.selected === model.size - 1
-  ? unselect(model)
-  : [ merge(model, {selected: model.selected + 1 })
-    , Effects.none
-    ]
-  )
+)
 
-const selectPrevious =
-  model =>
-  ( model.selected == null
-  ? [ ( model.size === 0
-      ? model
-      : merge(model, {selected: model.size -1 })
-      )
-    , Effects.none
+const selectPrevious = model =>( model.selected == null ? [
+      ( model.size === 0 ? model : merge(model, { selected: model.size - 1 })
+      ), Effects.none
+    ] : model.selected == 0 ? unselect(model) : [
+      merge(model, { selected: model.selected - 1 }), Effects.none
     ]
-  : model.selected == 0
-  ? unselect(model)
-  : [ merge(model, {selected: model.selected - 1 })
-    , Effects.none
-    ]
-  )
+)
 
-const updateQuery =
-  (model, query) =>
-  ( model.query === query
-  ? [ model, Effects.none ]
-  : [ merge(model, {query, queryID: model.queryID + 1 })
-    , Effects.batch
-      ( [ Effects.perform(abort(model.queryID))
-          .map(Abort)
+const updateQuery = (model, query) =>( model.query === query ? [model, Effects.none] : [
+      merge(model, { query, queryID: model.queryID + 1 }), Effects.batch([
+                                                                           Effects.perform(abort(model.queryID))
+                                                                                  .map(Abort)
 
-        , Effects.perform
-          (search(model.queryID + 1, query, model.limit))
-          .map(UpdateMatches)
-        ]
-      )
+                                                                           ,
+                                                                           Effects.perform(
+                                                                               search(model.queryID + 1, query,
+                                                                                      model.limit))
+                                                                                  .map(UpdateMatches)
+                                                                         ])
     ]
-  );
+);
 
 
-const updateMatches = (model, result) =>
-  ( result.isOk
-  ? replaceMatches(model, result.value)
-  : [ model
-    , Effects
-      .perform(Unknown.error(result.error))
-      .map(NoOp)
+const updateMatches = (model, result) =>( result.isOk ? replaceMatches(model, result.value) : [
+      model, Effects
+          .perform(Unknown.error(result.error))
+          .map(NoOp)
     ]
-  )
+)
 
 const replaceMatches = (model, results) => {
   const items = results.map(match => match.uri)
   const matches = {}
   results.forEach(match => matches[match.uri] = match)
-  return [retainSelected(model, {matches, items}), Effects.none]
+  return [retainSelected(model, { matches, items }), Effects.none]
 }
 
 // If updated entries no longer have item that was selected we reset
 // a selection. Otherwise we update a selection to have it keep the item
 // which was selected.
-const retainSelected = (model, {matches, items}) => {
+const retainSelected = (model, { matches, items }) => {
   // If there was no selected entry there is nothing to retain so
   // return as is.
   let selected = model.selected
@@ -173,54 +123,34 @@ const retainSelected = (model, {matches, items}) => {
     selected = items.indexOf(uri)
   }
   const size = Math.min(model.limit, items.length)
-  return merge(model, {size, selected, items, matches})
+  return merge(model, { size, selected, items, matches })
 };
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] =>
-  ( action.type === "Query"
-  ? updateQuery(model, action.source)
-  : action.type === "SelectNext"
-  ? selectNext(model)
-  : action.type === "SelectPrevious"
-  ? selectPrevious(model)
-  : action.type === "Unselect"
-  ? unselect(model)
-  : action.type === "UpdateMatches"
-  ? updateMatches(model, action.source)
-  : Unknown.update(model, action)
-  )
+export const update = (model:Model, action:Action):[Model, Effects<Action>] =>( action.type === "Query"
+        ? updateQuery(model, action.source)
+        : action.type === "SelectNext"
+        ? selectNext(model)
+        : action.type === "SelectPrevious"
+        ? selectPrevious(model)
+        : action.type === "Unselect"
+        ? unselect(model)
+        : action.type === "UpdateMatches"
+        ? updateMatches(model, action.source)
+        : Unknown.update(model, action)
+)
 
-const innerView =
-  (model, address, isSelected) =>
-  [ Icon.view('', isSelected)
-  , Title.view(model.title, isSelected)
-  , URL.view(model.uri, isSelected)
-  ];
+const innerView = (model, address, isSelected) =>[
+  Icon.view('', isSelected), Title.view(model.title, isSelected), URL.view(model.uri, isSelected)
+];
 
 
-export const render =
-  (model: Model, address: Address<Action>): DOM =>
-  html.section
-  ( { style: {borderColor: 'inherit' } }
-  , model.items.map
-    ( (uri, index) =>
-      Suggestion.view
-      ( model.selected === index
-      , innerView
-        ( model.matches[uri]
-        , forward(address, byURI(uri))
-        , model.selected === index
-        )
-      )
-    )
-  )
+export const render = (model:Model, address:Address<Action>):DOM =>html.section({ style: { borderColor: 'inherit' } },
+                                                                                model.items.map(
+                                                                                    (uri, index) =>Suggestion.view(
+                                                                                        model.selected === index,
+                                                                                        innerView(model.matches[uri],
+                                                                                                  forward(address,
+                                                                                                          byURI(uri)),
+                                                                                                  model.selected === index))))
 
-export const view =
-  (model: Model, address: Address<Action>): DOM =>
-  thunk
-  ( 'history'
-  , render
-  , model
-  , address
-  );
+export const view = (model:Model, address:Address<Action>):DOM =>thunk('history', render, model, address);

--- a/src/browser/Navigators/Navigator/Assistant/history.js
+++ b/src/browser/Navigators/Navigator/Assistant/history.js
@@ -32,14 +32,14 @@ const Abort =
   );
 
 export const Query =
-  (input/*:string*/)/*:Action*/ =>
+  (input: string): Action =>
   ( { type: "Query"
     , source: input
     }
   );
 
 const UpdateMatches =
-  (result/*:Result<Error, Array<Match>>*/)/*:Action*/ =>
+  (result: Result<Error, Array<Match>>): Action =>
   ( { type: "UpdateMatches"
     , source: result
     }
@@ -60,19 +60,19 @@ const byURI =
 const pendingRequests = Object.create(null);
 
 const abort =
-  (id/*:number*/)/*:Task<Never, number>*/ =>
+  (id: number): Task<Never, number> =>
   new Task(succeed => void(0))
 
 const search =
-  ( id/*:number*/
-  , input/*:string*/
-  , limit/*:number*/
-  )/*:Task<Never, Result<Error, Array<Match>>>*/ =>
+  ( id: number
+  , input: string
+  , limit: number
+  ): Task<Never, Result<Error, Array<Match>>> =>
   new Task(succeed => void(0))
 
 
 export const init =
-  (query/*:string*/, limit/*:number*/)/*:[Model, Effects<Action>]*/ =>
+  (query: string, limit: number): [Model, Effects<Action>] =>
   [ { query
     , size: 0
     , queryID: 0
@@ -177,7 +177,7 @@ const retainSelected = (model, {matches, items}) => {
 };
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model: Model, action: Action): [Model, Effects<Action>] =>
   ( action.type === "Query"
   ? updateQuery(model, action.source)
   : action.type === "SelectNext"
@@ -200,7 +200,7 @@ const innerView =
 
 
 export const render =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>): DOM =>
   html.section
   ( { style: {borderColor: 'inherit' } }
   , model.items.map
@@ -217,7 +217,7 @@ export const render =
   )
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>): DOM =>
   thunk
   ( 'history'
   , render

--- a/src/browser/Navigators/Navigator/Assistant/icon.js
+++ b/src/browser/Navigators/Navigator/Assistant/icon.js
@@ -35,7 +35,7 @@ const styleSheet = StyleSheet.create
   );
 
 export const render =
-  (content/*:string*/, isSelected/*:boolean*/)/*:DOM*/ =>
+  (content: string, isSelected: boolean): DOM =>
   html.span
   ( { className: 'assistant icon'
     , style: Style
@@ -51,7 +51,7 @@ export const render =
   );
 
 export const view =
-  (content/*:string*/, isSelected/*:boolean*/)/*:DOM*/ =>
+  (content: string, isSelected: boolean): DOM =>
   thunk
   ( `${content}`
   , render

--- a/src/browser/Navigators/Navigator/Assistant/icon.js
+++ b/src/browser/Navigators/Navigator/Assistant/icon.js
@@ -5,56 +5,33 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {Effects, html, forward, thunk} from "reflex";
-import {merge, always, batch} from "../../../../common/prelude";
-import {Style, StyleSheet} from '../../../../common/style';
+import { html, thunk } from 'reflex'
+import { Style, StyleSheet } from '../../../../common/style'
 
 /*::
-import type {Address, DOM} from "reflex"
-*/
+ import type {Address, DOM} from "reflex"
+ */
 
 
-const styleSheet = StyleSheet.create
-  ( { base:
-      { fontFamily: 'FontAwesome'
-      , fontSize: '17px'
-      , left: '13px'
-      , position: 'absolute'
-      // top:0 should not be required, but it's necessary for Servo.
-      // See https://github.com/servo/servo/issues/9687
-      , top: '0'
-      }
-    , selected:
-      { color: '#fff'
-      }
-    , unselected:
-      {
+const styleSheet = StyleSheet.create({
+                                       base: {
+                                         fontFamily: 'FontAwesome', fontSize: '17px', left: '13px', position: 'absolute'
+                                         // top:0 should not be required, but it's necessary for Servo.
+                                         // See https://github.com/servo/servo/issues/9687
+                                         , top: '0'
+                                       }, selected: {
+    color: '#fff'
+  }, unselected: {}
+                                     });
 
-      }
-    }
-  );
+export const render = (content:string, isSelected:boolean):DOM =>html.span({
+                                                                             className: 'assistant icon',
+                                                                             style: Style(styleSheet.base, ( isSelected
+                                                                                     ? styleSheet.selected
+                                                                                     : styleSheet.unselected
+                                                                             ))
+                                                                           }, [
+                                                                             content
+                                                                           ]);
 
-export const render =
-  (content: string, isSelected: boolean): DOM =>
-  html.span
-  ( { className: 'assistant icon'
-    , style: Style
-      ( styleSheet.base
-      , ( isSelected
-        ? styleSheet.selected
-        : styleSheet.unselected
-        )
-      )
-    }
-  , [ content
-    ]
-  );
-
-export const view =
-  (content: string, isSelected: boolean): DOM =>
-  thunk
-  ( `${content}`
-  , render
-  , content
-  , isSelected
-  );
+export const view = (content:string, isSelected:boolean):DOM =>thunk(`${content}`, render, content, isSelected);

--- a/src/browser/Navigators/Navigator/Assistant/search.js
+++ b/src/browser/Navigators/Navigator/Assistant/search.js
@@ -5,259 +5,170 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {Effects, Task, html, forward, thunk} from "reflex";
-import {merge, always, batch} from "../../../../common/prelude";
-import {Style, StyleSheet} from '../../../../common/style';
-import {indexOfOffset} from "../../../../common/selector";
-import {ok, error} from '../../../../common/result';
-
-import * as Title from "./title";
-import * as Icon from "./icon";
-import * as Suggestion from "./suggestion";
-import * as Unknown from '../../../../common/unknown';
+import { Effects, Task, html, forward, thunk } from 'reflex'
+import { merge, always } from '../../../../common/prelude'
+import { indexOfOffset } from '../../../../common/selector'
+import { ok, error } from '../../../../common/result'
+import * as Title from './title'
+import * as Icon from './icon'
+import * as Suggestion from './suggestion'
+import * as Unknown from '../../../../common/unknown'
 
 /*::
-import type {Address, DOM, Never} from "reflex";
-import type {Result} from "../../../../common/result";
-import type {Completion, Match, Model, Action} from "./search";
-*/
+ import type {Address, DOM, Never} from "reflex";
+ import type {Result} from "../../../../common/result";
+ import type {Completion, Match, Model, Action} from "./search";
+ */
 
-const NoOp = always({type: "NoOp"});
+const NoOp = always({ type: "NoOp" });
 
-const Abort =
-  queryID =>
-  ( { type: "Abort"
-    , source: queryID
-    }
-  );
+const Abort = queryID =>( {
+  type: "Abort", source: queryID
+}
+);
 
 export const SelectNext = { type: "SelectNext" };
 export const SelectPrevious = { type: "SelectPrevious" };
-export const Suggest =
-  (suggestion: Completion): Action =>
-  ( { type: "Suggest"
-    , source: suggestion
-    }
-  );
+export const Suggest = (suggestion:Completion):Action =>( {
+  type: "Suggest", source: suggestion
+}
+);
 
-export const Query =
-  (input: string): Action =>
-  ( { type: "Query"
-    , source: input
-    }
-  );
+export const Query = (input:string):Action =>( {
+  type: "Query", source: input
+}
+);
 
-export const Activate =
-  (): Action =>
-  ( { type: "Activate"
-    }
-  );
+export const Activate = ():Action =>( {
+  type: "Activate"
+}
+);
 
-const Load =
-  (uri) =>
-  ( { type: "Load"
-    , uri
-    }
-  );
+const Load = (uri) =>( {
+  type: "Load", uri
+}
+);
 
-const UpdateMatches =
-  (result: Result<Error, Array<Match>>): Action =>
-  ( { type: "UpdateMatches"
-    , source: result
-    }
-  );
+const UpdateMatches = (result:Result<Error, Array<Match>>):Action =>( {
+  type: "UpdateMatches", source: result
+}
+);
 
-const byURI =
-  uri =>
-  action =>
-  ( { type: "ByURI"
-    , source:
-      { uri
-      , action
-      }
-    }
-  );
+const byURI = uri =>action =>( {
+  type: "ByURI", source: {
+    uri, action
+  }
+}
+);
 
-const decodeFailure = ({target: request}) =>
-  error
+const decodeFailure = ({ target: request }) =>error
   // @FlowIssue: Flow does not know about `request.url`
   (Error(`Network request to ${request.url} has failed: ${request.statusText}`));
 
-const decodeResponseFailure =
-  request =>
-  // @FlowIssue: Flow does not know about `request.response`
-  error(Error(`Can not decode ${request.respose} received from ${request.url}`))
+const decodeResponseFailure = request =>// @FlowIssue: Flow does not know about `request.response`
+    error(Error(`Can not decode ${request.respose} received from ${request.url}`))
 
-const decodeMatches =
-  matches =>
-  ( Array.isArray(matches)
-  ? ok(matches.map(decodeMatch))
-  : error(Error(`Can not decode non array matches ${matches}`))
-  );
+const decodeMatches = matches =>( Array.isArray(matches) ? ok(matches.map(decodeMatch)) : error(
+        Error(`Can not decode non array matches ${matches}`))
+);
 
-const decodeMatch =
-  match =>
-  ( { title: match
-    , uri: `https://duckduckgo.com/?q=${encodeURIComponent(match)}`
-    }
-  );
+const decodeMatch = match =>( {
+  title: match, uri: `https://duckduckgo.com/?q=${encodeURIComponent(match)}`
+}
+);
 
-const decodeResponse = ({target: request}) =>
-  // @FlowIssue: Flow does not know about `request.responseType`
-  ( request.responseType !== 'json'
-  // @FlowIssue: Flow does not know about `request.url`
-  ? error(Error(`Can not decode ${request.responseType} type response from ${request.url}`))
-  : request.response == null
-  ? decodeResponseFailure(request)
-  : request.response[1] == null
-  ? decodeResponseFailure(request)
-  : decodeMatches(request.response[1])
-  );
+const decodeResponse = ({ target: request }) =>// @FlowIssue: Flow does not know about `request.responseType`
+    ( request.responseType !== 'json'
+            // @FlowIssue: Flow does not know about `request.url`
+            ? error(Error(`Can not decode ${request.responseType} type response from ${request.url}`))
+            : request.response == null
+            ? decodeResponseFailure(request)
+            : request.response[1] == null
+            ? decodeResponseFailure(request)
+            : decodeMatches(request.response[1])
+    );
 
 const pendingRequests = Object.create(null);
 
-const abort =
-  id =>
-  new Task((succeed, fail) => {
-    if (pendingRequests[id] != null) {
-      pendingRequests[id].abort();
-      delete pendingRequests[id];
-    }
-  })
+const abort = id =>new Task((succeed, fail) => {
+  if (pendingRequests[id] != null) {
+    pendingRequests[id].abort();
+    delete pendingRequests[id];
+  }
+})
 
-const search =
-  ( id: number
-  , input: string
-  , limit: number
-  ): Task<Never, Result<Error, Array<Match>>> =>
-  new Task((succeed, fail) => {
-    const request = new XMLHttpRequest({ mozSystem: true });
-    pendingRequests[id] = request;
-    const uri = `http://ac.duckduckgo.com/ac/?q=${input}&type=list`
-    request.open
-    ( 'GET'
-    , uri
-    , true
-    );
-    request.responseType = 'json';
-    // @FlowIgnore: We need this property
-    request.url = uri;
+const search = (id:number, input:string, limit:number):Task<Never, Result<Error, Array<Match>>> =>new Task((succeed,
+                                                                                                            fail) => {
+  const request = new XMLHttpRequest({ mozSystem: true });
+  pendingRequests[id] = request;
+  const uri = `http://ac.duckduckgo.com/ac/?q=${input}&type=list`
+  request.open('GET', uri, true);
+  request.responseType = 'json';
+  // @FlowIgnore: We need this property
+  request.url = uri;
 
-    request.onerror = event => {
-      delete pendingRequests[id];
-      succeed(decodeFailure(event));
-    };
-    request.onload = event => {
-      delete pendingRequests[id];
-      succeed(decodeResponse(event));
-    };
+  request.onerror = event => {
+    delete pendingRequests[id];
+    succeed(decodeFailure(event));
+  };
+  request.onload = event => {
+    delete pendingRequests[id];
+    succeed(decodeResponse(event));
+  };
 
-    request.send();
-  });
+  request.send();
+});
 
 
-export const init =
-  (query: string, limit: number): [Model, Effects<Action>] =>
-  [ { query
-    , size: 0
-    , queryID: 0
-    , limit
-    , selected: -1
-    , matches: {}
-    , items: []
-    }
-  , Effects.none
-  ]
+export const init = (query:string, limit:number):[Model, Effects<Action>] =>[
+  {
+    query, size: 0, queryID: 0, limit, selected: -1, matches: {}, items: []
+  }, Effects.none
+]
 
-const unselect =
-  model =>
-  [ merge(model, {selected: -1})
-  , Effects.none
-  ]
+const unselect = model =>[
+  merge(model, { selected: -1 }), Effects.none
+]
 
-const suggest = model =>
-  [ model
-  , Effects.receive
-    ( Suggest
-      ( { match: model.matches[model.items[model.selected]].title
-        , hint: ''
-        }
-      )
-    )
-  ]
+const suggest = model =>[
+  model, Effects.receive(Suggest({
+                                   match: model.matches[model.items[model.selected]].title, hint: ''
+                                 }))
+]
 
-const selectNext =
-  model =>
-  suggest
-  ( merge
-    ( model
-    , { selected:
-        indexOfOffset
-        ( model.selected
-        , 1
-        , model.size
-        , true
-        )
-      }
-    )
-  )
+const selectNext = model =>suggest(merge(model, {
+  selected: indexOfOffset(model.selected, 1, model.size, true)
+}))
 
-const selectPrevious =
-  model =>
-  suggest
-  ( merge
-    ( model
-    , { selected:
-        indexOfOffset
-        ( model.selected
-        , -1
-        , model.size
-        , true
-        )
-      }
-    )
-  )
+const selectPrevious = model =>suggest(merge(model, {
+  selected: indexOfOffset(model.selected, -1, model.size, true)
+}))
 
-const updateQuery =
-  (model, query) =>
-  ( model.query === query
-  ? [ model, Effects.none ]
-  : query.trim() === ""
-  ? [ merge
-      ( model
-      , { query: ""
-        , selected: -1
-        , matches: {}
-        , items: []
-        }
-      )
-    , Effects.perform
-      (abort(model.queryID))
-      .map(Abort)
+const updateQuery = (model, query) =>( model.query === query ? [model, Effects.none] : query.trim() === "" ? [
+      merge(model, {
+        query: "", selected: -1, matches: {}, items: []
+      }), Effects.perform(abort(model.queryID))
+                 .map(Abort)
+    ] : [
+      merge(model, { query, queryID: model.queryID + 1 }), Effects.batch([
+                                                                           Effects.perform(abort(model.queryID))
+                                                                                  .map(Abort)
+
+                                                                           ,
+                                                                           Effects.perform(
+                                                                               search(model.queryID + 1, query,
+                                                                                      model.limit))
+                                                                                  .map(UpdateMatches)
+                                                                         ])
     ]
-  : [ merge(model, {query, queryID: model.queryID + 1 })
-    , Effects.batch
-      ( [ Effects.perform
-          (abort(model.queryID))
-          .map(Abort)
+);
 
-        , Effects.perform
-          (search(model.queryID + 1, query, model.limit))
-          .map(UpdateMatches)
-        ]
-      )
+
+const updateMatches = (model, result) =>( result.isOk ? replaceMatches(model, result.value) : [
+      model, Effects.perform(Unknown.error(result.error))
+                    .map(NoOp)
     ]
-  );
-
-
-const updateMatches = (model, result) =>
-  ( result.isOk
-  ? replaceMatches(model, result.value)
-  : [ model
-    , Effects.perform(Unknown.error(result.error))
-      .map(NoOp)
-    ]
-  );
+);
 
 const replaceMatches = (model, results) => {
   const top = results[0]
@@ -276,13 +187,13 @@ const replaceMatches = (model, results) => {
   // return [retainSelected(model, {matches, items}), Effects.none]
   const size = Math.min(model.limit, items.length);
   const selected = 0;
-  return suggest(merge(model, {matches, items, size, selected}));
+  return suggest(merge(model, { matches, items, size, selected }));
 }
 
 // If updated entries no longer have item that was selected we reset
 // a selection  . Otherwise we update a selection to have it keep the item
 // which was selected.
-const retainSelected = (model, {matches, items}) => {
+const retainSelected = (model, { matches, items }) => {
   // If there was no selected entry there is nothing to retain so
   // return as is.
   let selected = model.selected
@@ -295,74 +206,46 @@ const retainSelected = (model, {matches, items}) => {
     selected = items.indexOf(uri)
   }
   const size = Math.min(model.limit, items.length)
-  return merge(model, {size, selected, items, matches})
+  return merge(model, { size, selected, items, matches })
 };
 
-const updateByURI =
-  (model, {uri, action}) =>
-  [model, Effects.none];
+const updateByURI = (model, { uri, action }) =>[model, Effects.none];
 
-const activate =
-  model =>
-  [ model
-  , ( model.selected < 0
-    ? Effects.none
-    : Effects.receive
-      ( Load(model.matches[model.items[model.selected]].uri)
-      )
-    )
-  ]
-
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] =>
-  ( action.type === "Query"
-  ? updateQuery(model, action.source)
-  : action.type === "SelectNext"
-  ? selectNext(model)
-  : action.type === "SelectPrevious"
-  ? selectPrevious(model)
-  : action.type === "Unselect"
-  ? unselect(model)
-  : action.type === "UpdateMatches"
-  ? updateMatches(model, action.source)
-  : action.type === "ByURI"
-  ? updateByURI(model, action.source)
-  : action.type === "Activate"
-  ? activate(model)
-  : Unknown.update(model, action)
+const activate = model =>[
+  model, ( model.selected < 0 ? Effects.none : Effects.receive(Load(model.matches[model.items[model.selected]].uri))
   )
+]
 
-const innerView =
-  (model, address, isSelected) =>
-  [ Icon.view('', isSelected)
-  , Title.view(model.title, isSelected)
-  ];
+export const update = (model:Model, action:Action):[Model, Effects<Action>] =>( action.type === "Query"
+        ? updateQuery(model, action.source)
+        : action.type === "SelectNext"
+        ? selectNext(model)
+        : action.type === "SelectPrevious"
+        ? selectPrevious(model)
+        : action.type === "Unselect"
+        ? unselect(model)
+        : action.type === "UpdateMatches"
+        ? updateMatches(model, action.source)
+        : action.type === "ByURI"
+        ? updateByURI(model, action.source)
+        : action.type === "Activate"
+        ? activate(model)
+        : Unknown.update(model, action)
+)
 
-export const render =
-  (model: Model, address: Address<Action>): DOM =>
-  html.section
-  ( { style: {borderColor: 'inherit' } }
-  , model
-    .items
-    .slice(0, model.limit)
-    .map
-    ( (uri, index) =>
-      Suggestion.view
-      ( model.selected === index
-      , innerView
-        ( model.matches[uri]
-        , forward(address, byURI(uri))
-        , model.selected === index
-        )
-      )
-    )
-  )
+const innerView = (model, address, isSelected) =>[
+  Icon.view('', isSelected), Title.view(model.title, isSelected)
+];
 
-export const view =
-  (model: Model, address: Address<Action>): DOM =>
-  thunk
-  ( 'search'
-  , render
-  , model
-  , address
-  );
+export const render = (model:Model, address:Address<Action>):DOM =>html.section({ style: { borderColor: 'inherit' } },
+                                                                                model
+                                                                                    .items
+                                                                                    .slice(0, model.limit)
+                                                                                    .map((uri, index) =>Suggestion.view(
+                                                                                        model.selected === index,
+                                                                                        innerView(model.matches[uri],
+                                                                                                  forward(address,
+                                                                                                          byURI(uri)),
+                                                                                                  model.selected === index))))
+
+export const view = (model:Model, address:Address<Action>):DOM =>thunk('search', render, model, address);

--- a/src/browser/Navigators/Navigator/Assistant/search.js
+++ b/src/browser/Navigators/Navigator/Assistant/search.js
@@ -34,21 +34,21 @@ const Abort =
 export const SelectNext = { type: "SelectNext" };
 export const SelectPrevious = { type: "SelectPrevious" };
 export const Suggest =
-  (suggestion/*:Completion*/)/*:Action*/ =>
+  (suggestion: Completion): Action =>
   ( { type: "Suggest"
     , source: suggestion
     }
   );
 
 export const Query =
-  (input/*:string*/)/*:Action*/ =>
+  (input: string): Action =>
   ( { type: "Query"
     , source: input
     }
   );
 
 export const Activate =
-  ()/*:Action*/ =>
+  (): Action =>
   ( { type: "Activate"
     }
   );
@@ -61,7 +61,7 @@ const Load =
   );
 
 const UpdateMatches =
-  (result/*:Result<Error, Array<Match>>*/)/*:Action*/ =>
+  (result: Result<Error, Array<Match>>): Action =>
   ( { type: "UpdateMatches"
     , source: result
     }
@@ -126,10 +126,10 @@ const abort =
   })
 
 const search =
-  ( id/*:number*/
-  , input/*:string*/
-  , limit/*:number*/
-  )/*:Task<Never, Result<Error, Array<Match>>>*/ =>
+  ( id: number
+  , input: string
+  , limit: number
+  ): Task<Never, Result<Error, Array<Match>>> =>
   new Task((succeed, fail) => {
     const request = new XMLHttpRequest({ mozSystem: true });
     pendingRequests[id] = request;
@@ -157,7 +157,7 @@ const search =
 
 
 export const init =
-  (query/*:string*/, limit/*:number*/)/*:[Model, Effects<Action>]*/ =>
+  (query: string, limit: number): [Model, Effects<Action>] =>
   [ { query
     , size: 0
     , queryID: 0
@@ -314,7 +314,7 @@ const activate =
   ]
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model: Model, action: Action): [Model, Effects<Action>] =>
   ( action.type === "Query"
   ? updateQuery(model, action.source)
   : action.type === "SelectNext"
@@ -339,7 +339,7 @@ const innerView =
   ];
 
 export const render =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>): DOM =>
   html.section
   ( { style: {borderColor: 'inherit' } }
   , model
@@ -359,7 +359,7 @@ export const render =
   )
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>): DOM =>
   thunk
   ( 'search'
   , render

--- a/src/browser/Navigators/Navigator/Assistant/suggestion.js
+++ b/src/browser/Navigators/Navigator/Assistant/suggestion.js
@@ -42,7 +42,7 @@ const styleSheet = StyleSheet.create
   );
 
 export const render =
-  (isSelected/*:boolean*/, content/*:Array<DOM>*/)/*:DOM*/ =>
+  (isSelected: boolean, content: Array<DOM>): DOM =>
   html.li
   ( { className: 'assistant suggestion'
     , style: Style

--- a/src/browser/Navigators/Navigator/Assistant/suggestion.js
+++ b/src/browser/Navigators/Navigator/Assistant/suggestion.js
@@ -5,55 +5,46 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {html, thunk} from "reflex";
-import {Style, StyleSheet} from '../../../../common/style';
+import { html } from 'reflex'
+import { Style, StyleSheet } from '../../../../common/style'
 
 /*::
-import type {Address, DOM} from "reflex"
-*/
+ import type {Address, DOM} from "reflex"
+ */
 
 
-const styleSheet = StyleSheet.create
-  ( { base:
-      { lineHeight: '40px'
-      , overflow: 'hidden'
-      , paddingLeft: '35px'
-      , paddingRight: '10px'
-      // Contains absolute elements.
-      , position: 'relative'
-      , whiteSpace: 'nowrap'
-      , textOverflow: 'ellipsis'
-      , borderLeft: 'none'
-      , borderRight: 'none'
-      , borderTop: 'none'
-      , borderBottom: '1px solid'
-      , color: 'inherit'
-      , borderColor: 'inherit'
-      , marginTop: '1px'
-      }
-    , unselected:
-      { opacity: 0.7
-      }
-    , selected:
-      { background: '#4A90E2'
-      , borderRadius: '3px'
-      }
-    }
-  );
+const styleSheet = StyleSheet.create({
+                                       base: {
+                                         lineHeight: '40px',
+                                         overflow: 'hidden',
+                                         paddingLeft: '35px',
+                                         paddingRight: '10px'
+                                         // Contains absolute elements.
+                                         ,
+                                         position: 'relative',
+                                         whiteSpace: 'nowrap',
+                                         textOverflow: 'ellipsis',
+                                         borderLeft: 'none',
+                                         borderRight: 'none',
+                                         borderTop: 'none',
+                                         borderBottom: '1px solid',
+                                         color: 'inherit',
+                                         borderColor: 'inherit',
+                                         marginTop: '1px'
+                                       }, unselected: {
+    opacity: 0.7
+  }, selected: {
+    background: '#4A90E2', borderRadius: '3px'
+  }
+                                     });
 
-export const render =
-  (isSelected: boolean, content: Array<DOM>): DOM =>
-  html.li
-  ( { className: 'assistant suggestion'
-    , style: Style
-      ( styleSheet.base
-      , ( isSelected
-        ? styleSheet.selected
-        : styleSheet.unselected
-        )
-      )
-    }
-  , content
-  );
+export const render = (isSelected:boolean, content:Array<DOM>):DOM =>html.li({
+                                                                               className: 'assistant suggestion',
+                                                                               style: Style(styleSheet.base,
+                                                                                            ( isSelected
+                                                                                                    ? styleSheet.selected
+                                                                                                    : styleSheet.unselected
+                                                                                            ))
+                                                                             }, content);
 
 export const view = render

--- a/src/browser/Navigators/Navigator/Assistant/title.js
+++ b/src/browser/Navigators/Navigator/Assistant/title.js
@@ -29,7 +29,7 @@ const styleSheet = StyleSheet.create
   );
 
 export const render =
-  (title/*:?string*/, isSelected/*:boolean*/)/*:DOM*/ =>
+  (title: ?string, isSelected: boolean): DOM =>
   html.span
   ( { className: 'assistant title'
     , style: Style
@@ -48,7 +48,7 @@ export const render =
   );
 
 export const view =
-  (title/*:?string*/, isSelected/*:boolean*/)/*:DOM*/ =>
+  (title: ?string, isSelected: boolean): DOM =>
   thunk
   ( `${title}`
   , render

--- a/src/browser/Navigators/Navigator/Assistant/title.js
+++ b/src/browser/Navigators/Navigator/Assistant/title.js
@@ -5,53 +5,31 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {Effects, html, forward, thunk} from "reflex";
-import {merge, always, batch} from "../../../../common/prelude";
-import {Style, StyleSheet} from '../../../../common/style';
+import { html, thunk } from 'reflex'
+import { Style, StyleSheet } from '../../../../common/style'
 
 /*::
-import type {Address, DOM} from "reflex"
-*/
+ import type {Address, DOM} from "reflex"
+ */
 
 
-const styleSheet = StyleSheet.create
-  ( { base:
-      { fontSize: '14px'
-      }
-    , selected:
-      { color: '#fff'
-      }
-    , unselected:
-      {
+const styleSheet = StyleSheet.create({
+                                       base: {
+                                         fontSize: '14px'
+                                       }, selected: {
+    color: '#fff'
+  }, unselected: {}
+                                     });
 
-      }
-    }
-  );
+export const render = (title:?string, isSelected:boolean):DOM =>html.span({
+                                                                            className: 'assistant title',
+                                                                            style: Style(styleSheet.base, ( isSelected
+                                                                                    ? styleSheet.selected
+                                                                                    : styleSheet.unselected
+                                                                            ))
+                                                                          }, [
+                                                                            ( title == null ? 'Untitled' : `${title}`
+                                                                            )
+                                                                          ]);
 
-export const render =
-  (title: ?string, isSelected: boolean): DOM =>
-  html.span
-  ( { className: 'assistant title'
-    , style: Style
-      ( styleSheet.base
-      , ( isSelected
-        ? styleSheet.selected
-        : styleSheet.unselected
-        )
-      )
-    }
-  , [ ( title == null
-      ? 'Untitled'
-      : `${title}`
-      )
-    ]
-  );
-
-export const view =
-  (title: ?string, isSelected: boolean): DOM =>
-  thunk
-  ( `${title}`
-  , render
-  , title
-  , isSelected
-  );
+export const view = (title:?string, isSelected:boolean):DOM =>thunk(`${title}`, render, title, isSelected);

--- a/src/browser/Navigators/Navigator/Assistant/url.js
+++ b/src/browser/Navigators/Navigator/Assistant/url.js
@@ -5,58 +5,36 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {Effects, html, forward, thunk} from "reflex";
-import {merge, always, batch} from "../../../../common/prelude";
-import {Style, StyleSheet} from '../../../../common/style';
-import * as URL from '../../../../common/url-helper';
+import { html, thunk } from 'reflex'
+import { Style, StyleSheet } from '../../../../common/style'
+import * as URL from '../../../../common/url-helper'
 
 /*::
-import type {Address, DOM} from "reflex";
-import type {URI} from "./url";
-*/
+ import type {Address, DOM} from "reflex";
+ import type {URI} from "./url";
+ */
 
 
-const styleSheet = StyleSheet.create
-  ( { base:
-      { fontSize: '14px'
-      }
-    , selected:
-      { color: 'rgba(255,255,255,0.7)'
-      }
-    , unselected:
-      {
+const styleSheet = StyleSheet.create({
+                                       base: {
+                                         fontSize: '14px'
+                                       }, selected: {
+    color: 'rgba(255,255,255,0.7)'
+  }, unselected: {}
+                                     });
 
-      }
-    }
-  );
+const preventDefault = event =>event.preventDefault();
 
-const preventDefault =
-  event =>
-  event.preventDefault();
+export const render = (uri:URI, isSelected:boolean):DOM =>html.a({
+                                                                   className: 'assistant url',
+                                                                   style: Style(styleSheet.base, ( isSelected
+                                                                           ? styleSheet.selected
+                                                                           : styleSheet.unselected
+                                                                   )),
+                                                                   href: uri,
+                                                                   onClick: preventDefault
+                                                                 }, [
+                                                                   ` - ${URL.prettify(uri)}`
+                                                                 ]);
 
-export const render =
-  (uri: URI, isSelected: boolean): DOM =>
-  html.a
-  ( { className: 'assistant url'
-    , style: Style
-      ( styleSheet.base
-      , ( isSelected
-        ? styleSheet.selected
-        : styleSheet.unselected
-        )
-      )
-    , href: uri
-    , onClick: preventDefault
-    }
-  , [ ` - ${URL.prettify(uri)}`
-    ]
-  );
-
-export const view =
-  (uri: URI, isSelected: boolean): DOM =>
-  thunk
-  ( uri
-  , render
-  , uri
-  , isSelected
-  );
+export const view = (uri:URI, isSelected:boolean):DOM =>thunk(uri, render, uri, isSelected);

--- a/src/browser/Navigators/Navigator/Assistant/url.js
+++ b/src/browser/Navigators/Navigator/Assistant/url.js
@@ -35,7 +35,7 @@ const preventDefault =
   event.preventDefault();
 
 export const render =
-  (uri/*:URI*/, isSelected/*:boolean*/)/*:DOM*/ =>
+  (uri: URI, isSelected: boolean): DOM =>
   html.a
   ( { className: 'assistant url'
     , style: Style
@@ -53,7 +53,7 @@ export const render =
   );
 
 export const view =
-  (uri/*:URI*/, isSelected/*:boolean*/)/*:DOM*/ =>
+  (uri: URI, isSelected: boolean): DOM =>
   thunk
   ( uri
   , render

--- a/src/browser/Navigators/Navigator/Display.js
+++ b/src/browser/Navigators/Navigator/Display.js
@@ -11,7 +11,7 @@ export class Model {
   opacity: Float;
   */
   constructor(
-    opacity/*:Float*/
+    opacity: Float
   ) {
     this.opacity = opacity
   }
@@ -22,10 +22,10 @@ export const deselected = new Model(0)
 export const closed = new Model(0)
 
 export const interpolate =
-  ( from/*:Model*/
-  , to/*:Model*/
-  , progress/*:Float*/
-  )/*:Model*/ =>
+  ( from: Model
+  , to: Model
+  , progress: Float
+  ): Model =>
   new Model
   ( Easing.float(from.opacity, to.opacity, progress)
   )

--- a/src/browser/Navigators/Navigator/Display.js
+++ b/src/browser/Navigators/Navigator/Display.js
@@ -1,18 +1,16 @@
 /* @flow */
 
-import * as Easing from "eased";
+import * as Easing from 'eased'
 
 /*::
-import type {Float} from "../../../common/prelude"
-*/
+ import type {Float} from "../../../common/prelude"
+ */
 
 export class Model {
   /*::
-  opacity: Float;
-  */
-  constructor(
-    opacity: Float
-  ) {
+   opacity: Float;
+   */
+  constructor(opacity:Float) {
     this.opacity = opacity
   }
 }
@@ -21,11 +19,5 @@ export const selected = new Model(1)
 export const deselected = new Model(0)
 export const closed = new Model(0)
 
-export const interpolate =
-  ( from: Model
-  , to: Model
-  , progress: Float
-  ): Model =>
-  new Model
-  ( Easing.float(from.opacity, to.opacity, progress)
-  )
+export const interpolate = (from:Model, to:Model, progress:Float):Model =>new Model(Easing.float(from.opacity,
+                                                                                                 to.opacity, progress))

--- a/src/browser/Navigators/Navigator/Header.js
+++ b/src/browser/Navigators/Navigator/Header.js
@@ -1,22 +1,22 @@
 /* @flow */
 
-import {html, thunk, forward} from 'reflex';
-import * as Style from '../../../common/style';
-import {always} from '../../../common/prelude';
-import * as Title from './Title';
-import * as ShowTabsButton from './Header/ShowTabsButton';
-import * as NewTabButton from './Header/NewTabButton';
-import * as BackButton from './Header/BackButton';
+import { html, thunk, forward } from 'reflex'
+import * as Style from '../../../common/style'
+import { always } from '../../../common/prelude'
+import * as Title from './Title'
+import * as ShowTabsButton from './Header/ShowTabsButton'
+import * as NewTabButton from './Header/NewTabButton'
+import * as BackButton from './Header/BackButton'
 
 /*::
-import type {Address, DOM} from "reflex"
+ import type {Address, DOM} from "reflex"
 
-export type Model = string
-export type Action =
-  | { type: "ShowTabs" }
-  | { type: "OpenNewTab" }
-  | { type: "GoBack" }
-*/
+ export type Model = string
+ export type Action =
+ | { type: "ShowTabs" }
+ | { type: "OpenNewTab" }
+ | { type: "GoBack" }
+ */
 
 const tagShowTabs = always({ type: "ShowTabs" });
 const tagNewTab = always({ type: "OpenNewTab" });
@@ -24,47 +24,31 @@ const tagGoBack = always({ type: "GoBack" });
 
 export const height = Title.outerHeight;
 
-export const render =
-  ( canGoBack: boolean
-  , address: Address<Action>
-  ): DOM =>
-  html.header
-  ( { className: 'topbar'
-    , style: styleSheet.base
-    }
-  , [ BackButton.view
-      ( canGoBack
-      , forward(address, tagGoBack)
-      )
-    , NewTabButton.view
-      ( forward(address, tagNewTab)
-      )
-    , ShowTabsButton.view
-      ( forward(address, tagShowTabs)
-      )
-    ]
-  );
+export const render = (canGoBack:boolean, address:Address<Action>):DOM =>html.header({
+                                                                                       className: 'topbar',
+                                                                                       style: styleSheet.base
+                                                                                     }, [
+                                                                                       BackButton.view(canGoBack,
+                                                                                                       forward(address,
+                                                                                                               tagGoBack)),
+                                                                                       NewTabButton.view(
+                                                                                           forward(address, tagNewTab)),
+                                                                                       ShowTabsButton.view(
+                                                                                           forward(address,
+                                                                                                   tagShowTabs))
+                                                                                     ]);
 
-export const view =
-  ( canGoBack: boolean
-  , address: Address<Action>
-  ): DOM =>
-  thunk
-  ( 'Browser/NavigatorDeck/Navigator/Header'
-  , render
-  , canGoBack
-  , address
-  )
+export const view = (canGoBack:boolean, address:Address<Action>):DOM =>thunk('Browser/NavigatorDeck/Navigator/Header',
+                                                                             render, canGoBack, address)
 
-const styleSheet = Style.createSheet
-  ( { base:
-      { position: 'absolute'
-      , top: 0
-      , left: 0
-      , width: '100%'
-      , height: `${height}px`
-      , color: 'inherit'
-      , background: 'inherit'
-      }
-    }
-  )
+const styleSheet = Style.createSheet({
+                                       base: {
+                                         position: 'absolute',
+                                         top: 0,
+                                         left: 0,
+                                         width: '100%',
+                                         height: `${height}px`,
+                                         color: 'inherit',
+                                         background: 'inherit'
+                                       }
+                                     })

--- a/src/browser/Navigators/Navigator/Header.js
+++ b/src/browser/Navigators/Navigator/Header.js
@@ -25,9 +25,9 @@ const tagGoBack = always({ type: "GoBack" });
 export const height = Title.outerHeight;
 
 export const render =
-  ( canGoBack/*:boolean*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  ( canGoBack: boolean
+  , address: Address<Action>
+  ): DOM =>
   html.header
   ( { className: 'topbar'
     , style: styleSheet.base
@@ -46,9 +46,9 @@ export const render =
   );
 
 export const view =
-  ( canGoBack/*:boolean*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  ( canGoBack: boolean
+  , address: Address<Action>
+  ): DOM =>
   thunk
   ( 'Browser/NavigatorDeck/Navigator/Header'
   , render

--- a/src/browser/Navigators/Navigator/Header/BackButton.js
+++ b/src/browser/Navigators/Navigator/Header/BackButton.js
@@ -1,66 +1,46 @@
 /* @flow */
 
-import {html, thunk, forward} from 'reflex'
+import { html, thunk, forward } from 'reflex'
 import * as Style from '../../../../common/style'
-import {always} from '../../../../common/prelude'
+import { always } from '../../../../common/prelude'
 import * as Title from '../Title'
 
 /*::
-import type {Address, DOM} from "reflex"
-export type Action =
-  | { type: "Click" }
-*/
+ import type {Address, DOM} from "reflex"
+ export type Action =
+ | { type: "Click" }
+ */
 
 const Click = always({ type: "Click" })
 
-export const render =
-  ( isEnabled:boolean
-  , address:Address<Action>
-  ) =>
-  html.button
-  ( { className: 'go-back-button'
-    , style: Style.mix
-      ( styleSheet.base
-      , ( isEnabled
-        ? styleSheet.enabled
-        : styleSheet.disabled
-        )
-      )
-    , onClick: forward(address, Click)
-    }
-  , ["\uf053"]
-  )
+export const render = (isEnabled:boolean, address:Address<Action>) =>html.button({
+                                                                                   className: 'go-back-button',
+                                                                                   style: Style.mix(styleSheet.base,
+                                                                                                    ( isEnabled
+                                                                                                            ? styleSheet.enabled
+                                                                                                            : styleSheet.disabled
+                                                                                                    )),
+                                                                                   onClick: forward(address, Click)
+                                                                                 }, ["\uf053"])
 
-export const view =
-  ( isEnabled:boolean
-  , address:Address<Action>
-  ) =>
-  thunk
-  ( 'Browser/NavigatorDeck/Navigator/Header/BackButton'
-  , render
-  , isEnabled
-  , address
-  )
+export const view = (isEnabled:boolean, address:Address<Action>) =>thunk(
+    'Browser/NavigatorDeck/Navigator/Header/BackButton', render, isEnabled, address)
 
-const styleSheet = Style.createSheet
-  ( { base:
-      { MozWindowDragging: 'no-drag'
-      , WebkitAppRegion: 'no-drag'
-      , position: 'absolute'
-      , height: '14px'
-      , lineHeight: '14px'
-      , fontFamily: 'FontAwesome'
-      , fontSize: '14px'
-      , left: '50%'
-      , marginLeft: `-${Title.innerWidth / 2 + 14 + 4}px`
-      , top: '7px'
-      , width: '14px'
-      , color: 'inherit'
-      , background: 'transparent'
-      , cursor: 'pointer'
-      }
-    , enabled: null
-    , disabled:
-      { display: 'none' }
-    }
-  )
+const styleSheet = Style.createSheet({
+                                       base: {
+                                         MozWindowDragging: 'no-drag',
+                                         WebkitAppRegion: 'no-drag',
+                                         position: 'absolute',
+                                         height: '14px',
+                                         lineHeight: '14px',
+                                         fontFamily: 'FontAwesome',
+                                         fontSize: '14px',
+                                         left: '50%',
+                                         marginLeft: `-${Title.innerWidth / 2 + 14 + 4}px`,
+                                         top: '7px',
+                                         width: '14px',
+                                         color: 'inherit',
+                                         background: 'transparent',
+                                         cursor: 'pointer'
+                                       }, enabled: null, disabled: { display: 'none' }
+                                     })

--- a/src/browser/Navigators/Navigator/Header/NewTabButton.js
+++ b/src/browser/Navigators/Navigator/Header/NewTabButton.js
@@ -1,51 +1,40 @@
 /* @flow */
 
-import {html, thunk, forward} from 'reflex'
+import { html, thunk, forward } from 'reflex'
 import * as Style from '../../../../common/style'
-import {always} from '../../../../common/prelude'
+import { always } from '../../../../common/prelude'
 
 /*::
-import type {Address, DOM} from "reflex"
-export type Action =
-  | { type: "Click" }
-*/
+ import type {Address, DOM} from "reflex"
+ export type Action =
+ | { type: "Click" }
+ */
 
 const Click = always({ type: "Click" })
 
-export const render =
-  (address:Address<Action>) =>
-  html.button
-  ( { className: 'new-tab-button'
-    , style: styleSheet.base
-    , onClick: forward(address, Click)
-    }
-  , ["\uf067"]
-  )
+export const render = (address:Address<Action>) =>html.button({
+                                                                className: 'new-tab-button',
+                                                                style: styleSheet.base,
+                                                                onClick: forward(address, Click)
+                                                              }, ["\uf067"])
 
-export const view =
-  ( address:Address<Action>
-  ) =>
-  thunk
-  ( 'Browser/NavigatorDeck/Navigator/Header/NewTabButton'
-  , render
-  , address
-  )
+export const view = (address:Address<Action>) =>thunk('Browser/NavigatorDeck/Navigator/Header/NewTabButton', render,
+                                                      address)
 
-const styleSheet = Style.createSheet
-  ( { base:
-      { MozWindowDragging: 'no-drag'
-      , WebkitAppRegion: 'no-drag'
-      , position: 'absolute'
-      , height: '14px'
-      , lineHeight: '14px'
-      , fontFamily: 'FontAwesome'
-      , fontSize: '14px'
-      , right: `${14 + 8 + 4}px`
-      , top: '7px'
-      , width: '14px'
-      , color: 'inherit'
-      , background: 'transparent'
-      , cursor: 'pointer'
-      }
-    }
-  )
+const styleSheet = Style.createSheet({
+                                       base: {
+                                         MozWindowDragging: 'no-drag',
+                                         WebkitAppRegion: 'no-drag',
+                                         position: 'absolute',
+                                         height: '14px',
+                                         lineHeight: '14px',
+                                         fontFamily: 'FontAwesome',
+                                         fontSize: '14px',
+                                         right: `${14 + 8 + 4}px`,
+                                         top: '7px',
+                                         width: '14px',
+                                         color: 'inherit',
+                                         background: 'transparent',
+                                         cursor: 'pointer'
+                                       }
+                                     })

--- a/src/browser/Navigators/Navigator/Header/ShowTabsButton.js
+++ b/src/browser/Navigators/Navigator/Header/ShowTabsButton.js
@@ -1,51 +1,40 @@
 /* @flow */
 
-import {html, thunk, forward} from 'reflex'
+import { html, thunk, forward } from 'reflex'
 import * as Style from '../../../../common/style'
-import {always} from '../../../../common/prelude'
+import { always } from '../../../../common/prelude'
 
 /*::
-import type {Address, DOM} from "reflex"
-export type Action =
-  | { type: "Click" }
-*/
+ import type {Address, DOM} from "reflex"
+ export type Action =
+ | { type: "Click" }
+ */
 
 const Click = always({ type: "Click" })
 
-export const render =
-  (address:Address<Action>) =>
-  html.button
-  ( { className: 'webview-show-tabs-button'
-    , style: styleSheet.base
-    , onClick: forward(address, Click)
-    }
-  , ["\uf0c9"]
-  )
+export const render = (address:Address<Action>) =>html.button({
+                                                                className: 'webview-show-tabs-button',
+                                                                style: styleSheet.base,
+                                                                onClick: forward(address, Click)
+                                                              }, ["\uf0c9"])
 
-export const view =
-  ( address:Address<Action>
-  ) =>
-  thunk
-  ( 'Browser/NavigatorDeck/Navigator/Header/ShowTabsButton'
-  , render
-  , address
-  )
+export const view = (address:Address<Action>) =>thunk('Browser/NavigatorDeck/Navigator/Header/ShowTabsButton', render,
+                                                      address)
 
-const styleSheet = Style.createSheet
-  ( { base:
-      { MozWindowDragging: 'no-drag'
-      , WebkitAppRegion: 'no-drag'
-      , position: 'absolute'
-      , height: '14px'
-      , lineHeight: '14px'
-      , fontFamily: 'FontAwesome'
-      , fontSize: '14px'
-      , right: '8px'
-      , top: '7px'
-      , width: '14px'
-      , color: 'inherit'
-      , background: 'transparent'
-      , cursor: 'pointer'
-      }
-    }
-  )
+const styleSheet = Style.createSheet({
+                                       base: {
+                                         MozWindowDragging: 'no-drag',
+                                         WebkitAppRegion: 'no-drag',
+                                         position: 'absolute',
+                                         height: '14px',
+                                         lineHeight: '14px',
+                                         fontFamily: 'FontAwesome',
+                                         fontSize: '14px',
+                                         right: '8px',
+                                         top: '7px',
+                                         width: '14px',
+                                         color: 'inherit',
+                                         background: 'transparent',
+                                         cursor: 'pointer'
+                                       }
+                                     })

--- a/src/browser/Navigators/Navigator/Input.js
+++ b/src/browser/Navigators/Navigator/Input.js
@@ -59,23 +59,23 @@ export type Action =
 // Create a new input submit action.
 export const Query/*:()=>Action*/ = always({ type: 'Query' });
 export const Suggest =
-  (suggestion/*:Suggestion*/)/*:Action*/ =>
+  (suggestion: Suggestion): Action =>
   ( { type: "Suggest"
     , suggest: suggestion
     }
   );
 
-export const SuggestNext/*:Action*/ = { type: 'SuggestNext' };
-export const SuggestPrevious/*:Action*/ = { type: 'SuggestPrevious' };
-export const Submit/*:Action*/ = {type: 'Submit'};
-export const Abort/*:Action*/ = {type: 'Abort'};
-export const Enter/*:Action*/ = {type: 'Enter'};
-export const Focus/*:Action*/ = {type: 'Focus', source: Focusable.Focus };
-export const Blur/*:Action*/ = {type: 'Blur', source: Focusable.Blur };
-export const Show/*:Action*/ = {type: 'Show'};
-export const Hide/*:Action*/ = {type: 'Hide'};
+export const SuggestNext: Action = { type: 'SuggestNext' };
+export const SuggestPrevious: Action = { type: 'SuggestPrevious' };
+export const Submit: Action = {type: 'Submit'};
+export const Abort: Action = {type: 'Abort'};
+export const Enter: Action = {type: 'Enter'};
+export const Focus: Action = {type: 'Focus', source: Focusable.Focus };
+export const Blur: Action = {type: 'Blur', source: Focusable.Blur };
+export const Show: Action = {type: 'Show'};
+export const Hide: Action = {type: 'Hide'};
 export const EnterSelection =
-  (value/*:string*/)/*:Action*/ =>
+  (value: string): Action =>
   ( { type: 'EnterSelection'
     , value
     }
@@ -98,7 +98,7 @@ const EditableAction =
     }
   );
 
-const Clear/*:Action*/ = EditableAction(Editable.Clear);
+const Clear: Action = EditableAction(Editable.Clear);
 
 const updateFocusable = cursor({
   tag: FocusableAction,
@@ -136,7 +136,7 @@ const defaultFlags =
   }
 
 export const init =
-  (flags/*:Flags*/=defaultFlags)/*:[Model, Effects<Action>]*/ =>
+  (flags: Flags=defaultFlags): [Model, Effects<Action>] =>
   [ ( { value: flags.value
       , isFocused: !!flags.isFocused
       , isVisible: !!flags.isVisible
@@ -158,7 +158,7 @@ const suggest = (model, {query, match, hint}) =>
   )
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ => {
+  (model: Model, action: Action): [Model, Effects<Action>] => {
     switch (action.type) {
       case 'Abort':
         return [merge(model, {isVisible: false}), Effects.none];
@@ -302,7 +302,7 @@ const style = Style.createSheet({
 
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>): DOM =>
   html.form({
     className: 'input-combobox',
     style: Style.mix

--- a/src/browser/Navigators/Navigator/Input.js
+++ b/src/browser/Navigators/Navigator/Input.js
@@ -4,111 +4,97 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, forward, Effects} from 'reflex';
-import {on, focus, selection} from '@driver';
-import {identity} from '../../../lang/functional';
-import {always, merge} from '../../../common/prelude';
-import {cursor} from "../../../common/cursor";
-import {compose, debounce} from '../../../lang/functional';
-import * as Focusable from '../../../common/focusable';
-import * as Editable from '../../../common/editable';
-import * as Keyboard from '../../../common/keyboard';
-import * as Unknown from '../../../common/unknown';
-import * as Style from '../../../common/style';
+import { html, forward, Effects } from 'reflex'
+import { on, focus, selection } from '@driver'
+import { compose } from '../../../lang/functional'
+import { always, merge } from '../../../common/prelude'
+import { cursor } from '../../../common/cursor'
+import * as Focusable from '../../../common/focusable'
+import * as Editable from '../../../common/editable'
+import * as Keyboard from '../../../common/keyboard'
+import * as Unknown from '../../../common/unknown'
+import * as Style from '../../../common/style'
 
 /*::
-import type {Address, DOM} from "reflex"
+ import type {Address, DOM} from "reflex"
 
-export type Flags =
-  { isVisible?: boolean
-  , isFocused?: boolean
-  , value: string
-  }
+ export type Flags =
+ { isVisible?: boolean
+ , isFocused?: boolean
+ , value: string
+ }
 
-export type Model =
-  { isVisible: boolean
-  , isFocused: boolean
-  , value: string
-  , selection: ?Editable.Selection
-  }
+ export type Model =
+ { isVisible: boolean
+ , isFocused: boolean
+ , value: string
+ , selection: ?Editable.Selection
+ }
 
-export type Suggestion =
-  { query: string
-  , match: string
-  , hint: string
-  }
+ export type Suggestion =
+ { query: string
+ , match: string
+ , hint: string
+ }
 
-export type Action =
-  | { type: 'Submit' }
-  | { type: 'Query' }
-  | { type: 'Abort' }
-  | { type: 'Enter' }
-  | { type: 'EnterSelection', value: string }
-  | { type: 'Show' }
-  | { type: 'Hide' }
-  | { type: 'SuggestNext' }
-  | { type: 'SuggestPrevious'}
-  | { type: 'Suggest', suggest: Suggestion }
-  | { type: 'Focus' }
-  | { type: 'Blur' }
-  | { type: "Change", value: string, selection: Editable.Selection }
-  | { type: 'Editable', editable: Editable.Action }
-  | { type: 'Focusable', focusable: Focusable.Action }
-*/
+ export type Action =
+ | { type: 'Submit' }
+ | { type: 'Query' }
+ | { type: 'Abort' }
+ | { type: 'Enter' }
+ | { type: 'EnterSelection', value: string }
+ | { type: 'Show' }
+ | { type: 'Hide' }
+ | { type: 'SuggestNext' }
+ | { type: 'SuggestPrevious'}
+ | { type: 'Suggest', suggest: Suggestion }
+ | { type: 'Focus' }
+ | { type: 'Blur' }
+ | { type: "Change", value: string, selection: Editable.Selection }
+ | { type: 'Editable', editable: Editable.Action }
+ | { type: 'Focusable', focusable: Focusable.Action }
+ */
 
 // Create a new input submit action.
 export const Query/*:()=>Action*/ = always({ type: 'Query' });
-export const Suggest =
-  (suggestion: Suggestion): Action =>
-  ( { type: "Suggest"
-    , suggest: suggestion
-    }
-  );
+export const Suggest = (suggestion:Suggestion):Action =>( {
+  type: "Suggest", suggest: suggestion
+}
+);
 
-export const SuggestNext: Action = { type: 'SuggestNext' };
-export const SuggestPrevious: Action = { type: 'SuggestPrevious' };
-export const Submit: Action = {type: 'Submit'};
-export const Abort: Action = {type: 'Abort'};
-export const Enter: Action = {type: 'Enter'};
-export const Focus: Action = {type: 'Focus', source: Focusable.Focus };
-export const Blur: Action = {type: 'Blur', source: Focusable.Blur };
-export const Show: Action = {type: 'Show'};
-export const Hide: Action = {type: 'Hide'};
-export const EnterSelection =
-  (value: string): Action =>
-  ( { type: 'EnterSelection'
-    , value
-    }
-  );
+export const SuggestNext:Action = { type: 'SuggestNext' };
+export const SuggestPrevious:Action = { type: 'SuggestPrevious' };
+export const Submit:Action = { type: 'Submit' };
+export const Abort:Action = { type: 'Abort' };
+export const Enter:Action = { type: 'Enter' };
+export const Focus:Action = { type: 'Focus', source: Focusable.Focus };
+export const Blur:Action = { type: 'Blur', source: Focusable.Blur };
+export const Show:Action = { type: 'Show' };
+export const Hide:Action = { type: 'Hide' };
+export const EnterSelection = (value:string):Action =>( {
+  type: 'EnterSelection', value
+}
+);
 
-const FocusableAction = action =>
-  ( action.type === 'Focus'
-  ? Focus
-  : action.type === 'Blur'
-  ? Blur
-  : { type: 'Focusable'
-    , focusable: action
+const FocusableAction = action =>( action.type === 'Focus' ? Focus : action.type === 'Blur' ? Blur : {
+      type: 'Focusable', focusable: action
     }
-  );
+);
 
-const EditableAction =
-  (action) =>
-  ( { type: 'Editable'
-    , editable: action
-    }
-  );
+const EditableAction = (action) =>( {
+  type: 'Editable', editable: action
+}
+);
 
-const Clear: Action = EditableAction(Editable.Clear);
+const Clear:Action = EditableAction(Editable.Clear);
 
 const updateFocusable = cursor({
-  tag: FocusableAction,
-  update: Focusable.update
-});
+                                 tag: FocusableAction, update: Focusable.update
+                               });
 
 const updateEditable = cursor({
-  tag: EditableAction,
-  update: Editable.update
-});
+                                tag: EditableAction, update: Editable.update
+                              });
 
 const enter = (model) => {
   const [next, focusFx] = updateFocusable(model, Focusable.Focus);
@@ -116,8 +102,7 @@ const enter = (model) => {
   return [result, Effects.batch([focusFx, editFx])];
 }
 
-const enterSelection = (model, value) =>
-  enterSelectionRange(model, value, 0, value.length);
+const enterSelection = (model, value) =>enterSelectionRange(model, value, 0, value.length);
 
 const enterSelectionRange = (model, value, start, end) => {
   const [next, focusFx] = updateFocusable(model, Focusable.Focus);
@@ -129,126 +114,102 @@ const enterSelectionRange = (model, value, start, end) => {
   return [result, Effects.batch([focusFx, editFx])];
 }
 
-const defaultFlags =
-  { isFocused: false
-  , isVisible: false
-  , value: ""
+const defaultFlags = {
+  isFocused: false, isVisible: false, value: ""
+}
+
+export const init = (flags:Flags = defaultFlags):[Model, Effects<Action>] =>[
+  ( {
+    value: flags.value, isFocused: !!flags.isFocused, isVisible: !!flags.isVisible, selection: null
   }
+  ), Effects.none
+];
 
-export const init =
-  (flags: Flags=defaultFlags): [Model, Effects<Action>] =>
-  [ ( { value: flags.value
-      , isFocused: !!flags.isFocused
-      , isVisible: !!flags.isVisible
-      , selection: null
-      }
-    )
-  , Effects.none
-  ];
+const suggest = (model, { query, match, hint }) =>enterSelectionRange(model, match, ( match.toLowerCase()
+                                                                                           .startsWith(
+                                                                                               query.toLowerCase())
+        ? query.length
+        : match.length
+), match.length)
 
-const suggest = (model, {query, match, hint}) =>
-  enterSelectionRange
-  ( model
-  , match
-  , ( match.toLowerCase().startsWith(query.toLowerCase())
-    ? query.length
-    : match.length
-    )
-  , match.length
-  )
-
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] => {
-    switch (action.type) {
-      case 'Abort':
-        return [merge(model, {isVisible: false}), Effects.none];
+export const update = (model:Model, action:Action):[Model, Effects<Action>] => {
+  switch (action.type) {
+    case 'Abort':
+      return [merge(model, { isVisible: false }), Effects.none];
       // We don't really do anything on submit action for now
       // although in a future we may clear the value or do blur
       // the input.
-      case 'Submit':
-        return [model, Effects.none];
-      case 'Enter':
-        return enter(merge(model, {isVisible: true}));
-      case 'Focus':
-        return updateFocusable
-        ( merge(model, {isFocused: true, isVisible: true})
-        , Focusable.Focus
-        );
-      case 'Blur':
-        return updateFocusable(model, Focusable.Blur);
-      case 'EnterSelection':
-        return enterSelection(merge(model, {isVisible: true}), action.value);
-      case 'Focusable':
-        return updateFocusable(model, action.focusable);
-      case 'Editable':
-        return updateEditable(model, action.editable);
-      case 'Change':
-        return updateEditable(model, Editable.Change(action.value, action.selection));
-      case 'Show':
-        return [merge(model, {isVisible: true}), Effects.none];
-      case 'Hide':
-        return [merge(model, {isVisible: false}), Effects.none];
-      case 'SuggestNext':
-        return [model, Effects.none];
-      case 'SuggestPrevious':
-        return [model, Effects.none];
-      case 'Suggest':
-        return suggest(model, action.suggest);
-      default:
-        return Unknown.update(model, action)
-    }
-  };
+    case 'Submit':
+      return [model, Effects.none];
+    case 'Enter':
+      return enter(merge(model, { isVisible: true }));
+    case 'Focus':
+      return updateFocusable(merge(model, { isFocused: true, isVisible: true }), Focusable.Focus);
+    case 'Blur':
+      return updateFocusable(model, Focusable.Blur);
+    case 'EnterSelection':
+      return enterSelection(merge(model, { isVisible: true }), action.value);
+    case 'Focusable':
+      return updateFocusable(model, action.focusable);
+    case 'Editable':
+      return updateEditable(model, action.editable);
+    case 'Change':
+      return updateEditable(model, Editable.Change(action.value, action.selection));
+    case 'Show':
+      return [merge(model, { isVisible: true }), Effects.none];
+    case 'Hide':
+      return [merge(model, { isVisible: false }), Effects.none];
+    case 'SuggestNext':
+      return [model, Effects.none];
+    case 'SuggestPrevious':
+      return [model, Effects.none];
+    case 'Suggest':
+      return suggest(model, action.suggest);
+    default:
+      return Unknown.update(model, action)
+  }
+};
 
 
 const decodeKeyDown = Keyboard.bindings({
-  'up': always(SuggestPrevious),
-  'control p': always(SuggestPrevious),
-  'down': always(SuggestNext),
-  'control n': always(SuggestNext),
-  'enter': always(Submit),
-  'escape': always(Abort)
-});
+                                          'up': always(SuggestPrevious),
+                                          'control p': always(SuggestPrevious),
+                                          'down': always(SuggestNext),
+                                          'control n': always(SuggestNext),
+                                          'enter': always(Submit),
+                                          'escape': always(Abort)
+                                        });
 
 // Read a selection model from an event target.
 // @TODO type signature
 const readSelection = target => ({
-  start: target.selectionStart,
-  end: target.selectionEnd,
-  direction: target.selectionDirection
+  start: target.selectionStart, end: target.selectionEnd, direction: target.selectionDirection
 });
 
 // Read change action from a dom event.
 // @TODO type signature
-const readChange =
-  ({target}) =>
-  ( { type: "Change"
-    , value: target.value
-    , selection: readSelection(target)
-    }
-  );
+const readChange = ({ target }) =>( {
+  type: "Change", value: target.value, selection: readSelection(target)
+}
+);
 
 // Read select action from a dom event.
 // @TODO type signature
-const readSelect = compose
-  ( EditableAction
-  , ({target}) =>
-      Editable.Select(readSelection(target))
-  );
+const readSelect = compose(EditableAction, ({ target }) =>Editable.Select(readSelection(target)));
 
 const inputWidth = 480;
 const inputHeight = 40;
 const inputXPadding = 32;
 
 const style = Style.createSheet({
-  combobox: {
-    height: inputHeight,
-    right: '50%',
-    marginRight: `${-1 * (inputWidth / 2)}px`,
-    position: 'absolute',
-    top: '40px',
-    width: `${inputWidth}px`,
-  },
-  field: {
+                                  combobox: {
+                                    height: inputHeight,
+                                    right: '50%',
+                                    marginRight: `${-1 * (inputWidth / 2)}px`,
+                                    position: 'absolute',
+                                    top: '40px',
+                                    width: `${inputWidth}px`,
+                                  }, field: {
     backgroundColor: '#EBEEF2',
     borderRadius: '5px',
     borderWidth: '3px',
@@ -262,27 +223,15 @@ const style = Style.createSheet({
     margin: 0,
     padding: `0 ${inputXPadding}px`,
     width: `${(inputWidth - 6) - (inputXPadding * 2)}px`
-  },
-  fieldFocused: {
-    backgroundColor: '#fff',
-    borderColor: '#3D91F2'
-  },
-  fieldBlured: {
-
-  },
-  fieldEmpty: {
+  }, fieldFocused: {
+    backgroundColor: '#fff', borderColor: '#3D91F2'
+  }, fieldBlured: {}, fieldEmpty: {
     // Temporary fix until Servo has a better placeholder style:
     // https://github.com/servo/servo/issues/10561
     color: '#A9A9A9',
-  },
-  fieldNotEmpty: {
-
-  },
-  inactive: {
-    opacity: 0,
-    pointerEvents: 'none'
-  },
-  searchIcon: {
+  }, fieldNotEmpty: {}, inactive: {
+    opacity: 0, pointerEvents: 'none'
+  }, searchIcon: {
     color: 'rgba(0,0,0,0.7)',
     fontFamily: 'FontAwesome',
     fontSize: '16px',
@@ -290,57 +239,62 @@ const style = Style.createSheet({
     lineHeight: '40px',
     position: 'absolute',
     top: 0
-  },
-  hidden: {
-    opacity: 0,
-    pointerEvents: 'none'
-  },
-  visible: {
-
-  }
-});
+  }, hidden: {
+    opacity: 0, pointerEvents: 'none'
+  }, visible: {}
+                                });
 
 
-export const view =
-  (model: Model, address: Address<Action>): DOM =>
-  html.form({
-    className: 'input-combobox',
-    style: Style.mix
-    ( style.combobox
-    , ( model.isVisible
-      ? style.visible
-      : style.hidden
-      )
-    ),
-    // Note we submit new query only on `onInput` that's when we expect
-    onInput: forward(address, Query)
-  }, [
-    html.figure({
-      className: 'input-search-icon',
-      style: style.searchIcon
-    }, ['']),
-    html.input({
-      className: 'input-field',
-      placeholder: 'Search or enter address',
-      style: Style.mix
-        ( style.field
-        , ( model.isFocused
-          ? style.fieldFocused
-          : style.fieldBlured
-          )
-        , ( model.value.length == 0
-          ? style.fieldEmpty
-          : style.fieldNotEmpty
-          )
-        ),
-      type: 'text',
-      value: model.value,
-      isFocused: focus(model.isFocused),
-      selection: selection(model.selection),
-      onInput: on(address, readChange),
-      onSelect: on(address, readSelect),
-      onFocus: on(address, always(Focus)),
-      onBlur: on(address, always(Blur)),
-      onKeyDown: on(address, decodeKeyDown)
-    })
-  ]);
+export const view = (model:Model, address:Address<Action>):DOM =>html.form({
+                                                                             className: 'input-combobox',
+                                                                             style: Style.mix(style.combobox,
+                                                                                              ( model.isVisible
+                                                                                                      ? style.visible
+                                                                                                      : style.hidden
+                                                                                              )), // Note we submit new
+                                                                                                  // query only on
+                                                                                                  // `onInput` that's
+                                                                                                  // when we expect
+                                                                             onInput: forward(address, Query)
+                                                                           }, [
+                                                                             html.figure({
+                                                                                           className: 'input-search-icon',
+                                                                                           style: style.searchIcon
+                                                                                         }, ['']), html.input({
+                                                                                                                 className: 'input-field',
+                                                                                                                 placeholder: 'Search or enter address',
+                                                                                                                 style: Style.mix(
+                                                                                                                     style.field,
+                                                                                                                     ( model.isFocused
+                                                                                                                             ? style.fieldFocused
+                                                                                                                             : style.fieldBlured
+                                                                                                                     ),
+                                                                                                                     ( model.value.length == 0
+                                                                                                                             ? style.fieldEmpty
+                                                                                                                             : style.fieldNotEmpty
+                                                                                                                     )),
+                                                                                                                 type: 'text',
+                                                                                                                 value: model.value,
+                                                                                                                 isFocused: focus(
+                                                                                                                     model.isFocused),
+                                                                                                                 selection: selection(
+                                                                                                                     model.selection),
+                                                                                                                 onInput: on(
+                                                                                                                     address,
+                                                                                                                     readChange),
+                                                                                                                 onSelect: on(
+                                                                                                                     address,
+                                                                                                                     readSelect),
+                                                                                                                 onFocus: on(
+                                                                                                                     address,
+                                                                                                                     always(
+                                                                                                                         Focus)),
+                                                                                                                 onBlur: on(
+                                                                                                                     address,
+                                                                                                                     always(
+                                                                                                                         Blur)),
+                                                                                                                 onKeyDown: on(
+                                                                                                                     address,
+                                                                                                                     decodeKeyDown)
+                                                                                                               })
+                                                                           ]);

--- a/src/browser/Navigators/Navigator/Overlay.js
+++ b/src/browser/Navigators/Navigator/Overlay.js
@@ -4,200 +4,129 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Effects, html, thunk, forward} from "reflex";
-import {merge, always} from "../../../common/prelude";
-import {cursor} from "../../../common/cursor";
-import * as Style from "../../../common/style";
-import * as Easing from "eased";
-import * as Animation from "../../../common/Animation"
-import * as Unknown from "../../../common/unknown";
-import * as Display from "./Overlay/Display"
+import { Effects, html, thunk, forward } from 'reflex'
+import { always } from '../../../common/prelude'
+import { cursor } from '../../../common/cursor'
+import * as Style from '../../../common/style'
+import * as Easing from 'eased'
+import * as Animation from '../../../common/Animation'
+import * as Unknown from '../../../common/unknown'
+import * as Display from './Overlay/Display'
 
 /*::
-import type {Address, DOM} from "reflex"
-import type {Time} from "../../../common/prelude"
+ import type {Address, DOM} from "reflex"
+ import type {Time} from "../../../common/prelude"
 
-export type Flags = boolean
+ export type Flags = boolean
 
-export type Action =
-  | { type: "Click" }
-  | { type: "Show" }
-  | { type: "Hide" }
-  | { type: "Animation", animation: Animation.Action }
-*/
+ export type Action =
+ | { type: "Click" }
+ | { type: "Show" }
+ | { type: "Hide" }
+ | { type: "Animation", animation: Animation.Action }
+ */
 
 export class Model {
   /*::
-  animation: Animation.Model<Display.Model>;
-  isVisible: boolean;
-  */
-  constructor(
-    isVisible: boolean
-  , animation: Animation.Model<Display.Model>
-  ) {
+   animation: Animation.Model<Display.Model>;
+   isVisible: boolean;
+   */
+  constructor(isVisible:boolean, animation:Animation.Model<Display.Model>) {
     this.isVisible = isVisible;
     this.animation = animation;
   }
 }
 
-const Click = always({type: "Click"})
-export const Show = {type: "Show"}
-export const Hide = {type: "Hide"}
+const Click = always({ type: "Click" })
+export const Show = { type: "Show" }
+export const Hide = { type: "Hide" }
 
-const tagAnimation =
-  action =>
-  ( { type: "Animation"
-    , animation: action
-    }
-  );
+const tagAnimation = action =>( {
+  type: "Animation", animation: action
+}
+);
 
-export const init =
-  ( isVisible: boolean=false
-  ): [Model, Effects<Action>] => {
-    const display =
-      ( isVisible
-      ? Display.visible
-      : Display.invisible
-      )
-    const [animation, $animation] =
+export const init = (isVisible:boolean = false):[Model, Effects<Action>] => {
+  const display = ( isVisible ? Display.visible : Display.invisible
+  )
+  const [animation, $animation] =
       Animation.init(display)
 
-    const model = new Model
-      ( isVisible
-      , animation
-      )
+  const model = new Model(isVisible, animation)
 
-    const fx =
-      $animation
+  const fx = $animation
       .map(tagAnimation)
 
-    return [model, fx]
+  return [model, fx]
+}
+
+
+export const update = (model:Model, action:Action):[Model, Effects<Action>] => {
+  switch (action.type) {
+    case "Animation":
+      return updateAnimation(model, action.animation)
+    case "Show":
+      return show(model)
+    case "Hide":
+      return hide(model)
+    case "Click":
+      return nofx(model)
+    default:
+      return Unknown.update(model, action)
   }
+};
+
+const show = (model) =>( model.isVisible ? nofx(model) : startAnimation(true, Animation.transition(model.animation,
+                                                                                                   Display.visible,
+                                                                                                   300))
+)
+
+const hide = (model) =>( !model.isVisible ? nofx(model) : startAnimation(false, Animation.transition(model.animation,
+                                                                                                     Display.invisible,
+                                                                                                     300))
+)
+
+const animate = (animation, action) =>Animation.updateWith(Easing.easeOutQuad, Display.interpolate, animation, action)
 
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] => {
-    switch (action.type) {
-      case "Animation":
-        return updateAnimation(model, action.animation)
-      case "Show":
-        return show(model)
-      case "Hide":
-        return hide(model)
-      case "Click":
-        return nofx(model)
-      default:
-        return Unknown.update(model, action)
-    }
-  };
+const updateAnimation = cursor({
+                                 get: model => model.animation,
+                                 set: (model, animation) =>new Model(model.isVisible, animation),
+                                 tag: tagAnimation,
+                                 update: animate
+                               })
 
-const show =
-  ( model ) =>
-  ( model.isVisible
-  ? nofx(model)
-  : startAnimation
-    ( true
-    , Animation.transition
-      ( model.animation
-      , Display.visible
-      , 300
-      )
-    )
-  )
+const startAnimation = (isVisible, [animation, fx]) =>[
+  new Model(isVisible, animation), fx.map(tagAnimation)
+]
 
-const hide =
-  ( model ) =>
-  ( !model.isVisible
-  ? nofx(model)
-  : startAnimation
-    ( false
-    , Animation.transition
-      ( model.animation
-      , Display.invisible
-      , 300
-      )
-    )
-  )
+const nofx = model =>[
+  model, Effects.none
+]
 
-const animate =
-  (animation, action) =>
-  Animation.updateWith
-  ( Easing.easeOutQuad
-  , Display.interpolate
-  , animation
-  , action
-  )
+export const render = (model:Model, address:Address<Action>):DOM =>html.div({
+                                                                              className: 'overlay',
+                                                                              style: Style.mix(styleSheet.base,
+                                                                                               ( model.isVisible
+                                                                                                       ? styleSheet.visible
+                                                                                                       : styleSheet.invisible
+                                                                                               ), {
+                                                                                                 opacity: model.animation.state.opacity
+                                                                                               }),
+                                                                              onClick: forward(address, Click)
+                                                                            });
 
 
-const updateAnimation = cursor
-  ( { get: model => model.animation
-    , set:
-      (model, animation) =>
-      new Model
-      ( model.isVisible
-      , animation
-      )
-    , tag: tagAnimation
-    , update: animate
-    }
-  )
+export const view = (model:Model, address:Address<Action>):DOM =>thunk('Browser/NavigatorDeck/Navigator/Overaly',
+                                                                       render, model, address);
 
-const startAnimation =
-  (isVisible, [animation, fx]) =>
-  [ new Model
-    ( isVisible
-    , animation
-    )
-  , fx.map(tagAnimation)
-  ]
-
-const nofx =
-  model =>
-  [ model
-  , Effects.none
-  ]
-
-export const render =
-  ( model: Model
-  , address: Address<Action>
-  ): DOM =>
-  html.div
-  ( { className: 'overlay'
-    , style: Style.mix
-      ( styleSheet.base
-      , ( model.isVisible
-        ? styleSheet.visible
-        : styleSheet.invisible
-        )
-      , { opacity: model.animation.state.opacity
-        }
-      )
-    , onClick: forward(address, Click)
-    }
-  );
-
-
-export const view =
-  ( model: Model
-  , address: Address<Action>
-  ): DOM =>
-  thunk
-  ( 'Browser/NavigatorDeck/Navigator/Overaly'
-  , render
-  , model
-  , address
-  );
-
-const styleSheet = Style.createSheet
-  ( { base:
-      { background: 'rgb(0, 0, 0)'
-      , position: 'absolute'
-      , width: '100vw'
-      , height: '100vh'
-      }
-    , visible: null
-    , invisible:
-      { zIndex: -1
-      }
-    }
-  )
+const styleSheet = Style.createSheet({
+                                       base: {
+                                         background: 'rgb(0, 0, 0)',
+                                         position: 'absolute',
+                                         width: '100vw',
+                                         height: '100vh'
+                                       }, visible: null, invisible: {
+    zIndex: -1
+  }
+                                     })

--- a/src/browser/Navigators/Navigator/Overlay.js
+++ b/src/browser/Navigators/Navigator/Overlay.js
@@ -32,8 +32,8 @@ export class Model {
   isVisible: boolean;
   */
   constructor(
-    isVisible/*:boolean*/
-  , animation/*:Animation.Model<Display.Model>*/
+    isVisible: boolean
+  , animation: Animation.Model<Display.Model>
   ) {
     this.isVisible = isVisible;
     this.animation = animation;
@@ -52,8 +52,8 @@ const tagAnimation =
   );
 
 export const init =
-  ( isVisible/*:boolean*/=false
-  )/*:[Model, Effects<Action>]*/ => {
+  ( isVisible: boolean=false
+  ): [Model, Effects<Action>] => {
     const display =
       ( isVisible
       ? Display.visible
@@ -76,7 +76,7 @@ export const init =
 
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ => {
+  (model: Model, action: Action): [Model, Effects<Action>] => {
     switch (action.type) {
       case "Animation":
         return updateAnimation(model, action.animation)
@@ -158,9 +158,9 @@ const nofx =
   ]
 
 export const render =
-  ( model/*:Model*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  ( model: Model
+  , address: Address<Action>
+  ): DOM =>
   html.div
   ( { className: 'overlay'
     , style: Style.mix
@@ -178,9 +178,9 @@ export const render =
 
 
 export const view =
-  ( model/*:Model*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  ( model: Model
+  , address: Address<Action>
+  ): DOM =>
   thunk
   ( 'Browser/NavigatorDeck/Navigator/Overaly'
   , render

--- a/src/browser/Navigators/Navigator/Overlay/Display.js
+++ b/src/browser/Navigators/Navigator/Overlay/Display.js
@@ -10,7 +10,7 @@ export class Model {
   /*::
   opacity: Float;
   */
-  constructor(opacity/*:Float*/) {
+  constructor(opacity: Float) {
     this.opacity = opacity
   }
 }
@@ -19,10 +19,10 @@ export const visible = new Model(0.1)
 export const invisible = new Model(0)
 
 export const interpolate =
-  ( from/*:Model*/
-  , to/*:Model*/
-  , progress/*:number*/
-  )/*:Model*/ =>
+  ( from: Model
+  , to: Model
+  , progress: number
+  ): Model =>
   new Model
   ( Easing.float(from.opacity, to.opacity, progress)
   )

--- a/src/browser/Navigators/Navigator/Overlay/Display.js
+++ b/src/browser/Navigators/Navigator/Overlay/Display.js
@@ -1,16 +1,16 @@
 /* @flow */
 
-import * as Easing from "eased"
+import * as Easing from 'eased'
 
 /*::
-import type {Float} from "../../../../common/prelude"
-*/
+ import type {Float} from "../../../../common/prelude"
+ */
 
 export class Model {
   /*::
-  opacity: Float;
-  */
-  constructor(opacity: Float) {
+   opacity: Float;
+   */
+  constructor(opacity:Float) {
     this.opacity = opacity
   }
 }
@@ -18,11 +18,5 @@ export class Model {
 export const visible = new Model(0.1)
 export const invisible = new Model(0)
 
-export const interpolate =
-  ( from: Model
-  , to: Model
-  , progress: number
-  ): Model =>
-  new Model
-  ( Easing.float(from.opacity, to.opacity, progress)
-  )
+export const interpolate = (from:Model, to:Model, progress:number):Model =>new Model(Easing.float(from.opacity,
+                                                                                                  to.opacity, progress))

--- a/src/browser/Navigators/Navigator/Progress.js
+++ b/src/browser/Navigators/Navigator/Progress.js
@@ -5,58 +5,48 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {Effects, Task, html} from 'reflex';
-import {ease, easeOutQuart, float} from 'eased';
-import * as Style from '../../../common/style';
-import {always} from '../../../common/prelude';
-import * as Unknown from '../../../common/unknown';
-import * as Runtime from '../../../common/runtime';
-import * as Ref from '../../../common/ref';
-import * as PolyfillView from './Progress/PolyfillView';
-import * as ProgressView from './Progress/ProgressView';
+import { Effects, Task } from 'reflex'
+import { always } from '../../../common/prelude'
+import * as Unknown from '../../../common/unknown'
+import * as Runtime from '../../../common/runtime'
+import * as Ref from '../../../common/ref'
+import * as PolyfillView from './Progress/PolyfillView'
+import * as ProgressView from './Progress/ProgressView'
 
 /*::
-import type {Address, DOM} from "reflex"
-import type {Time, Float} from "../../../common/prelude"
+ import type {Address, DOM} from "reflex"
+ import type {Time, Float} from "../../../common/prelude"
 
-// Implied to be 0.0 - 1.0 range
-export type LoadProgress = Float
-type Percentage = number
+ // Implied to be 0.0 - 1.0 range
+ export type LoadProgress = Float
+ type Percentage = number
 
-export type Display =
-  { opacity: number
-  , x: number
-  }
+ export type Display =
+ { opacity: number
+ , x: number
+ }
 
-export type Action =
-  | { type: "LoadStart", time: Time }
-  | { type: "LoadEnd", time: Time }
-  | { type: "Connect", time: Time }
-  | { type: "Tick", time: Time }
-  | { type: "NoOp" }
-*/
+ export type Action =
+ | { type: "LoadStart", time: Time }
+ | { type: "LoadEnd", time: Time }
+ | { type: "Connect", time: Time }
+ | { type: "Tick", time: Time }
+ | { type: "NoOp" }
+ */
 
 const second = 1000;
 
 export class Model {
   /*::
-  ref: Ref.Model;
-  value: Percentage;
+   ref: Ref.Model;
+   value: Percentage;
 
-  updateTime: Time;
-  loadStart: Time;
-  connectTime: Time;
-  loadEnd: Time;
-  */
-  constructor(
-    ref: Ref.Model
-  , value: Percentage
-
-  , updateTime: Time
-  , loadStart: Time
-  , connectTime: Time
-  , loadEnd: Time
-  ) {
+   updateTime: Time;
+   loadStart: Time;
+   connectTime: Time;
+   loadEnd: Time;
+   */
+  constructor(ref:Ref.Model, value:Percentage, updateTime:Time, loadStart:Time, connectTime:Time, loadEnd:Time) {
     this.ref = ref
     this.value = value
     this.updateTime = updateTime
@@ -68,41 +58,34 @@ export class Model {
 
 const NoOp = always({ type: "NoOp" })
 
-export const LoadStart =
-  (time: Time): Action =>
-  ( { type: "LoadStart"
-    , time
-    }
-  );
+export const LoadStart = (time:Time):Action =>( {
+  type: "LoadStart", time
+}
+);
 
-export const Connect =
-  (time: Time): Action =>
-  ( { type: 'Connect'
-    , time
-    }
-  );
+export const Connect = (time:Time):Action =>( {
+  type: 'Connect', time
+}
+);
 
-export const LoadEnd =
-  (time: Time): Action =>
-  ( { type: "LoadEnd"
-    , time
-    }
-  );
+export const LoadEnd = (time:Time):Action =>( {
+  type: "LoadEnd", time
+}
+);
 
-const Tick =
-  (time: Time): Action =>
-  ( { type: "Tick"
-    , time
-    }
-  );
+const Tick = (time:Time):Action =>( {
+  type: "Tick", time
+}
+);
 
 // Parameters
 
-// Zone A is while connecting (waiting for the server to respond). This can be very fast (especially if server has beeen reached before).
-// Zone B is downloading the page and loading it.
-// Zone C is when the page is fully loaded and we finish the animation
+// Zone A is while connecting (waiting for the server to respond). This can be very fast (especially if server has
+// beeen reached before). Zone B is downloading the page and loading it. Zone C is when the page is fully loaded and we
+// finish the animation
 
-const limitA = 0.2; // what is the limit for the A zone. It will never reach this point, but tend to it. 1 is 100% of the width
+const limitA = 0.2; // what is the limit for the A zone. It will never reach this point, but tend to it. 1 is 100% of
+                    // the width
 const limitB = 0.7;
 const inflectionA = (1 * second); // After how many ms it stops accelerating to slowing approaching the limit
 const inflectionB = (2 * second);
@@ -110,229 +93,131 @@ const durationC = 200;
 
 const TAU = Math.PI / 2;
 
-const curve = (currentTime, inflectionTime) =>
-  (Math.atan((TAU / 2) * (currentTime / inflectionTime)) / TAU);
+const curve = (currentTime, inflectionTime) =>(Math.atan((TAU / 2) * (currentTime / inflectionTime)) / TAU);
 
-const progressConnecting =
-  (loadStart, updateTime) =>
-  limitA * curve(updateTime - loadStart, inflectionA);
+const progressConnecting = (loadStart, updateTime) =>limitA * curve(updateTime - loadStart, inflectionA);
 
-const progressLoading =
-  (loadStart, connectTime, updateTime) => {
-    const padding = progressConnecting(loadStart, connectTime);
-    const toFill = limitB - padding;
-    return padding + toFill * curve(updateTime - connectTime, inflectionB);
-  }
+const progressLoading = (loadStart, connectTime, updateTime) => {
+  const padding = progressConnecting(loadStart, connectTime);
+  const toFill = limitB - padding;
+  return padding + toFill * curve(updateTime - connectTime, inflectionB);
+}
 
-const progressLoaded =
-  (loadStart, connectTime, loadEnd, updateTime) => {
-    const padding = progressLoading(loadStart, connectTime, updateTime);
-    const toFill = 1 - padding;
-    return padding + toFill * (updateTime - loadEnd) / durationC;
-  }
+const progressLoaded = (loadStart, connectTime, loadEnd, updateTime) => {
+  const padding = progressLoading(loadStart, connectTime, updateTime);
+  const toFill = 1 - padding;
+  return padding + toFill * (updateTime - loadEnd) / durationC;
+}
 
-const progress =
-  ( start
-  , connect
-  , end
-  , now
-  ): LoadProgress =>
-  ( end > 0
-  ? progressLoaded(start, connect, end, now)
-  : connect > 0
-  ? progressLoading(start, connect, now)
-  : start > 0
-  ? progressConnecting(start, now)
-  : 0
-  );
+const progress = (start, connect, end, now):LoadProgress =>( end > 0
+        ? progressLoaded(start, connect, end, now)
+        : connect > 0
+        ? progressLoading(start, connect, now)
+        : start > 0
+        ? progressConnecting(start, now)
+        : 0
+);
 
 // Start a new progress cycle.
-export const loadStart =
-  ( model: Model
-  , time: Time
-  ): [Model, Effects<Action>] =>
-  [ new Model
-    ( model.ref
-    , 0
-    , time
-    , time
-    , 0
-    , 0
-    )
-  , ( Runtime.env.progressbar !== 'standalone'
-    ? Effects
-      .perform(Task.requestAnimationFrame())
-      .map(Tick)
-    : Effects
-      .perform(standalone.loadStart(model.ref, time))
-      .map(NoOp)
-    )
-  ];
+export const loadStart = (model:Model, time:Time):[Model, Effects<Action>] =>[
+  new Model(model.ref, 0, time, time, 0, 0), ( Runtime.env.progressbar !== 'standalone' ? Effects
+          .perform(Task.requestAnimationFrame())
+          .map(Tick) : Effects
+          .perform(standalone.loadStart(model.ref, time))
+          .map(NoOp)
+  )
+];
 
 
-export const connect =
-  ( model: Model
-  , time: Time
-  ): [Model, Effects<Action>] =>
-  [ new Model
-    ( model.ref
-    , model.value
-    , time
-    , model.loadStart
-    , time
-    , model.loadEnd
-    )
-  , ( Runtime.env.progressbar !== 'standalone'
-    ? Effects.none
-    : Effects
-      .perform(standalone.connect(model.ref, time))
-      .map(NoOp)
-    )
-  ]
+export const connect = (model:Model, time:Time):[Model, Effects<Action>] =>[
+  new Model(model.ref, model.value, time, model.loadStart, time, model.loadEnd),
+  ( Runtime.env.progressbar !== 'standalone' ? Effects.none : Effects
+          .perform(standalone.connect(model.ref, time))
+          .map(NoOp)
+  )
+]
 
 // Invoked on End action and returns model with updated `timeStamp`:
-export const loadEnd =
-  ( model: Model
-  , time: Time
-  ): [Model, Effects<Action>] =>
-  [ new Model
-    ( model.ref
-    , model.value
-    , time
-    , model.loadStart
-    , model.connectTime
-    , time
-    )
-  , ( Runtime.env.progressbar !== 'standalone'
-    ? Effects.none
-    : Effects
-      .perform(standalone.loadEnd(model.ref, time))
-      .map(NoOp)
-    )
-  ]
+export const loadEnd = (model:Model, time:Time):[Model, Effects<Action>] =>[
+  new Model(model.ref, model.value, time, model.loadStart, model.connectTime, time),
+  ( Runtime.env.progressbar !== 'standalone' ? Effects.none : Effects
+          .perform(standalone.loadEnd(model.ref, time))
+          .map(NoOp)
+  )
+]
 
 // Update the progress and request another tick.
 // Returns a new model and a tick effect.
-export const tick =
-  ( model: Model
-  , time: Time
-  ): [Model, Effects<Action>] => {
-    if (model.loadStart === 0) {
-      const fx =
-        Effects
+export const tick = (model:Model, time:Time):[Model, Effects<Action>] => {
+  if (model.loadStart === 0) {
+    const fx = Effects
         .perform(Unknown.warn(`Received Tick when progress was Idle: https://github.com/servo/servo/issues/10322`))
         .map(NoOp)
 
-      return [ model, fx ]
-    }
-    else {
-      const value = 100 * progress
-        ( model.loadStart
-        , model.connectTime
-        , model.loadEnd
-        , time
-        )
+    return [model, fx]
+  } else {
+    const value = 100 * progress(model.loadStart, model.connectTime, model.loadEnd, time)
 
-      const next =
-        ( value > 100
-        ? new Model
-          ( model.ref
-          , 0
-          , 0
-          , 0
-          , 0
-          , 0
-          )
-        : new Model
-          ( model.ref
-          , value
-          , time
-          , model.loadStart
-          , model.connectTime
-          , model.loadEnd
-          )
-        )
-
-      const fx =
-        ( next.updateTime > 0
-        ? Effects
-          .perform(Task.requestAnimationFrame())
-          .map(Tick)
-        : Effects.none
-        )
-
-      return [next, fx]
-    }
-  }
-
-
-export const init =
-  (): [Model, Effects<Action>] =>
-  [ new Model
-    ( Ref.create()
-    , 0
-    , 0
-    , 0
-    , 0
-    , 0
+    const next = ( value > 100
+            ? new Model(model.ref, 0, 0, 0, 0, 0)
+            : new Model(model.ref, value, time, model.loadStart, model.connectTime, model.loadEnd)
     )
-  , Effects.none
-  ];
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] => {
-    switch (action.type) {
-      case "LoadStart":
-        return loadStart(model, action.time);
-      case "LoadEnd":
-        return loadEnd(model, action.time);
-      case "Connect":
-        return connect(model, action.time);
-      case "Tick":
-        return tick(model, action.time);
-      case "NoOp":
-        return nofx(model);
-      default:
-        return Unknown.update(model, action);
-    }
-  };
+    const fx = ( next.updateTime > 0 ? Effects
+            .perform(Task.requestAnimationFrame())
+            .map(Tick) : Effects.none
+    )
 
-const nofx =
-  model =>
-  [ model
-  , Effects.none
-  ]
+    return [next, fx]
+  }
+}
 
 
+export const init = ():[Model, Effects<Action>] =>[
+  new Model(Ref.create(), 0, 0, 0, 0, 0), Effects.none
+];
 
-const standalone =
-  { loadStart:
-      (ref, time) =>
-      Ref
+export const update = (model:Model, action:Action):[Model, Effects<Action>] => {
+  switch (action.type) {
+    case "LoadStart":
+      return loadStart(model, action.time);
+    case "LoadEnd":
+      return loadEnd(model, action.time);
+    case "Connect":
+      return connect(model, action.time);
+    case "Tick":
+      return tick(model, action.time);
+    case "NoOp":
+      return nofx(model);
+    default:
+      return Unknown.update(model, action);
+  }
+};
+
+const nofx = model =>[
+  model, Effects.none
+]
+
+
+const standalone = {
+  loadStart: (ref, time) =>Ref
       .deref(ref)
       .chain(element => new Task((succeed, fail) => {
-        const onTick =
-          time => {
-            const value = progress
-            // @FlowIgnore
-            ( element.loadStart
-            // @FlowIgnore
-            , element.connect
-            // @FlowIgnore
-            , element.loadEnd
-            , time
-            )
-            // @FlowIgnore
-            element.updateTime = time;
+        const onTick = time => {
+          const value = progress(// @FlowIgnore
+                                 element.loadStart, // @FlowIgnore
+                                 element.connect, // @FlowIgnore
+                                 element.loadEnd, time)
+          // @FlowIgnore
+          element.updateTime = time;
 
-            if (value < 1) {
-              window.requestAnimationFrame(onTick);
-              standalone.drawLoading(element, time);
-            }
-            else {
-              standalone.drawIdle(element, time)
-            }
-          };
+          if (value < 1) {
+            window.requestAnimationFrame(onTick);
+            standalone.drawLoading(element, time);
+          } else {
+            standalone.drawIdle(element, time)
+          }
+        };
 
 
         // @FlowIgnore
@@ -345,62 +230,48 @@ const standalone =
         element.loadEnd = 0;
 
         window.requestAnimationFrame(onTick);
-      }))
-  , connect:
-      (ref, time) =>
-      Ref
+      })), connect: (ref, time) =>Ref
       .deref(ref)
       .chain(element => new Task((succeed, fail) => {
         // @FlowIgnore
         element.connectTime = time;
-      }))
-  , loadEnd:
-      (ref, time) =>
-      Ref
+      })), loadEnd: (ref, time) =>Ref
       .deref(ref)
       .chain(element => new Task((succeed, fail) => {
         // @FlowIgnore
         element.loadEnd = time;
-      }))
-  , drawLoading:
-      (element, time) => {
-        const value =
-          progress
-          // @FlowIgnore
-          ( element.loadStart
-          // @FlowIgnore
-          , element.connect
-          // @FlowIgnore
-          , element.loadEnd
-          // @FlowIgnore
-          , element.updateTime
-          ) * 100;
+      })), drawLoading: (element, time) => {
+    const value = progress
         // @FlowIgnore
-        element.value = value;
-        element.style.transform = `translateX(${value - 100}%)`;
-        element.style.opacity = `1`;
-      }
-  , drawIdle:
-      (element, time) => {
-        // @FlowIgnore
-        element.loadStart = 0;
-        // @FlowIgnore
-        element.updateTime = 0;
-        // @FlowIgnore
-        element.connectTime = 0;
-        // @FlowIgnore
-        element.loadEnd = 0;
-        // @FlowIgnore
-        element.value = 0;
-        element.style.transform = `translateX(-100%)`;
-        element.style.opacity = `0`;
-      }
+            (element.loadStart
+                       // @FlowIgnore
+            , element.connect
+                       // @FlowIgnore
+            , element.loadEnd
+                       // @FlowIgnore
+            , element.updateTime) * 100;
+    // @FlowIgnore
+    element.value = value;
+    element.style.transform = `translateX(${value - 100}%)`;
+    element.style.opacity = `1`;
+  }, drawIdle: (element, time) => {
+    // @FlowIgnore
+    element.loadStart = 0;
+    // @FlowIgnore
+    element.updateTime = 0;
+    // @FlowIgnore
+    element.connectTime = 0;
+    // @FlowIgnore
+    element.loadEnd = 0;
+    // @FlowIgnore
+    element.value = 0;
+    element.style.transform = `translateX(-100%)`;
+    element.style.opacity = `0`;
   }
+}
 
 
-export const view =
-  (model: Model): DOM =>
-  ( Runtime.isServo
-  ? PolyfillView.view(model.ref, model.value)
-  : ProgressView.view(model.ref, model.value)
-  )
+export const view = (model:Model):DOM =>( Runtime.isServo
+        ? PolyfillView.view(model.ref, model.value)
+        : ProgressView.view(model.ref, model.value)
+)

--- a/src/browser/Navigators/Navigator/Progress.js
+++ b/src/browser/Navigators/Navigator/Progress.js
@@ -49,13 +49,13 @@ export class Model {
   loadEnd: Time;
   */
   constructor(
-    ref/*:Ref.Model*/
-  , value/*:Percentage*/
+    ref: Ref.Model
+  , value: Percentage
 
-  , updateTime/*:Time*/
-  , loadStart/*:Time*/
-  , connectTime/*:Time*/
-  , loadEnd/*:Time*/
+  , updateTime: Time
+  , loadStart: Time
+  , connectTime: Time
+  , loadEnd: Time
   ) {
     this.ref = ref
     this.value = value
@@ -69,28 +69,28 @@ export class Model {
 const NoOp = always({ type: "NoOp" })
 
 export const LoadStart =
-  (time/*:Time*/)/*:Action*/ =>
+  (time: Time): Action =>
   ( { type: "LoadStart"
     , time
     }
   );
 
 export const Connect =
-  (time/*:Time*/)/*:Action*/ =>
+  (time: Time): Action =>
   ( { type: 'Connect'
     , time
     }
   );
 
 export const LoadEnd =
-  (time/*:Time*/)/*:Action*/ =>
+  (time: Time): Action =>
   ( { type: "LoadEnd"
     , time
     }
   );
 
 const Tick =
-  (time/*:Time*/)/*:Action*/ =>
+  (time: Time): Action =>
   ( { type: "Tick"
     , time
     }
@@ -136,7 +136,7 @@ const progress =
   , connect
   , end
   , now
-  )/*:LoadProgress*/ =>
+  ): LoadProgress =>
   ( end > 0
   ? progressLoaded(start, connect, end, now)
   : connect > 0
@@ -148,9 +148,9 @@ const progress =
 
 // Start a new progress cycle.
 export const loadStart =
-  ( model/*:Model*/
-  , time/*:Time*/
-  )/*:[Model, Effects<Action>]*/ =>
+  ( model: Model
+  , time: Time
+  ): [Model, Effects<Action>] =>
   [ new Model
     ( model.ref
     , 0
@@ -171,9 +171,9 @@ export const loadStart =
 
 
 export const connect =
-  ( model/*:Model*/
-  , time/*:Time*/
-  )/*:[Model, Effects<Action>]*/ =>
+  ( model: Model
+  , time: Time
+  ): [Model, Effects<Action>] =>
   [ new Model
     ( model.ref
     , model.value
@@ -192,9 +192,9 @@ export const connect =
 
 // Invoked on End action and returns model with updated `timeStamp`:
 export const loadEnd =
-  ( model/*:Model*/
-  , time/*:Time*/
-  )/*:[Model, Effects<Action>]*/ =>
+  ( model: Model
+  , time: Time
+  ): [Model, Effects<Action>] =>
   [ new Model
     ( model.ref
     , model.value
@@ -214,9 +214,9 @@ export const loadEnd =
 // Update the progress and request another tick.
 // Returns a new model and a tick effect.
 export const tick =
-  ( model/*:Model*/
-  , time/*:Time*/
-  )/*:[Model, Effects<Action>]*/ => {
+  ( model: Model
+  , time: Time
+  ): [Model, Effects<Action>] => {
     if (model.loadStart === 0) {
       const fx =
         Effects
@@ -267,7 +267,7 @@ export const tick =
 
 
 export const init =
-  ()/*:[Model, Effects<Action>]*/ =>
+  (): [Model, Effects<Action>] =>
   [ new Model
     ( Ref.create()
     , 0
@@ -280,7 +280,7 @@ export const init =
   ];
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ => {
+  (model: Model, action: Action): [Model, Effects<Action>] => {
     switch (action.type) {
       case "LoadStart":
         return loadStart(model, action.time);
@@ -399,7 +399,7 @@ const standalone =
 
 
 export const view =
-  (model/*:Model*/)/*:DOM*/ =>
+  (model: Model): DOM =>
   ( Runtime.isServo
   ? PolyfillView.view(model.ref, model.value)
   : ProgressView.view(model.ref, model.value)

--- a/src/browser/Navigators/Navigator/Progress/PolyfillView.js
+++ b/src/browser/Navigators/Navigator/Progress/PolyfillView.js
@@ -1,64 +1,45 @@
 /* @flow */
 
-import {thunk, html} from 'reflex';
-import * as Style from '../../../../common/style';
+import { thunk, html } from 'reflex'
+import * as Style from '../../../../common/style'
 
 /*::
-import * as Ref from '../../../../common/ref';
-import type {DOM} from 'reflex';
-*/
+ import * as Ref from '../../../../common/ref';
+ import type {DOM} from 'reflex';
+ */
 
-export const render =
-  (ref: Ref.Model, value: number): DOM =>
-  html.div
-  ( { className: "progress"
-    , style: styleSheet.base
-    }
-  , [ html.div
-      ( { style:
-          ( value > 0
-          ? styleLoading(value)
-          : styleSheet.idle
-          )
-        , [ref.name]: ref.value
-        }
-      )
-    ]
-  )
+export const render = (ref:Ref.Model, value:number):DOM =>html.div({
+                                                                     className: "progress", style: styleSheet.base
+                                                                   }, [
+                                                                     html.div({
+                                                                                style: ( value > 0
+                                                                                        ? styleLoading(value)
+                                                                                        : styleSheet.idle
+                                                                                ), [ref.name]: ref.value
+                                                                              })
+                                                                   ])
 
-export const view =
-  (ref: Ref.Model, value: number): DOM =>
-  thunk
-  ( 'Browser/NavigtorDeck/Navigator/Progress/PolyfillView'
-  , render
-  , ref
-  , value
-  )
+export const view = (ref:Ref.Model, value:number):DOM =>thunk('Browser/NavigtorDeck/Navigator/Progress/PolyfillView',
+                                                              render, ref, value)
 
 
-const styleSheet = Style.createSheet
-  ( { base:
-      { height: "4px"
-      , overflow: "hidden"
+const styleSheet = Style.createSheet({
+                                       base: {
+                                         height: "4px", overflow: "hidden"
 
-      , position: 'absolute'
-      , top: '24px'
-      , width: "100%"
-      }
-    , idle:
-      { opacity: 0
-      , height: "inherit"
-      , backgroundImage: "linear-gradient(135deg, #4A90E2 calc(100% - 4px), transparent calc(100% - 4px))"
-      , transform: "translateX(-100%)"
-      }
-    }
-  )
+                                         , position: 'absolute', top: '24px', width: "100%"
+                                       }, idle: {
+    opacity: 0,
+    height: "inherit",
+    backgroundImage: "linear-gradient(135deg, #4A90E2 calc(100% - 4px), transparent calc(100% - 4px))",
+    transform: "translateX(-100%)"
+  }
+                                     })
 
-const styleLoading =
-  value =>
-  ( { transform: `translateX(${(value) - 100}%)`
-    , opacity: 1
-    , height: styleSheet.idle.height
-    , backgroundImage: styleSheet.idle.backgroundImage
-    }
-  )
+const styleLoading = value =>( {
+  transform: `translateX(${(value) - 100}%)`,
+  opacity: 1,
+  height: styleSheet.idle.height,
+  backgroundImage: styleSheet.idle.backgroundImage
+}
+)

--- a/src/browser/Navigators/Navigator/Progress/PolyfillView.js
+++ b/src/browser/Navigators/Navigator/Progress/PolyfillView.js
@@ -9,7 +9,7 @@ import type {DOM} from 'reflex';
 */
 
 export const render =
-  (ref/*:Ref.Model*/, value/*:number*/)/*:DOM*/ =>
+  (ref: Ref.Model, value: number): DOM =>
   html.div
   ( { className: "progress"
     , style: styleSheet.base
@@ -27,7 +27,7 @@ export const render =
   )
 
 export const view =
-  (ref/*:Ref.Model*/, value/*:number*/)/*:DOM*/ =>
+  (ref: Ref.Model, value: number): DOM =>
   thunk
   ( 'Browser/NavigtorDeck/Navigator/Progress/PolyfillView'
   , render

--- a/src/browser/Navigators/Navigator/Progress/ProgressView.js
+++ b/src/browser/Navigators/Navigator/Progress/ProgressView.js
@@ -1,62 +1,48 @@
 /* @flow */
 
-import {thunk, html} from 'reflex';
-import * as Style from '../../../../common/style';
+import { thunk, html } from 'reflex'
+import * as Style from '../../../../common/style'
 
 /*::
-import * as Ref from '../../../../common/ref';
-import type {DOM} from 'reflex';
-*/
+ import * as Ref from '../../../../common/ref';
+ import type {DOM} from 'reflex';
+ */
 
-export const render =
-  (ref: Ref.Model, value: number): DOM =>
-  html.progress
-  ( { [ref.name]: ref.value
-    , style: Style.mix
-      ( styleSheet.base
-      , ( value > 0
-        ? styleSheet.loading
-        : styleSheet.idle
-        )
-      )
-    , min: 0
-    , max: 100
-    , value
-    }
-  )
+export const render = (ref:Ref.Model, value:number):DOM =>html.progress({
+                                                                          [ref.name]: ref.value,
+                                                                          style: Style.mix(styleSheet.base, ( value > 0
+                                                                                  ? styleSheet.loading
+                                                                                  : styleSheet.idle
+                                                                          )),
+                                                                          min: 0,
+                                                                          max: 100,
+                                                                          value
+                                                                        })
 
-export const view =
-  (ref: Ref.Model, value: number): DOM =>
-  thunk
-  ( 'Browser/NavigtorDeck/Navigator/Progress/ProgressView'
-  , render
-  , ref
-  , value
-  )
+export const view = (ref:Ref.Model, value:number):DOM =>thunk('Browser/NavigtorDeck/Navigator/Progress/ProgressView',
+                                                              render, ref, value)
 
-const styleSheet = Style.createSheet
-  ( { base:
-      { appearance: "none"
-      , WebkitAppearance: "none"
-      , border: "none"
-      , height: "4px"
-      , borderRadius: 0
-      , boxShadow: "none"
-      , color: "#4A90E2"
-      , overflow: "hidden"
-      , backgroundColor: "transparent"
-      , backgroundImage: "linear-gradient(135deg, #4A90E2 calc(100% - 4px), transparent calc(100% - 4px))"
-      , backgroundSize: 0
+const styleSheet = Style.createSheet({
+                                       base: {
+                                         appearance: "none",
+                                         WebkitAppearance: "none",
+                                         border: "none",
+                                         height: "4px",
+                                         borderRadius: 0,
+                                         boxShadow: "none",
+                                         color: "#4A90E2",
+                                         overflow: "hidden",
+                                         backgroundColor: "transparent",
+                                         backgroundImage: "linear-gradient(135deg, #4A90E2 calc(100% - 4px), transparent calc(100% - 4px))",
+                                         backgroundSize: 0
 
-      , position: 'absolute'
-      , top: '24px'
-      , width: "100%"
-      }
-    , idle:
-      { opacity: 0
-      }
-    , loading:
-      { opacity: 1
-      }
-    }
-  )
+                                         ,
+                                         position: 'absolute',
+                                         top: '24px',
+                                         width: "100%"
+                                       }, idle: {
+    opacity: 0
+  }, loading: {
+    opacity: 1
+  }
+                                     })

--- a/src/browser/Navigators/Navigator/Progress/ProgressView.js
+++ b/src/browser/Navigators/Navigator/Progress/ProgressView.js
@@ -9,7 +9,7 @@ import type {DOM} from 'reflex';
 */
 
 export const render =
-  (ref/*:Ref.Model*/, value/*:number*/)/*:DOM*/ =>
+  (ref: Ref.Model, value: number): DOM =>
   html.progress
   ( { [ref.name]: ref.value
     , style: Style.mix
@@ -26,7 +26,7 @@ export const render =
   )
 
 export const view =
-  (ref/*:Ref.Model*/, value/*:number*/)/*:DOM*/ =>
+  (ref: Ref.Model, value: number): DOM =>
   thunk
   ( 'Browser/NavigtorDeck/Navigator/Progress/ProgressView'
   , render

--- a/src/browser/Navigators/Navigator/Title.js
+++ b/src/browser/Navigators/Navigator/Title.js
@@ -15,11 +15,11 @@ const Activate = always({ type: "Activate" })
 
 
 export const render =
-  ( isDisabled/*:boolean*/
-  , title/*:string*/
-  , secure/*:boolean*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  ( isDisabled: boolean
+  , title: string
+  , secure: boolean
+  , address: Address<Action>
+  ): DOM =>
   html.summary
   ( { className: 'webview-combobox'
     , style: Style.mix
@@ -59,11 +59,11 @@ export const render =
   );
 
 export const view =
-  ( isDisabled/*:boolean*/
-  , title/*:string*/
-  , secure/*:boolean*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  ( isDisabled: boolean
+  , title: string
+  , secure: boolean
+  , address: Address<Action>
+  ): DOM =>
   thunk
   ( 'Browser/NavigatorDeck/Navigator/Header/Title'
   , render

--- a/src/browser/Navigators/Navigator/Title.js
+++ b/src/browser/Navigators/Navigator/Title.js
@@ -1,133 +1,101 @@
 /* @flow */
 
-import {html, thunk, forward} from 'reflex';
-import * as Style from '../../../common/style';
-import {always} from '../../../common/prelude';
+import { html, thunk, forward } from 'reflex'
+import * as Style from '../../../common/style'
+import { always } from '../../../common/prelude'
 
 /*::
-import type {Address, DOM} from "reflex"
+ import type {Address, DOM} from "reflex"
 
-export type Action =
-  | { type: "Activate" }
-*/
+ export type Action =
+ | { type: "Activate" }
+ */
 
 const Activate = always({ type: "Activate" })
 
 
-export const render =
-  ( isDisabled: boolean
-  , title: string
-  , secure: boolean
-  , address: Address<Action>
-  ): DOM =>
-  html.summary
-  ( { className: 'webview-combobox'
-    , style: Style.mix
-      ( styleSheet.base
-      , ( isDisabled
-        ? styleSheet.disabled
-        : styleSheet.enabled
-        )
-      )
-    , onClick: forward(address, Activate)
-    , open: true
-    }
-  , [ html.figure
-      ( { className: 'webview-search-icon'
-        , style: styleSheet.searchIcon
-        }
-      , ['\uf002']
-      )
-    , html.caption
-      ( { className: 'webview-title-container'
-        , style: styleSheet.summary
-        }
-      , [ html.figure
-          ( { className: 'webview-security'
-            , style:
-              ( secure
-              ? styleSheet.secureIcon
-              : styleSheet.insecureIcon
-              )
-            }
-          , ['\uf023']
-          )
-        , title
-        ]
-      )
-    ]
-  );
+export const render = (isDisabled:boolean, title:string, secure:boolean, address:Address<Action>):DOM =>html.summary({
+                                                                                                                       className: 'webview-combobox',
+                                                                                                                       style: Style.mix(
+                                                                                                                           styleSheet.base,
+                                                                                                                           ( isDisabled
+                                                                                                                                   ? styleSheet.disabled
+                                                                                                                                   : styleSheet.enabled
+                                                                                                                           )),
+                                                                                                                       onClick: forward(
+                                                                                                                           address,
+                                                                                                                           Activate),
+                                                                                                                       open: true
+                                                                                                                     },
+                                                                                                                     [
+                                                                                                                       html.figure(
+                                                                                                                           {
+                                                                                                                             className: 'webview-search-icon',
+                                                                                                                             style: styleSheet.searchIcon
+                                                                                                                           },
+                                                                                                                           ['\uf002']),
+                                                                                                                       html.caption(
+                                                                                                                           {
+                                                                                                                             className: 'webview-title-container',
+                                                                                                                             style: styleSheet.summary
+                                                                                                                           },
+                                                                                                                           [
+                                                                                                                             html.figure(
+                                                                                                                                 {
+                                                                                                                                   className: 'webview-security',
+                                                                                                                                   style: ( secure
+                                                                                                                                           ? styleSheet.secureIcon
+                                                                                                                                           : styleSheet.insecureIcon
+                                                                                                                                   )
+                                                                                                                                 },
+                                                                                                                                 ['\uf023']),
+                                                                                                                             title
+                                                                                                                           ])
+                                                                                                                     ]);
 
-export const view =
-  ( isDisabled: boolean
-  , title: string
-  , secure: boolean
-  , address: Address<Action>
-  ): DOM =>
-  thunk
-  ( 'Browser/NavigatorDeck/Navigator/Header/Title'
-  , render
-  , isDisabled
-  , title
-  , secure
-  , address
-  )
+export const view = (isDisabled:boolean, title:string, secure:boolean, address:Address<Action>):DOM =>thunk(
+    'Browser/NavigatorDeck/Navigator/Header/Title', render, isDisabled, title, secure, address)
 
 export const innerHeight = 21;
 export const innerWidth = 250;
 export const outerHeight = 27;
 
 
-const styleSheet = Style.createSheet
-  ( { base:
-      { MozWindowDragging: 'no-drag'
-      , WebkitAppRegion: 'no-drag'
-      , position: 'absolute'
-      , left: '50%'
-      , top: 0
-      , height: `${innerHeight}px`
-      , lineHeight: `${innerHeight}px`
-      , width: `${innerWidth}px`
-      , marginTop: `${(outerHeight / 2) - (innerHeight / 2)}px`
-      , marginLeft: `-${innerWidth / 2}px`
-      , borderRadius: '5px'
-      , cursor: 'text'
-      , color: 'inherit'
-      }
-    , summary:
-      { fontSize: '13px'
-      , position: 'absolute'
-      , top: 0
-      , left: 0
-      , paddingLeft: '30px'
-      , paddingRight: '30px'
-      , width: 'calc(100% - 60px)'
-      , textAlign: 'center'
-      , whiteSpace: 'nowrap'
-      , overflow: 'hidden'
-      , textOverflow: 'ellipsis'
-      , listStyleType: 'none'
-      }
-    , searchIcon:
-      { fontFamily: 'FontAwesome'
-      , fontSize: '14px'
-      , left: '5px'
-      , position: 'absolute'
-      , display: 'inline'
-      }
-    , secureIcon:
-      { fontFamily: 'FontAwesome'
-      , marginRight: '6px'
-      , display: 'inline'
-      }
-    , insecureIcon:
-      { fontFamily: 'FontAwesome'
-      , marginRight: '6px'
-      , display: 'none'
-      }
-    , disabled:
-      { display: 'none'
-      }
-    , enabled: null
-    }
-  );
+const styleSheet = Style.createSheet({
+                                       base: {
+                                         MozWindowDragging: 'no-drag',
+                                         WebkitAppRegion: 'no-drag',
+                                         position: 'absolute',
+                                         left: '50%',
+                                         top: 0,
+                                         height: `${innerHeight}px`,
+                                         lineHeight: `${innerHeight}px`,
+                                         width: `${innerWidth}px`,
+                                         marginTop: `${(outerHeight / 2) - (innerHeight / 2)}px`,
+                                         marginLeft: `-${innerWidth / 2}px`,
+                                         borderRadius: '5px',
+                                         cursor: 'text',
+                                         color: 'inherit'
+                                       }, summary: {
+    fontSize: '13px',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    paddingLeft: '30px',
+    paddingRight: '30px',
+    width: 'calc(100% - 60px)',
+    textAlign: 'center',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    listStyleType: 'none'
+  }, searchIcon: {
+    fontFamily: 'FontAwesome', fontSize: '14px', left: '5px', position: 'absolute', display: 'inline'
+  }, secureIcon: {
+    fontFamily: 'FontAwesome', marginRight: '6px', display: 'inline'
+  }, insecureIcon: {
+    fontFamily: 'FontAwesome', marginRight: '6px', display: 'none'
+  }, disabled: {
+    display: 'none'
+  }, enabled: null
+                                     });

--- a/src/browser/Navigators/Navigator/WebView.js
+++ b/src/browser/Navigators/Navigator/WebView.js
@@ -128,15 +128,15 @@ export class Model {
   page: Page.Model;
   */
   constructor(
-    ref/*: Ref.Model*/
-  , guestInstanceId/*: ?string*/
-  , name/*: string*/
-  , features/*: string*/
-  , tab/*: Tab.Model*/
-  , shell/*: Shell.Model*/
-  , navigation/*: Navigation.Model*/
-  , security/*: Security.Model*/
-  , page/*: Page.Model*/
+    ref:  Ref.Model
+  , guestInstanceId:  ?string
+  , name:  string
+  , features:  string
+  , tab:  Tab.Model
+  , shell:  Shell.Model
+  , navigation:  Navigation.Model
+  , security:  Security.Model
+  , page:  Page.Model
   ) {
     this.ref = ref
     this.guestInstanceId = guestInstanceId
@@ -152,36 +152,36 @@ export class Model {
 
 const NoOp = always({ type: "NoOp" });
 
-export const Close/*:Action*/ =
+export const Close: Action =
   { type: "Close"
   };
 
-export const Select/*:Action*/ =
+export const Select: Action =
   { type: "Select"
   };
 
-export const Closed/*:Action*/ =
+export const Closed: Action =
   { type: "Closed"
   };
 
-export const Edit/*:Action*/ =
+export const Edit: Action =
   { type: "Edit"
   };
 
-export const ShowTabs/*:Action*/ =
+export const ShowTabs: Action =
   { type: 'ShowTabs'
   };
 
-export const Create/*:Action*/ =
+export const Create: Action =
   { type: 'Create'
   };
 
-export const Focus/*:Action*/ =
+export const Focus: Action =
   { type: 'Focus'
   };
 
 export const Load =
-  (uri/*:URI*/)/*:Action*/ =>
+  (uri: URI): Action =>
   ( { type: 'Load'
     , uri
     }
@@ -194,12 +194,12 @@ const ShellAction = action =>
     }
   );
 
-export const ZoomIn/*:Action*/ = ShellAction(Shell.ZoomIn);
-export const ZoomOut/*:Action*/ = ShellAction(Shell.ZoomOut);
-export const ResetZoom/*:Action*/ = ShellAction(Shell.ResetZoom);
-export const MakeVisible/*:Action*/ =
+export const ZoomIn: Action = ShellAction(Shell.ZoomIn);
+export const ZoomOut: Action = ShellAction(Shell.ZoomOut);
+export const ResetZoom: Action = ShellAction(Shell.ResetZoom);
+export const MakeVisible: Action =
   ShellAction(Shell.MakeVisible);
-export const MakeNotVisible/*:Action*/ =
+export const MakeNotVisible: Action =
   ShellAction(Shell.MakeNotVisible);
 
 const NavigationAction = action =>
@@ -207,13 +207,13 @@ const NavigationAction = action =>
     , navigation: action
   });
 
-export const Stop/*:Action*/ =
+export const Stop: Action =
   NavigationAction(Navigation.Stop);
-export const Reload/*:Action*/ =
+export const Reload: Action =
   NavigationAction(Navigation.Reload);
-export const GoBack/*:Action*/ =
+export const GoBack: Action =
   NavigationAction(Navigation.GoBack);
-export const GoForward/*:Action*/ =
+export const GoForward: Action =
   NavigationAction(Navigation.GoForward);
 
 const SecurityAction = action =>
@@ -315,7 +315,7 @@ const updateNavigation = cursor
 
 
 export const init =
-  (options/*:Flags*/)/*:[Model, Effects<Action>]*/ => {
+  (options: Flags): [Model, Effects<Action>] => {
     const ref = Ref.create()
     return assemble(
         ref
@@ -331,15 +331,15 @@ export const init =
   };
 
 const assemble =
-  ( ref/*:Ref.Model*/
-  , guestInstanceId/*:?string*/
-  , name/*:string*/
-  , features/*:string*/
-  , [tab, $tab]/*:[Tab.Model, Effects<Tab.Action>]*/
-  , [shell, $shell]/*:[Shell.Model, Effects<Shell.Action>]*/
-  , [navigation, $navigation]/*:[Navigation.Model, Effects<Navigation.Action>]*/
-  , [security, $security]/*:[Security.Model, Effects<Security.Action>]*/
-  , [page, $page]/*:[Page.Model, Effects<Page.Action>]*/
+  ( ref: Ref.Model
+  , guestInstanceId: ?string
+  , name: string
+  , features: string
+  , [tab, $tab]: [Tab.Model, Effects<Tab.Action>]
+  , [shell, $shell]: [Shell.Model, Effects<Shell.Action>]
+  , [navigation, $navigation]: [Navigation.Model, Effects<Navigation.Action>]
+  , [security, $security]: [Security.Model, Effects<Security.Action>]
+  , [page, $page]: [Page.Model, Effects<Page.Action>]
   ) => {
     const model = new Model
       ( ref
@@ -392,7 +392,7 @@ const endLoad = (model, time) =>
   );
 
 const nofx = /*::<model, action>*/
-  (model/*:model*/)/*:[model, Effects<action>]*/ =>
+  (model: model): [model, Effects<action>] =>
   [ model, Effects.none ]
 
 const connect = nofx;
@@ -410,7 +410,7 @@ const close = model =>
   [ model, Effects.receive(Closed) ];
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ => {
+  (model: Model, action: Action): [Model, Effects<Action>] => {
     switch (action.type) {
       case "NoOp":
         return [ model, Effects.none ];
@@ -491,5 +491,5 @@ const Frame =
 
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>): DOM =>
   Frame.view(styleSheet, model, address);

--- a/src/browser/Navigators/Navigator/WebView.js
+++ b/src/browser/Navigators/Navigator/WebView.js
@@ -5,139 +5,127 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {Effects, html, forward} from 'reflex';
-import {merge, always, batch} from '../../../common/prelude';
-import {cursor} from '../../../common/cursor';
-import {compose} from '../../../lang/functional';
-import {on} from '@driver';
-import {isElectron} from "../../../common/runtime";
-import * as Shell from './WebView/Shell';
-import * as Navigation from './WebView/Navigation';
-import * as Security from './WebView/Security';
-import * as Page from './WebView/Page';
-import * as Unknown from '../../../common/unknown';
-import {Style, StyleSheet} from '../../../common/style';
-import {readTitle, isDark, canGoBack} from './WebView/Util';
-import * as Driver from '@driver';
-import * as Focusable from '../../../common/focusable';
-import * as Easing from 'eased';
-import * as MozBrowserFrame from './WebView/MozBrowserFrame';
-import * as ElectronFrame from './WebView/ElectronFrame';
-import * as Ref from '../../../common/ref';
-import * as Tab from '../../Sidebar/Tab';
+import { Effects } from 'reflex'
+import { merge, always, batch } from '../../../common/prelude'
+import { cursor } from '../../../common/cursor'
+import { compose } from '../../../lang/functional'
+import { on } from '@driver'
+import { isElectron } from '../../../common/runtime'
+import * as Shell from './WebView/Shell'
+import * as Navigation from './WebView/Navigation'
+import * as Security from './WebView/Security'
+import * as Page from './WebView/Page'
+import * as Unknown from '../../../common/unknown'
+import { StyleSheet } from '../../../common/style'
+import * as MozBrowserFrame from './WebView/MozBrowserFrame'
+import * as ElectronFrame from './WebView/ElectronFrame'
+import * as Ref from '../../../common/ref'
+import * as Tab from '../../Sidebar/Tab'
 
 /*::
-import type {Address, DOM} from "reflex"
-import type {URI, Time, Integer, Float} from "../../../common/prelude"
-import type {Icon} from "../../../common/favicon"
-import {performance} from "../../../common/performance"
+ import type {Address, DOM} from "reflex"
+ import type {URI, Time, Integer, Float} from "../../../common/prelude"
+ import type {Icon} from "../../../common/favicon"
+ import {performance} from "../../../common/performance"
 
-export type {URI, Time}
+ export type {URI, Time}
 
-export type Display =
-  { opacity: Float
-  }
+ export type Display =
+ { opacity: Float
+ }
 
-export type Disposition =
-  | 'default'
-  | 'foreground-tab'
-  | 'background-tab'
-  | 'new-window'
-  | 'new-popup'
+ export type Disposition =
+ | 'default'
+ | 'foreground-tab'
+ | 'background-tab'
+ | 'new-window'
+ | 'new-popup'
 
-export type Flags =
-  { uri: URI
-  , disposition: Disposition
-  , name: string
-  , features: string
-  , options?: {}
-  , ref: any
-  , guestInstanceId: ?string
-  }
+ export type Flags =
+ { uri: URI
+ , disposition: Disposition
+ , name: string
+ , features: string
+ , options?: {}
+ , ref: any
+ , guestInstanceId: ?string
+ }
 
-export type Action =
-  | { type: "NoOp" }
-  | { type: "Focus" }
-  | { type: "Blur" }
-  | { type: "Load", uri: URI }
-  | { type: "LoadStart", time: Time }
-  | { type: "LoadEnd", time: Time }
-  | { type: "Connect", time: Time }
-  | { type: "LocationChanged"
-    , uri: URI
-    , canGoBack: ?boolean
-    , canGoForward: ?boolean
-    , time: Time
-    }
-  | { type: "FirstPaint" }
-  | { type: "DocumentFirstPaint" }
-  | { type: "MetaChanged", name: string, content: string }
-  | { type: "IconChanged", icon: Icon }
-  | { type: "TitleChanged", title: string }
-  | { type: "SecurityChanged"
-    , state: "broken" | "secure" | "insecure"
-    , extendedValidation: boolean
-    , trackingContent: boolean
-    , mixedContent: boolean
-    }
-  | { type: "Select" }
-  | { type: "Close" }
-  | { type: "Closed" }
-  | { type: "Edit" }
-  | { type: "ShowTabs" }
-  | { type: "Create" }
-  | { type: "Shell", shell: Shell.Action }
-  | { type: "Page", page: Page.Action }
-  | { type: "Tab", tab: Tab.Action }
-  | { type: "Security", security: Security.Action }
-  | { type: "Navigation", navigation: Navigation.Action }
-  | { type: "Open", options: Flags }
-  | { type: "ContextMenu"
-    , clientX: Float
-    , clientY: Float
-    , systemTargets: any
-    , contextMenu: any
-    }
-  | { type: "Authentificate"
-    , host: string
-    , realm: string
-    , isProxy: boolean
-    }
-  | { type: "LoadFail"
-    , time: Time
-    , reason: string
-    , code: Integer
-    }
-  | { type: "ModalPrompt"
-    , kind: "alert" | "confirm" | "prompt"
-    , title: string
-    , message: string
-    }
-*/
+ export type Action =
+ | { type: "NoOp" }
+ | { type: "Focus" }
+ | { type: "Blur" }
+ | { type: "Load", uri: URI }
+ | { type: "LoadStart", time: Time }
+ | { type: "LoadEnd", time: Time }
+ | { type: "Connect", time: Time }
+ | { type: "LocationChanged"
+ , uri: URI
+ , canGoBack: ?boolean
+ , canGoForward: ?boolean
+ , time: Time
+ }
+ | { type: "FirstPaint" }
+ | { type: "DocumentFirstPaint" }
+ | { type: "MetaChanged", name: string, content: string }
+ | { type: "IconChanged", icon: Icon }
+ | { type: "TitleChanged", title: string }
+ | { type: "SecurityChanged"
+ , state: "broken" | "secure" | "insecure"
+ , extendedValidation: boolean
+ , trackingContent: boolean
+ , mixedContent: boolean
+ }
+ | { type: "Select" }
+ | { type: "Close" }
+ | { type: "Closed" }
+ | { type: "Edit" }
+ | { type: "ShowTabs" }
+ | { type: "Create" }
+ | { type: "Shell", shell: Shell.Action }
+ | { type: "Page", page: Page.Action }
+ | { type: "Tab", tab: Tab.Action }
+ | { type: "Security", security: Security.Action }
+ | { type: "Navigation", navigation: Navigation.Action }
+ | { type: "Open", options: Flags }
+ | { type: "ContextMenu"
+ , clientX: Float
+ , clientY: Float
+ , systemTargets: any
+ , contextMenu: any
+ }
+ | { type: "Authentificate"
+ , host: string
+ , realm: string
+ , isProxy: boolean
+ }
+ | { type: "LoadFail"
+ , time: Time
+ , reason: string
+ , code: Integer
+ }
+ | { type: "ModalPrompt"
+ , kind: "alert" | "confirm" | "prompt"
+ , title: string
+ , message: string
+ }
+ */
 
 export class Model {
   /*::
-  ref: Ref.Model;
-  guestInstanceId: ?string;
-  name: string;
-  features: string;
-  tab: Tab.Model;
-  shell: Shell.Model;
-  navigation: Navigation.Model;
-  security: Security.Model;
-  page: Page.Model;
-  */
-  constructor(
-    ref:  Ref.Model
-  , guestInstanceId:  ?string
-  , name:  string
-  , features:  string
-  , tab:  Tab.Model
-  , shell:  Shell.Model
-  , navigation:  Navigation.Model
-  , security:  Security.Model
-  , page:  Page.Model
-  ) {
+   ref: Ref.Model;
+   guestInstanceId: ?string;
+   name: string;
+   features: string;
+   tab: Tab.Model;
+   shell: Shell.Model;
+   navigation: Navigation.Model;
+   security: Security.Model;
+   page: Page.Model;
+   */
+  constructor(ref:Ref.Model, guestInstanceId:?string, name:string, features:string, tab:Tab.Model, shell:Shell.Model,
+              navigation:Navigation.Model, security:Security.Model, page:Page.Model)
+  {
     this.ref = ref
     this.guestInstanceId = guestInstanceId
     this.name = name
@@ -152,344 +140,251 @@ export class Model {
 
 const NoOp = always({ type: "NoOp" });
 
-export const Close: Action =
-  { type: "Close"
-  };
+export const Close:Action = {
+  type: "Close"
+};
 
-export const Select: Action =
-  { type: "Select"
-  };
+export const Select:Action = {
+  type: "Select"
+};
 
-export const Closed: Action =
-  { type: "Closed"
-  };
+export const Closed:Action = {
+  type: "Closed"
+};
 
-export const Edit: Action =
-  { type: "Edit"
-  };
+export const Edit:Action = {
+  type: "Edit"
+};
 
-export const ShowTabs: Action =
-  { type: 'ShowTabs'
-  };
+export const ShowTabs:Action = {
+  type: 'ShowTabs'
+};
 
-export const Create: Action =
-  { type: 'Create'
-  };
+export const Create:Action = {
+  type: 'Create'
+};
 
-export const Focus: Action =
-  { type: 'Focus'
-  };
+export const Focus:Action = {
+  type: 'Focus'
+};
 
-export const Load =
-  (uri: URI): Action =>
-  ( { type: 'Load'
-    , uri
-    }
-  );
+export const Load = (uri:URI):Action =>( {
+  type: 'Load', uri
+}
+);
 
 
-const ShellAction = action =>
-  ( { type: 'Shell'
-    , shell: action
-    }
-  );
+const ShellAction = action =>( {
+  type: 'Shell', shell: action
+}
+);
 
-export const ZoomIn: Action = ShellAction(Shell.ZoomIn);
-export const ZoomOut: Action = ShellAction(Shell.ZoomOut);
-export const ResetZoom: Action = ShellAction(Shell.ResetZoom);
-export const MakeVisible: Action =
-  ShellAction(Shell.MakeVisible);
-export const MakeNotVisible: Action =
-  ShellAction(Shell.MakeNotVisible);
+export const ZoomIn:Action = ShellAction(Shell.ZoomIn);
+export const ZoomOut:Action = ShellAction(Shell.ZoomOut);
+export const ResetZoom:Action = ShellAction(Shell.ResetZoom);
+export const MakeVisible:Action = ShellAction(Shell.MakeVisible);
+export const MakeNotVisible:Action = ShellAction(Shell.MakeNotVisible);
 
-const NavigationAction = action =>
-  ( { type: 'Navigation'
-    , navigation: action
-  });
+const NavigationAction = action =>( {
+  type: 'Navigation', navigation: action
+});
 
-export const Stop: Action =
-  NavigationAction(Navigation.Stop);
-export const Reload: Action =
-  NavigationAction(Navigation.Reload);
-export const GoBack: Action =
-  NavigationAction(Navigation.GoBack);
-export const GoForward: Action =
-  NavigationAction(Navigation.GoForward);
+export const Stop:Action = NavigationAction(Navigation.Stop);
+export const Reload:Action = NavigationAction(Navigation.Reload);
+export const GoBack:Action = NavigationAction(Navigation.GoBack);
+export const GoForward:Action = NavigationAction(Navigation.GoForward);
 
-const SecurityAction = action =>
-  ( { type: 'Security'
-    , security: action
-    }
-  );
+const SecurityAction = action =>( {
+  type: 'Security', security: action
+}
+);
 
-const SecurityChanged =
-  compose
-  ( SecurityAction
-  , Security.Changed
-  );
+const SecurityChanged = compose(SecurityAction, Security.Changed);
 
 
-const PageAction = action =>
-  ({type: "Page", page: action});
+const PageAction = action =>({ type: "Page", page: action });
 
 const FirstPaint = PageAction(Page.FirstPaint);
 const DocumentFirstPaint = PageAction(Page.DocumentFirstPaint);
-const TitleChanged =
-  compose
-  ( PageAction
-  , Page.TitleChanged
-  );
-const IconChanged =
-  compose
-  ( PageAction
-  , Page.IconChanged
-  );
-const MetaChanged =
-  compose
-  ( PageAction
-  , Page.MetaChanged
-  );
-const Scrolled =
-  compose
-  ( PageAction
-  , Page.Scrolled
-  );
-const OverflowChanged =
-  compose
-  ( PageAction
-  , Page.OverflowChanged
-  );
+const TitleChanged = compose(PageAction, Page.TitleChanged);
+const IconChanged = compose(PageAction, Page.IconChanged);
+const MetaChanged = compose(PageAction, Page.MetaChanged);
+const Scrolled = compose(PageAction, Page.Scrolled);
+const OverflowChanged = compose(PageAction, Page.OverflowChanged);
 
 const TabAction = action => {
-    switch (action.type) {
-      case "Close":
-        return Close;
-      case "Select":
-        return Select;
-      default:
-        return {
-          type: "Tab"
-        , tab: action
-        };
-    }
-  };
-
-const updatePage = cursor
-  ( { get: model => model.page
-    , set: (model, page) => merge(model, {page})
-    , tag: PageAction
-    , update: Page.update
-    }
-  );
-
-const updateTab = cursor
-  ( { get: model => model.tab
-    , set: (model, tab) => merge(model, {tab})
-    , tag: TabAction
-    , update: Tab.update
-    }
-  );
-
-const updateShell = cursor
-  ( { get: model => model.shell
-    , set: (model, shell) => merge(model, {shell})
-    , tag: ShellAction
-    , update: Shell.update
-    }
-  );
-
-const updateSecurity = cursor
-  ( { get: model => model.security
-    , set: (model, security) => merge(model, {security})
-    , tag: SecurityAction
-    , update: Security.update
-    })
-
-const updateNavigation = cursor
-  ( { get: model => model.navigation
-    , set: (model, navigation) => merge(model, {navigation})
-    , tag: NavigationAction
-    , update: Navigation.update
-    }
-  );
-
-
-export const init =
-  (options: Flags): [Model, Effects<Action>] => {
-    const ref = Ref.create()
-    return assemble(
-        ref
-      , options.guestInstanceId
-      , options.name
-      , options.features
-      , Tab.init()
-      , Shell.init(ref, false)
-      , Navigation.init(ref, options.uri)
-      , Security.init()
-      , Page.init(options.uri)
-      )
-  };
-
-const assemble =
-  ( ref: Ref.Model
-  , guestInstanceId: ?string
-  , name: string
-  , features: string
-  , [tab, $tab]: [Tab.Model, Effects<Tab.Action>]
-  , [shell, $shell]: [Shell.Model, Effects<Shell.Action>]
-  , [navigation, $navigation]: [Navigation.Model, Effects<Navigation.Action>]
-  , [security, $security]: [Security.Model, Effects<Security.Action>]
-  , [page, $page]: [Page.Model, Effects<Page.Action>]
-  ) => {
-    const model = new Model
-      ( ref
-      , guestInstanceId
-      , name
-      , features
-      , tab
-      , shell
-      , navigation
-      , security
-      , page
-      )
-
-    const fx = Effects.batch
-      ( [ $shell.map(ShellAction)
-        , $page.map(PageAction)
-        , $tab.map(TabAction)
-        , $security.map(SecurityAction)
-        , $navigation.map(NavigationAction)
-        ]
-      )
-
-    return [model, fx]
+  switch (action.type) {
+    case "Close":
+      return Close;
+    case "Select":
+      return Select;
+    default:
+      return {
+        type: "Tab", tab: action
+      };
   }
+};
+
+const updatePage = cursor({
+                            get: model => model.page,
+                            set: (model, page) => merge(model, { page }),
+                            tag: PageAction,
+                            update: Page.update
+                          });
+
+const updateTab = cursor({
+                           get: model => model.tab,
+                           set: (model, tab) => merge(model, { tab }),
+                           tag: TabAction,
+                           update: Tab.update
+                         });
+
+const updateShell = cursor({
+                             get: model => model.shell,
+                             set: (model, shell) => merge(model, { shell }),
+                             tag: ShellAction,
+                             update: Shell.update
+                           });
+
+const updateSecurity = cursor({
+                                get: model => model.security,
+                                set: (model, security) => merge(model, { security }),
+                                tag: SecurityAction,
+                                update: Security.update
+                              })
+
+const updateNavigation = cursor({
+                                  get: model => model.navigation,
+                                  set: (model, navigation) => merge(model, { navigation }),
+                                  tag: NavigationAction,
+                                  update: Navigation.update
+                                });
 
 
-const focus =
-  model =>
-  updateShell(model, Shell.Focus)
+export const init = (options:Flags):[Model, Effects<Action>] => {
+  const ref = Ref.create()
+  return assemble(ref, options.guestInstanceId, options.name, options.features, Tab.init(), Shell.init(ref, false),
+                  Navigation.init(ref, options.uri), Security.init(), Page.init(options.uri))
+};
 
-const load = (model, uri) =>
-  updateNavigation(model, Navigation.Load(uri));
+const assemble = (ref:Ref.Model, guestInstanceId:?string, name:string, features:string,
+    [tab, $tab]: [Tab.Model, Effects<Tab.Action>], [shell, $shell]: [Shell.Model, Effects<Shell.Action>],
+    [navigation, $navigation]: [Navigation.Model, Effects<Navigation.Action>],
+    [security, $security]: [Security.Model, Effects<Security.Action>],
+    [page, $page]: [Page.Model, Effects<Page.Action>]) => {
+  const model = new Model(ref, guestInstanceId, name, features, tab, shell, navigation, security, page)
+
+  const fx = Effects.batch([
+                             $shell.map(ShellAction),
+                             $page.map(PageAction),
+                             $tab.map(TabAction),
+                             $security.map(SecurityAction),
+                             $navigation.map(NavigationAction)
+                           ])
+
+  return [model, fx]
+}
 
 
-const startLoad = (model, time) =>
-  batch
-  ( update
-  , model
-  , [ PageAction(Page.LoadStart)
-    , SecurityAction(Security.LoadStart)
-    ]
-  );
+const focus = model =>updateShell(model, Shell.Focus)
 
-const endLoad = (model, time) =>
-  batch
-  ( update
-  , model
-  , [ PageAction(Page.LoadEnd)
-    ]
-  );
+const load = (model, uri) =>updateNavigation(model, Navigation.Load(uri));
+
+
+const startLoad = (model, time) =>batch(update, model, [
+  PageAction(Page.LoadStart), SecurityAction(Security.LoadStart)
+]);
+
+const endLoad = (model, time) =>batch(update, model, [
+  PageAction(Page.LoadEnd)
+]);
 
 const nofx = /*::<model, action>*/
-  (model: model): [model, Effects<action>] =>
-  [ model, Effects.none ]
+    (model:model):[model, Effects<action>] =>[model, Effects.none]
 
 const connect = nofx;
 
-const changeLocation = (model, uri, canGoBack, canGoForward) =>
-  batch
-  ( update
-  , model
-  , [ NavigationAction(Navigation.LocationChanged(uri, canGoBack, canGoForward))
-    , PageAction(Page.LocationChanged(uri))
-    ]
-  );
+const changeLocation = (model, uri, canGoBack, canGoForward) =>batch(update, model, [
+  NavigationAction(Navigation.LocationChanged(uri, canGoBack, canGoForward)), PageAction(Page.LocationChanged(uri))
+]);
 
-const close = model =>
-  [ model, Effects.receive(Closed) ];
+const close = model =>[model, Effects.receive(Closed)];
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] => {
-    switch (action.type) {
-      case "NoOp":
-        return [ model, Effects.none ];
-      case "Focus":
-        return focus(model);
-      case "Blur":
-        return updateShell(model, action);
-      case "Load":
-        return load(model, action.uri);
+export const update = (model:Model, action:Action):[Model, Effects<Action>] => {
+  switch (action.type) {
+    case "NoOp":
+      return [model, Effects.none];
+    case "Focus":
+      return focus(model);
+    case "Blur":
+      return updateShell(model, action);
+    case "Load":
+      return load(model, action.uri);
 
-  // Dispatch
-      case "LoadStart":
-        return startLoad(model, action.time);
-      case "LoadEnd":
-        return endLoad(model, action.time);
-      case "Connect":
-        return connect(model, action.time);
-      case "LocationChanged":
-        return changeLocation(model, action.uri, action.canGoBack, action.canGoForward);
-      case "SecurityChanged":
-        return updateSecurity(model, action);
-      case "TitleChanged":
-        return updatePage(model, action);
-      case "IconChanged":
-        return updatePage(model, action);
-      case "MetaChanged":
-        return updatePage(model, action);
-      case "FirstPaint":
-        return updatePage(model, action);
-      case "DocumentFirstPaint":
-        return updatePage(model, action);
-      case "LoadFail":
-        return [ model
-          , Effects.perform(Unknown.warn(action))
-            .map(NoOp)
-          ];
-      case "Close":
-        return close(model);
+      // Dispatch
+    case "LoadStart":
+      return startLoad(model, action.time);
+    case "LoadEnd":
+      return endLoad(model, action.time);
+    case "Connect":
+      return connect(model, action.time);
+    case "LocationChanged":
+      return changeLocation(model, action.uri, action.canGoBack, action.canGoForward);
+    case "SecurityChanged":
+      return updateSecurity(model, action);
+    case "TitleChanged":
+      return updatePage(model, action);
+    case "IconChanged":
+      return updatePage(model, action);
+    case "MetaChanged":
+      return updatePage(model, action);
+    case "FirstPaint":
+      return updatePage(model, action);
+    case "DocumentFirstPaint":
+      return updatePage(model, action);
+    case "LoadFail":
+      return [
+        model, Effects.perform(Unknown.warn(action))
+                      .map(NoOp)
+      ];
+    case "Close":
+      return close(model);
 
-  // Delegate
-      case "Shell":
-        return updateShell(model, action.shell);
-      case "Page":
-        return updatePage(model, action.page);
-      case "Tab":
-        return updateTab(model, action.tab);
-      case "Security":
-        return updateSecurity(model, action.security);
-      case "Navigation":
-        return updateNavigation(model, action.navigation);
-      default:
-        return Unknown.update(model, action);
-    }
-  };
+      // Delegate
+    case "Shell":
+      return updateShell(model, action.shell);
+    case "Page":
+      return updatePage(model, action.page);
+    case "Tab":
+      return updateTab(model, action.tab);
+    case "Security":
+      return updateSecurity(model, action.security);
+    case "Navigation":
+      return updateNavigation(model, action.navigation);
+    default:
+      return Unknown.update(model, action);
+  }
+};
 
 const topBarHeight = '27px';
 
 const styleSheet = StyleSheet.create({
-  base: {
-    position: 'absolute',
-    top: topBarHeight,
-    left: 0,
-    width: '100%',
-    height: `calc(100% - ${topBarHeight})`,
-    mozUserSelect: 'none', // necessary to pass text drag to iframe's content
-    borderWidth: 0,
-    backgroundColor: 'white',
-    MozWindowDragging: 'no-drag',
-    WebkitAppRegion: 'no-drag',
-  }
-});
+                                       base: {
+                                         position: 'absolute',
+                                         top: topBarHeight,
+                                         left: 0,
+                                         width: '100%',
+                                         height: `calc(100% - ${topBarHeight})`,
+                                         mozUserSelect: 'none', // necessary to pass text drag to iframe's content
+                                         borderWidth: 0,
+                                         backgroundColor: 'white',
+                                         MozWindowDragging: 'no-drag',
+                                         WebkitAppRegion: 'no-drag',
+                                       }
+                                     });
 
-const Frame =
-  ( isElectron
-  ? ElectronFrame
-  : MozBrowserFrame
-  );
+const Frame = ( isElectron ? ElectronFrame : MozBrowserFrame
+);
 
 
-export const view =
-  (model: Model, address: Address<Action>): DOM =>
-  Frame.view(styleSheet, model, address);
+export const view = (model:Model, address:Address<Action>):DOM =>Frame.view(styleSheet, model, address);

--- a/src/browser/Navigators/Navigator/WebView/ElectronFrame.js
+++ b/src/browser/Navigators/Navigator/WebView/ElectronFrame.js
@@ -24,9 +24,9 @@ const DocumentFirstPaint = always({ type: "DocumentFirstPaint" });
 
 export const view =
   ( styleSheet/*:{ base: Style.Rules }*/
-  , model/*:Model*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  , model: Model
+  , address: Address<Action>
+  ): DOM =>
   node
   ( 'webview'
   , { [model.ref.name]: model.ref.value

--- a/src/browser/Navigators/Navigator/WebView/ElectronFrame.js
+++ b/src/browser/Navigators/Navigator/WebView/ElectronFrame.js
@@ -1,18 +1,16 @@
 /* @flow */
 
-import {Effects, node, html, forward} from 'reflex';
-import * as URL from '../../../../common/url-helper';
-import * as Driver from '@driver';
-import * as Style from '../../../../common/style';
-import {on} from '@driver';
-import {always} from '../../../../common/prelude';
+import { node, forward } from 'reflex'
+import { on } from '@driver'
+import * as Style from '../../../../common/style'
+import { always } from '../../../../common/prelude'
 
 
 /*::
-import type {Address, DOM} from "reflex"
-import type {Model, Action} from "../WebView"
-import {performance} from "../../../../common/performance"
-*/
+ import type {Address, DOM} from "reflex"
+ import type {Model, Action} from "../WebView"
+ import {performance} from "../../../../common/performance"
+ */
 
 const Blur = always({ type: "Blur" });
 const Focus = always({ type: "Focus" });
@@ -21,125 +19,89 @@ const FirstPaint = always({ type: "FirstPaint" });
 const DocumentFirstPaint = always({ type: "DocumentFirstPaint" });
 
 
+export const view = (styleSheet/*:{ base: Style.Rules }*/, model:Model, address:Address<Action>):DOM =>node('webview', {
+  [model.ref.name]: model.ref.value,
+  src: model.navigation.src,
+  'data-current-uri': model.navigation.currentURI,
+  'data-name': model.name,
+  'data-features': model.features
+  // Stock electron does not actually connect a window with it's opener in any
+  // way. Brave desktop browser has patched Electron to add support for it
+  // via `data-guest-instance-id` attribute. Once that patch is uplifted
+  // this will take take care of connecting a window and it's opener. For more
+  // details see: https://github.com/browserhtml/browserhtml/issues/566
+  ,
+  'data-guest-instance-id': ( model.guestInstanceId == null ? void(0) : model.guestInstanceId
+  ),
+  style: Style.mix(styleSheet.base,
+                   ( model.page.pallet.background != null ? { backgroundColor: model.page.pallet.background } : null
+                   ))
 
-export const view =
-  ( styleSheet/*:{ base: Style.Rules }*/
-  , model: Model
-  , address: Address<Action>
-  ): DOM =>
-  node
-  ( 'webview'
-  , { [model.ref.name]: model.ref.value
-    , src: model.navigation.src
-    , 'data-current-uri': model.navigation.currentURI
-    , 'data-name': model.name
-    , 'data-features': model.features
-    // Stock electron does not actually connect a window with it's opener in any
-    // way. Brave desktop browser has patched Electron to add support for it
-    // via `data-guest-instance-id` attribute. Once that patch is uplifted
-    // this will take take care of connecting a window and it's opener. For more
-    // details see: https://github.com/browserhtml/browserhtml/issues/566
-    , 'data-guest-instance-id':
-      ( model.guestInstanceId == null
-      ? void(0)
-      : model.guestInstanceId
-      )
-    , style: Style.mix
-      ( styleSheet.base
-      , ( model.page.pallet.background != null
-        ? { backgroundColor: model.page.pallet.background }
-        : null
-        )
-      )
+  // Events
 
-    // Events
-
-    , onBlur: forward(address, Blur)
-    , onFocus: forward(address, Focus)
-    , onClose: on(address, Close)
-    , "onNew-Window": on(address, decodeOpenWindow)
-    , "onPage-Favicon-Updated": on(address, decodeIconChange)
-    , "onPage-Title-Updated": on(address, decodeTitleChange)
-    , "onDid-Start-Loading": on(address, decodeLoadStart)
-    , "onDid-Navigate": on(address, decodeLocationChange)
-    , "onDid-Fail-Load": on(address, decodeLoadFail)
-    , "onDid-Stop-Loading": on(address, decodeLoadEnd)
-    , "onDid-Change-Theme-Color": on(address, decodeMetaChange)
-    , "onDOM-Ready": forward(address, DocumentFirstPaint)
-    ,
-    }
-  );
+  ,
+  onBlur: forward(address, Blur),
+  onFocus: forward(address, Focus),
+  onClose: on(address, Close),
+  "onNew-Window": on(address, decodeOpenWindow),
+  "onPage-Favicon-Updated": on(address, decodeIconChange),
+  "onPage-Title-Updated": on(address, decodeTitleChange),
+  "onDid-Start-Loading": on(address, decodeLoadStart),
+  "onDid-Navigate": on(address, decodeLocationChange),
+  "onDid-Fail-Load": on(address, decodeLoadFail),
+  "onDid-Stop-Loading": on(address, decodeLoadEnd),
+  "onDid-Change-Theme-Color": on(address, decodeMetaChange),
+  "onDOM-Ready": forward(address, DocumentFirstPaint),
+});
 
 // See: http://electron.atom.io/docs/v0.37.4/api/web-view-tag/#event-new-window
-const decodeOpenWindow =
-  ( event ) =>
-  ( { type: "Open"
-    , options:
-      { uri: event.url
-      , name: event.frameName
-      , disposition: event.disposition
-      , features: ''
-      , guestInstanceId:
-        ( ( event.options != null &&
-            event.options.webPreferences != null
-          )
-        ? event.options.webPreferences.guestInstanceId
-        : null
-        )
-      , ref: null
-      , options: event.options
-      }
-    }
-  );
+const decodeOpenWindow = (event) =>( {
+  type: "Open", options: {
+    uri: event.url,
+    name: event.frameName,
+    disposition: event.disposition,
+    features: '',
+    guestInstanceId: ( ( event.options != null && event.options.webPreferences != null
+        ) ? event.options.webPreferences.guestInstanceId : null
+    ),
+    ref: null,
+    options: event.options
+  }
+}
+);
 
 // See: http://electron.atom.io/docs/v0.37.4/api/web-view-tag/#event-page-favicon-updated
-const decodeIconChange =
-  ( event ) =>
-  ( { type: "IconChanged"
-    , icon:
-      { href:
-        ( event.favicons.length > 0
-        ? event.favicons[0]
-        : ''
-        )
-      , rel: null
-      }
-    }
-  );
+const decodeIconChange = (event) =>( {
+  type: "IconChanged", icon: {
+    href: ( event.favicons.length > 0 ? event.favicons[0] : ''
+    ), rel: null
+  }
+}
+);
 
 // See: http://electron.atom.io/docs/v0.37.4/api/web-view-tag/#event-page-title-updated
-const decodeTitleChange =
-  ( event ) =>
-  ( { type: "TitleChanged"
-    , title: event.title
-    }
-  );
+const decodeTitleChange = (event) =>( {
+  type: "TitleChanged", title: event.title
+}
+);
 
 // See: http://electron.atom.io/docs/v0.37.4/api/web-view-tag/#event-load-commit
-const decodeLoadStart =
-  ( event ) =>
-  ( { type: "LoadStart"
-    , time: performance.now()
-    }
-  );
+const decodeLoadStart = (event) =>( {
+  type: "LoadStart", time: performance.now()
+}
+);
 
 // See: http://electron.atom.io/docs/v0.37.4/api/web-view-tag/#event-did-frame-finish-load
-const decodeLoadEnd =
-  ( event ) =>
-  ( { type: "LoadEnd"
-    , time: performance.now()
-    }
-  );
+const decodeLoadEnd = (event) =>( {
+  type: "LoadEnd", time: performance.now()
+}
+);
 
 // See: http://electron.atom.io/docs/v0.37.4/api/web-view-tag/#event-did-fail-load
-const decodeLoadFail =
-  ( event ) =>
-  ( { type: "LoadFail"
-    , time: performance.now()
-    , reason: event.errorDescription
-    , code: event.errorCode
-    }
-  );
+const decodeLoadFail = (event) =>( {
+  type: "LoadFail", time: performance.now(), reason: event.errorDescription, code: event.errorCode
+}
+);
 
 // @TODO: We are missing "Connected" event and I think 'did-get-response-details'
 // maybe it in electron.
@@ -147,21 +109,17 @@ const decodeLoadFail =
 
 // See: http://electron.atom.io/docs/v0.37.4/api/web-view-tag/#event-did-navigate
 // TODO: Consider `will-navigate` event instead.
-const decodeLocationChange =
-  ( event ) =>
-  ( { type: "LocationChanged"
-    , uri: event.url
-    , time: performance.now()
-    , canGoBack: event.target.canGoBack()
-    , canGoForward: event.target.canGoForward()
-    }
-  );
+const decodeLocationChange = (event) =>( {
+  type: "LocationChanged",
+  uri: event.url,
+  time: performance.now(),
+  canGoBack: event.target.canGoBack(),
+  canGoForward: event.target.canGoForward()
+}
+);
 
 // See: http://electron.atom.io/docs/v0.37.4/api/web-view-tag/#event-did-change-theme-color
-const decodeMetaChange =
-  ( event ) =>
-  ( { type: "MetaChanged"
-    , name: "theme-color"
-    , content: event.themeColor
-    }
-  );
+const decodeMetaChange = (event) =>( {
+  type: "MetaChanged", name: "theme-color", content: event.themeColor
+}
+);

--- a/src/browser/Navigators/Navigator/WebView/MozBrowserFrame.js
+++ b/src/browser/Navigators/Navigator/WebView/MozBrowserFrame.js
@@ -22,9 +22,9 @@ const DocumentFirstPaint = always({ type: "DocumentFirstPaint" });
 
 export const view =
   ( styleSheet/*:{ base: Style.Rules }*/
-  , model/*:Model*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  , model: Model
+  , address: Address<Action>
+  ): DOM =>
   html.iframe
   ( { [model.ref.name]: model.ref.value
     , src: model.navigation.src

--- a/src/browser/Navigators/Navigator/WebView/MozBrowserFrame.js
+++ b/src/browser/Navigators/Navigator/WebView/MozBrowserFrame.js
@@ -1,18 +1,17 @@
 /* @flow */
 
-import {Effects, node, html, forward} from 'reflex';
-import * as URL from '../../../../common/url-helper';
-import * as Driver from '@driver';
-import * as Style from '../../../../common/style';
-import {on} from '@driver';
-import {always} from '../../../../common/prelude';
+import { html, forward } from 'reflex'
+import * as URL from '../../../../common/url-helper'
+import { on } from '@driver'
+import * as Style from '../../../../common/style'
+import { always } from '../../../../common/prelude'
 
 
 /*::
-import type {Address, DOM} from "reflex"
-import type {Model, Action} from "../WebView"
-import {performance} from "../../../../common/performance"
-*/
+ import type {Address, DOM} from "reflex"
+ import type {Model, Action} from "../WebView"
+ import {performance} from "../../../../common/performance"
+ */
 
 const Blur = always({ type: "Blur" });
 const Focus = always({ type: "Focus" });
@@ -20,220 +19,214 @@ const Close = always({ type: "Close" });
 const FirstPaint = always({ type: "FirstPaint" });
 const DocumentFirstPaint = always({ type: "DocumentFirstPaint" });
 
-export const view =
-  ( styleSheet/*:{ base: Style.Rules }*/
-  , model: Model
-  , address: Address<Action>
-  ): DOM =>
-  html.iframe
-  ( { [model.ref.name]: model.ref.value
-    , src: model.navigation.src
-    , 'data-current-uri': model.navigation.currentURI
-    , 'data-name': model.name
-    , 'data-features': model.features
-    , style: Style.mix
-      ( styleSheet.base
-      , frameStyleSheet.mozbrowser
-      , ( model.page.pallet.background != null
-        ? { backgroundColor: model.page.pallet.background }
-        : null
-        )
-      )
-    , attributes:
-      { mozbrowser: true
-      , remote: true
-      , mozapp:
-        ( URL.isPrivileged(model.navigation.currentURI)
-        ? URL.getManifestURL().href
-        : void(0)
-        )
-      , mozallowfullscreen: true
-      }
+export const view = (styleSheet/*:{ base: Style.Rules }*/, model:Model, address:Address<Action>):DOM =>html.iframe({
+                                                                                                                     [model.ref.name]: model.ref.value,
+                                                                                                                     src: model.navigation.src,
+                                                                                                                     'data-current-uri': model.navigation.currentURI,
+                                                                                                                     'data-name': model.name,
+                                                                                                                     'data-features': model.features,
+                                                                                                                     style: Style.mix(
+                                                                                                                         styleSheet.base,
+                                                                                                                         frameStyleSheet.mozbrowser,
+                                                                                                                         ( model.page.pallet.background != null
+                                                                                                                                 ? { backgroundColor: model.page.pallet.background }
+                                                                                                                                 : null
+                                                                                                                         )),
+                                                                                                                     attributes: {
+                                                                                                                       mozbrowser: true,
+                                                                                                                       remote: true,
+                                                                                                                       mozapp: ( URL.isPrivileged(
+                                                                                                                               model.navigation.currentURI)
+                                                                                                                               ? URL.getManifestURL().href
+                                                                                                                               : void(0)
+                                                                                                                       ),
+                                                                                                                       mozallowfullscreen: true
+                                                                                                                     }
 
-    // Events
+                                                                                                                     // Events
 
-    , onBlur: forward(address, Blur)
-    , onFocus: forward(address, Focus)
-    , onMozBrowserClose: on(address, Close)
-    , onMozBrowserOpenWindow: on(address, decodeOpenWindow)
-    , onMozBrowserOpenTab: on(address, decodeOpenTab)
-    , onMozBrowserContextMenu: on(address, decodeContexMenu)
-    , onMozBrowserError: on(address, decodeLoadFail)
-    , onMozBrowserLoadStart: on(address, decodeLoadStart)
-    , onMozBrowserConnected: on(address, decodeConnected)
-    , onMozBrowserLoadEnd: on(address, decodeLoadEnd)
-    , onMozBrowserFirstPaint: on(address, FirstPaint)
-    , onMozBrowserDocumentFirstPaint: on(address, DocumentFirstPaint)
-    , onMozBrowserMetaChange: on(address, decodeMetaChange)
-    , onMozBrowserIconChange: on(address, decodeIconChange)
-    , onMozBrowserLocationChange: on(address, decodeLocationChange)
-    , onMozBrowserSecurityChange: on(address, decodeSecurityChange)
-    , onMozBrowserTitleChange: on(address, decodeTitleChange)
-    , onMozBrowserShowModalPrompt: on(address, decodeModalPrompt)
-    , onMozBrowserUserNameAndPasswordRequired: on(address, decodeAuthenticate)
-    }
-  );
+                                                                                                                     ,
+                                                                                                                     onBlur: forward(
+                                                                                                                         address,
+                                                                                                                         Blur),
+                                                                                                                     onFocus: forward(
+                                                                                                                         address,
+                                                                                                                         Focus),
+                                                                                                                     onMozBrowserClose: on(
+                                                                                                                         address,
+                                                                                                                         Close),
+                                                                                                                     onMozBrowserOpenWindow: on(
+                                                                                                                         address,
+                                                                                                                         decodeOpenWindow),
+                                                                                                                     onMozBrowserOpenTab: on(
+                                                                                                                         address,
+                                                                                                                         decodeOpenTab),
+                                                                                                                     onMozBrowserContextMenu: on(
+                                                                                                                         address,
+                                                                                                                         decodeContexMenu),
+                                                                                                                     onMozBrowserError: on(
+                                                                                                                         address,
+                                                                                                                         decodeLoadFail),
+                                                                                                                     onMozBrowserLoadStart: on(
+                                                                                                                         address,
+                                                                                                                         decodeLoadStart),
+                                                                                                                     onMozBrowserConnected: on(
+                                                                                                                         address,
+                                                                                                                         decodeConnected),
+                                                                                                                     onMozBrowserLoadEnd: on(
+                                                                                                                         address,
+                                                                                                                         decodeLoadEnd),
+                                                                                                                     onMozBrowserFirstPaint: on(
+                                                                                                                         address,
+                                                                                                                         FirstPaint),
+                                                                                                                     onMozBrowserDocumentFirstPaint: on(
+                                                                                                                         address,
+                                                                                                                         DocumentFirstPaint),
+                                                                                                                     onMozBrowserMetaChange: on(
+                                                                                                                         address,
+                                                                                                                         decodeMetaChange),
+                                                                                                                     onMozBrowserIconChange: on(
+                                                                                                                         address,
+                                                                                                                         decodeIconChange),
+                                                                                                                     onMozBrowserLocationChange: on(
+                                                                                                                         address,
+                                                                                                                         decodeLocationChange),
+                                                                                                                     onMozBrowserSecurityChange: on(
+                                                                                                                         address,
+                                                                                                                         decodeSecurityChange),
+                                                                                                                     onMozBrowserTitleChange: on(
+                                                                                                                         address,
+                                                                                                                         decodeTitleChange),
+                                                                                                                     onMozBrowserShowModalPrompt: on(
+                                                                                                                         address,
+                                                                                                                         decodeModalPrompt),
+                                                                                                                     onMozBrowserUserNameAndPasswordRequired: on(
+                                                                                                                         address,
+                                                                                                                         decodeAuthenticate)
+                                                                                                                   });
 
 // See: https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowseropenwindow
-const decodeOpenWindow =
-  ( { detail } ) =>
-  ( { type: "Open"
-    , options:
-      { uri: detail.url
-      , disposition: 'default'
-      , name: detail.name
-      , features: detail.features
-      , ref: detail.frameElement
-      , guestInstanceId: null
-      }
-    }
-  );
+const decodeOpenWindow = ({ detail }) =>( {
+  type: "Open", options: {
+    uri: detail.url,
+    disposition: 'default',
+    name: detail.name,
+    features: detail.features,
+    ref: detail.frameElement,
+    guestInstanceId: null
+  }
+}
+);
 
 // See: https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowseropentab
-const decodeOpenTab =
-  ( { detail } ) =>
-  ( { type: "Open"
-    , options:
-      { uri: detail.url
-      , disposition: 'default'
-      , name: ''
-      , features: ''
-      , ref: null
-      , guestInstanceId: null
-      }
-    }
-  );
+const decodeOpenTab = ({ detail }) =>( {
+  type: "Open", options: {
+    uri: detail.url, disposition: 'default', name: '', features: '', ref: null, guestInstanceId: null
+  }
+}
+);
 
 // See: https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowsererror
-const decodeLoadFail =
-  ( { detail } ) =>
-  ( { type: "LoadFail"
-    , time: performance.now()
-    , reason: detail.type
-    // Gecko unlike Electron does not actually pass error codes. Absense of
-    // it is identified as `-1` which is what used here.
-    , code: -1
-    }
-  );
+const decodeLoadFail = ({ detail }) =>( {
+  type: "LoadFail", time: performance.now(), reason: detail.type
+  // Gecko unlike Electron does not actually pass error codes. Absense of
+  // it is identified as `-1` which is what used here.
+  , code: -1
+}
+);
 
 // See: https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowsercontextmenu
-const decodeContexMenu =
-  ( { detail } ) =>
-  ( { type: "ContextMenu"
-    , clientX: detail.clientX
-    , clientY: detail.clientY
-    , systemTargets: detail.systemTargets
-    , contextMenu: detail.contextmenu
-    }
-  );
+const decodeContexMenu = ({ detail }) =>( {
+  type: "ContextMenu",
+  clientX: detail.clientX,
+  clientY: detail.clientY,
+  systemTargets: detail.systemTargets,
+  contextMenu: detail.contextmenu
+}
+);
 
 // See: https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowserloadstart
-const decodeLoadStart =
-  ( { detail } ) =>
-  ( { type: "LoadStart"
-    , time: performance.now()
-    }
-  );
+const decodeLoadStart = ({ detail }) =>( {
+  type: "LoadStart", time: performance.now()
+}
+);
 
 // See: https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowserloadend
-const decodeLoadEnd =
-  ( { detail } ) =>
-  ( { type: "LoadEnd"
-    , time: performance.now()
-    }
-  );
+const decodeLoadEnd = ({ detail }) =>( {
+  type: "LoadEnd", time: performance.now()
+}
+);
 
-const decodeConnected =
-  ( { detail } ) =>
-  ( { type: "Connect"
-    , time: performance.now()
-    }
-  );
+const decodeConnected = ({ detail }) =>( {
+  type: "Connect", time: performance.now()
+}
+);
 
-const decodeMetaChange =
-  ( { detail } ) =>
-  ( { type: "MetaChanged"
-    , name: detail.name
-    , content: detail.content
-    }
-  );
+const decodeMetaChange = ({ detail }) =>( {
+  type: "MetaChanged", name: detail.name, content: detail.content
+}
+);
 
 // See: https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowsericonchange
-const decodeIconChange =
-  ( { detail } ) =>
-  ( { type: "IconChanged"
-    , icon:
-      { href: detail.href
-      , sizes: detail.sizes
-      , rel: detail.rel
-      }
-    }
-  );
+const decodeIconChange = ({ detail }) =>( {
+  type: "IconChanged", icon: {
+    href: detail.href, sizes: detail.sizes, rel: detail.rel
+  }
+}
+);
 
 // See: https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowserlocationchange
 
-const decodeLocationChange =
-  ( { detail } ) =>
-  // Servo and Gecko have different implementation of detail.
-  // In Gecko, detail is a string (the uri).
-  // In Servo, detail is an object {uri,canGoBack,canGoForward}
-  ( typeof(detail) === "string"
-  ? { type: "LocationChanged"
-    , uri: detail
-    , time: performance.now()
-    , canGoBack: null
-    , canGoForward: null
-    }
-  : { type: "LocationChanged"
-    , uri: detail.uri
-    , time: performance.now()
-    , canGoBack: detail.canGoBack
-    , canGoForward: detail.canGoForward
-    }
-  );
+const decodeLocationChange = ({ detail }) =>// Servo and Gecko have different implementation of detail.
+    // In Gecko, detail is a string (the uri).
+    // In Servo, detail is an object {uri,canGoBack,canGoForward}
+    ( typeof(detail) === "string"
+            ? {
+          type: "LocationChanged",
+          uri: detail,
+          time: performance.now(),
+          canGoBack: null,
+          canGoForward: null
+        }
+            : {
+          type: "LocationChanged",
+          uri: detail.uri,
+          time: performance.now(),
+          canGoBack: detail.canGoBack,
+          canGoForward: detail.canGoForward
+        }
+    );
 
 // See: https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowsersecuritychange
-const decodeSecurityChange =
-  ( { detail } ) =>
-  ( { type: "SecurityChanged"
-    , state: detail.state
-    , extendedValidation: detail.extendedValidation
-    , trackingContent: detail.trackingContent
-    , mixedContent: detail.mixedContent
-    }
-  );
+const decodeSecurityChange = ({ detail }) =>( {
+  type: "SecurityChanged",
+  state: detail.state,
+  extendedValidation: detail.extendedValidation,
+  trackingContent: detail.trackingContent,
+  mixedContent: detail.mixedContent
+}
+);
 
-const decodeTitleChange =
-  ( { detail } ) =>
-  ( { type: "TitleChanged"
-    , title: detail
-    }
-  );
+const decodeTitleChange = ({ detail }) =>( {
+  type: "TitleChanged", title: detail
+}
+);
 
 // See: https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowsershowmodalprompt
-const decodeModalPrompt =
-  ( { detail } ) =>
-  ( { type: "ModalPrompt"
-    , kind: detail.promptType
-    , title: detail.title
-    , message: detail.message
-    }
-  );
+const decodeModalPrompt = ({ detail }) =>( {
+  type: "ModalPrompt", kind: detail.promptType, title: detail.title, message: detail.message
+}
+);
 
 // See: https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowserusernameandpasswordrequired
-const decodeAuthenticate =
-  ( { detail } ) =>
-  ( { type: "Authentificate"
-    , host: detail.host
-    , realm: detail.realm
-    , isProxy: detail.isProxy
-    }
-  );
+const decodeAuthenticate = ({ detail }) =>( {
+  type: "Authentificate", host: detail.host, realm: detail.realm, isProxy: detail.isProxy
+}
+);
 
 
-const frameStyleSheet = Style.createSheet
-  ( { mozbrowser:
-      { display: "block"
-      }
-    }
-  );
+const frameStyleSheet = Style.createSheet({
+                                            mozbrowser: {
+                                              display: "block"
+                                            }
+                                          });

--- a/src/browser/Navigators/Navigator/WebView/Navigation.js
+++ b/src/browser/Navigators/Navigator/WebView/Navigation.js
@@ -4,79 +4,73 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {always} from '../../../../common/prelude';
-import {ok, error} from '../../../../common/result';
-import {Effects, Task} from 'reflex';
+import { always } from '../../../../common/prelude'
+import { ok, error } from '../../../../common/result'
+import { Effects, Task } from 'reflex'
 import * as Unknown from '../../../../common/unknown'
-import * as Ref from '../../../../common/ref';
+import * as Ref from '../../../../common/ref'
 
 /*::
-import type {Never} from "reflex";
-import type {Result} from '../../../../common/result';
-import type {ID, URI, Time} from "../../../../common/prelude"
+ import type {Never} from "reflex";
+ import type {Result} from '../../../../common/result';
+ import type {ID, URI, Time} from "../../../../common/prelude"
 
-export type Action =
-  | { type: "NoOp" }
-  | { type: "LocationChanged"
-    , uri: URI
-    , canGoBack: ?boolean
-    , canGoForward: ?boolean
-    }
-  | { type: "Load"
-    , uri: URI
-    }
-  | { type: "Stop" }
-  | { type: "Reload" }
-  | { type: "GoBack" }
-  | { type: "GoForward" }
-  // When the model is updated with the above action, effects with the following
-  // response actions are triggered.
-  | { type: "CanGoBackChanged"
-    , canGoBackChanged: Result<Error, boolean>
-    }
-  | { type: "CanGoForwardChanged"
-    , canGoForwardChanged: Result<Error, boolean>
-    }
-  | { type: "Stopped"
-    , stopped: Result<Error, void>
-    }
-  | { type: "Reloaded"
-    , reloaded: Result<Error, void>
-    }
-  | { type: "WentBack"
-    , wentBack: Result<Error, void>
-    }
-  | { type: "WentForward"
-    , wentForward: Result<Error, void>
-    }
-*/
+ export type Action =
+ | { type: "NoOp" }
+ | { type: "LocationChanged"
+ , uri: URI
+ , canGoBack: ?boolean
+ , canGoForward: ?boolean
+ }
+ | { type: "Load"
+ , uri: URI
+ }
+ | { type: "Stop" }
+ | { type: "Reload" }
+ | { type: "GoBack" }
+ | { type: "GoForward" }
+ // When the model is updated with the above action, effects with the following
+ // response actions are triggered.
+ | { type: "CanGoBackChanged"
+ , canGoBackChanged: Result<Error, boolean>
+ }
+ | { type: "CanGoForwardChanged"
+ , canGoForwardChanged: Result<Error, boolean>
+ }
+ | { type: "Stopped"
+ , stopped: Result<Error, void>
+ }
+ | { type: "Reloaded"
+ , reloaded: Result<Error, void>
+ }
+ | { type: "WentBack"
+ , wentBack: Result<Error, void>
+ }
+ | { type: "WentForward"
+ , wentForward: Result<Error, void>
+ }
+ */
 
 export class Model {
   /*::
-  ref: Ref.Model;
-  canGoBack: boolean;
-  canGoForward: boolean;
-  // URI of the page displayed by a web-view. This uri updates during any
-  // redirects or when the user navigates away by going back / forward or by
-  // navigating to a new uri.
-  currentURI: URI;
-  // URI that was entered in a location bar by the user. Note this may not be an
-  // URI of currently loaded page as URI could have being redirect or the user
-  // could have navigated away by clicking a link or pressing go back / go
-  // forward buttons.
-  // Note: This field is needed to workaround unfortunate API of the iframe.
-  // The field's value is used as `src` attribute of the iframe and we can't use
-  // `currentURI` as that would cause iframe a reload every time the user
-  // navigates away & also destroy navgation history along the way.
-  src: URI;
-  */
-  constructor(
-    ref:  Ref.Model
-  , canGoBack:  boolean
-  , canGoForward:  boolean
-  , currentURI:  URI
-  , src:  URI
-  ) {
+   ref: Ref.Model;
+   canGoBack: boolean;
+   canGoForward: boolean;
+   // URI of the page displayed by a web-view. This uri updates during any
+   // redirects or when the user navigates away by going back / forward or by
+   // navigating to a new uri.
+   currentURI: URI;
+   // URI that was entered in a location bar by the user. Note this may not be an
+   // URI of currently loaded page as URI could have being redirect or the user
+   // could have navigated away by clicking a link or pressing go back / go
+   // forward buttons.
+   // Note: This field is needed to workaround unfortunate API of the iframe.
+   // The field's value is used as `src` attribute of the iframe and we can't use
+   // `currentURI` as that would cause iframe a reload every time the user
+   // navigates away & also destroy navgation history along the way.
+   src: URI;
+   */
+  constructor(ref:Ref.Model, canGoBack:boolean, canGoForward:boolean, currentURI:URI, src:URI) {
     this.ref = ref
     this.canGoBack = canGoBack
     this.canGoForward = canGoForward
@@ -87,106 +81,87 @@ export class Model {
 
 
 // User interaction interaction may also triggered following actions:
-export const Stop: Action = {type: "Stop"};
-export const Reload: Action = {type: "Reload"};
-export const GoBack: Action = {type: "GoBack"};
-export const GoForward: Action = {type: "GoForward"};
+export const Stop:Action = { type: "Stop" };
+export const Reload:Action = { type: "Reload" };
+export const GoBack:Action = { type: "GoBack" };
+export const GoForward:Action = { type: "GoForward" };
 
-const NoOp = always({type: "NoOp"});
-export const Load =
-  (uri: URI): Action =>
-  ({type: "Load", uri});
+const NoOp = always({ type: "NoOp" });
+export const Load = (uri:URI):Action =>({ type: "Load", uri });
 
-export const LocationChanged =
-  (uri: URI, canGoBack: ?boolean, canGoForward: ?boolean): Action =>
-  ({type: "LocationChanged", uri, canGoBack, canGoForward});
+export const LocationChanged = (uri:URI, canGoBack:?boolean, canGoForward:?boolean):Action =>({
+  type: "LocationChanged",
+  uri,
+  canGoBack,
+  canGoForward
+});
 
-const CanGoBackChanged =
-  result =>
-  ( { type: "CanGoBackChanged"
-    , canGoBackChanged: result
+const CanGoBackChanged = result =>( {
+  type: "CanGoBackChanged", canGoBackChanged: result
+}
+);
+
+const CanGoForwardChanged = result =>( {
+  type: "CanGoForwardChanged", canGoForwardChanged: result
+}
+);
+
+const Stopped = result =>( {
+  type: "Stopped", stopped: result
+}
+);
+
+const Reloaded = result =>( {
+  type: "Reloaded", reloaded: result
+}
+);
+
+const WentBack = result =>( {
+  type: "WentBack", wentBack: result
+}
+);
+
+const WentForward = result =>( {
+  type: "WentForward", wentForward: result
+}
+);
+
+export const canGoBack = (ref:Ref.Model):Task<Never, Result<Error, boolean>> =>Ref
+    .deref(ref)
+    .chain(elementCanGoBack);
+
+const elementCanGoBack = target =>new Task((succeed, fail) => {
+  if (typeof(target.getCanGoBack) !== "function") {
+    succeed(error(Error(`.getCanGoBack is not supported by runtime`)));
+  }
+
+  else {
+    target.getCanGoBack().onsuccess = request => {
+      succeed(ok(request.target.result));
+    };
+  }
+});
+
+export const canGoForward = (ref:Ref.Model):Task<Never, Result<Error, boolean>> =>Ref
+    .deref(ref)
+    .chain(elementCanGoForward);
+
+const elementCanGoForward = target =>new Task((succeed, fail) => {
+  if (typeof(target.getCanGoForward) !== "function") {
+    succeed(error(Error(`.getCanGoForward is not supported by runtime`)))
+  }
+
+  else {
+    target.getCanGoForward().onsuccess = request => {
+      succeed(ok(request.target.result));
     }
-  );
-
-const CanGoForwardChanged =
-  result =>
-  ( { type: "CanGoForwardChanged"
-    , canGoForwardChanged: result
-    }
-  );
-
-const Stopped =
-  result =>
-  ( { type: "Stopped"
-    , stopped: result
-    }
-  );
-
-const Reloaded =
-  result =>
-  ( { type: "Reloaded"
-    , reloaded: result
-    }
-  );
-
-const WentBack = result =>
-  ( { type: "WentBack"
-    , wentBack: result
-    }
-  );
-
-const WentForward = result =>
-  ( { type: "WentForward"
-    , wentForward: result
-    }
-  );
-
-export const canGoBack =
-  (ref: Ref.Model): Task<Never, Result<Error, boolean>> =>
-  Ref
-  .deref(ref)
-  .chain(elementCanGoBack);
-
-const elementCanGoBack =
-  target =>
-  new Task((succeed, fail) => {
-    if (typeof(target.getCanGoBack) !== "function") {
-      succeed(error(Error(`.getCanGoBack is not supported by runtime`)));
-    }
-
-    else {
-      target.getCanGoBack().onsuccess = request => {
-        succeed(ok(request.target.result));
-      };
-    }
-  });
-
-export const canGoForward =
-  (ref: Ref.Model): Task<Never, Result<Error, boolean>> =>
-  Ref
-  .deref(ref)
-  .chain(elementCanGoForward);
-
-const elementCanGoForward =
-  target =>
-  new Task((succeed, fail) => {
-    if (typeof(target.getCanGoForward) !== "function") {
-      succeed(error(Error(`.getCanGoForward is not supported by runtime`)))
-    }
-
-    else {
-      target.getCanGoForward().onsuccess = request => {
-        succeed(ok(request.target.result));
-      }
-    }
-  });
+  }
+});
 
 
-const invoke =
-  name => {
-    const elementInvoke = /*::<value>*/
-      (element: HTMLElement): Task<Never, Result<Error, value>> =>
-      new Task((succeed, fail) => {
+const invoke = name => {
+  const elementInvoke = /*::<value>*/
+      (element:HTMLElement):Task<Never, Result<Error, value>> =>new Task((succeed, fail) => {
         try {
           // @FlowIgnore: We know that method may not exist.
           element[name]();
@@ -195,188 +170,140 @@ const invoke =
         }
       })
 
-    const task = /*::<value>*/
-      (ref: Ref.Model): Task<Never, Result<Error, value>> =>
-      Ref
-      .deref(ref)
-      .chain(elementInvoke)
+  const task = /*::<value>*/
+      (ref:Ref.Model):Task<Never, Result<Error, value>> =>Ref
+          .deref(ref)
+          .chain(elementInvoke)
 
-    return task
-  }
+  return task
+}
 
 export const stop = invoke('stop');
 export const reload = invoke('reload');
 export const goBack = invoke('goBack');
 export const goForward = invoke('goForward');
 
-const report =
-  error =>
-  new Task((succeed, fail) => {
-    console.warn(error);
-  });
+const report = error =>new Task((succeed, fail) => {
+  console.warn(error);
+});
 
-export const init =
-  ( ref: Ref.Model=Ref.create()
-  , uri: URI='about:blank'
-  , canGoBack:  boolean = false
-  , canGoForward:  boolean = false
-  ): [Model, Effects<Action>] =>
-  [ new Model
-    ( ref
-    , canGoBack
-    , canGoForward
-    , uri
-    , uri
-    )
-  , Effects.none
-  ]
+export const init = (ref:Ref.Model = Ref.create(), uri:URI = 'about:blank', canGoBack:boolean = false,
+                     canGoForward:boolean = false):[Model, Effects<Action>] =>[
+  new Model(ref, canGoBack, canGoForward, uri, uri), Effects.none
+]
 
-const updateCanGoBack =
-  ( model, canGoBack ) =>
-  [ new Model
-    ( model.ref
-    , canGoBack
-    , model.canGoForward
-    , model.currentURI
-    , model.src
-    )
-  , Effects.none
-  ]
+const updateCanGoBack = (model, canGoBack) =>[
+  new Model(model.ref, canGoBack, model.canGoForward, model.currentURI, model.src), Effects.none
+]
 
-const updateCanGoForward =
-  ( model, canGoForward ) =>
-  [ new Model
-    ( model.ref
-    , model.canGoBack
-    , canGoForward
-    , model.currentURI
-    , model.src
-    )
-  , Effects.none
-  ]
+const updateCanGoForward = (model, canGoForward) =>[
+  new Model(model.ref, model.canGoBack, canGoForward, model.currentURI, model.src), Effects.none
+]
 
-const updateResponse =
-  (model, result) =>
-  ( result.isOk
-  ? [model, Effects.none]
-  : [model, Effects.perform(report(result.error)).map(NoOp)]
-  );
-
-const updateLocation =
-  (model, uri, canGoBackValue, canGoForwardValue) =>
-  // In the case where LocationChanged carries information about
-  // canGoBack and canGoForward, we update the model with the new info.
-  // This scenario will be hit in Servo.
-  ( ( canGoBackValue != null && canGoForwardValue != null )
-  ? [ new Model
-      ( model.ref
-      , canGoBackValue
-      , canGoForwardValue
-      , uri
-      // Please note that `src` does not change here, because it is
-      // reflected as `src` on iframe & therefor it would cause undesired
-      // fresh page load when iframe navigates away, for example when user
-      // clicks a link.
-      , model.src
-      )
-    , Effects.none
+const updateResponse = (model, result) =>( result.isOk
+        ? [
+      model,
+      Effects.none
     ]
-  // Otherwise, update the currentURI and create a task to read
-  // canGoBack, canGoForward from the iframe.
-  // This scenario will be hit in Gecko.
-  : [ new Model
-      ( model.ref
-      , model.canGoBack
-      , model.canGoForward
-      , uri
-      , model.src
-      )
-    , Effects.batch
-      ( [ Effects
-          .perform(canGoBack(model.ref))
-          .map(CanGoBackChanged)
-        , Effects
-          .perform(canGoForward(model.ref))
-          .map(CanGoForwardChanged)
+        : [
+      model,
+      Effects.perform(report(result.error)).map(NoOp)
+    ]
+);
+
+const updateLocation = (model, uri, canGoBackValue,
+                        canGoForwardValue) =>// In the case where LocationChanged carries information about
+    // canGoBack and canGoForward, we update the model with the new info.
+    // This scenario will be hit in Servo.
+    ( ( canGoBackValue != null && canGoForwardValue != null ) ? [
+          new Model(model.ref, canGoBackValue, canGoForwardValue, uri
+              // Please note that `src` does not change here, because it is
+              // reflected as `src` on iframe & therefor it would cause undesired
+              // fresh page load when iframe navigates away, for example when user
+              // clicks a link.
+              , model.src), Effects.none
         ]
-      )
-    ]
-  );
+            // Otherwise, update the currentURI and create a task to read
+            // canGoBack, canGoForward from the iframe.
+            // This scenario will be hit in Gecko.
+            : [
+          new Model(model.ref, model.canGoBack, model.canGoForward, uri, model.src), Effects.batch([
+                                                                                                     Effects
+                                                                                                         .perform(
+                                                                                                             canGoBack(
+                                                                                                                 model.ref))
+                                                                                                         .map(
+                                                                                                             CanGoBackChanged),
+                                                                                                     Effects
+                                                                                                         .perform(
+                                                                                                             canGoForward(
+                                                                                                                 model.ref))
+                                                                                                         .map(
+                                                                                                             CanGoForwardChanged)
+                                                                                                   ])
+        ]
+    );
 
-export const load =
-  ( model: Model
-  , uri: URI='about:blank'
-  ): [Model, Effects<Action>] =>
-  [ new Model
-    ( model.ref
-    , false
-    , false
-    // Please note that both `src` & `currentURI` are updated. The
-    // former will be reflected as `src` on the iframe, while the later
-    // represents currently loaded `URI` (They get out of sync when iframe
-    // navigates away, for example when a link on a page is clicked).
-    , uri
-    , uri
-    )
-  , Effects.none
-  ]
+export const load = (model:Model, uri:URI = 'about:blank'):[Model, Effects<Action>] =>[
+  new Model(model.ref, false, false
+      // Please note that both `src` & `currentURI` are updated. The
+      // former will be reflected as `src` on the iframe, while the later
+      // represents currently loaded `URI` (They get out of sync when iframe
+      // navigates away, for example when a link on a page is clicked).
+      , uri, uri), Effects.none
+]
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] => {
-    switch (action.type) {
-      case "CanGoForwardChanged":
-        return  (
-          action.canGoForwardChanged.isOk
-        ? updateCanGoForward(model, action.canGoForwardChanged.value)
-        : [ model
-          , Effects.perform(report(action.canGoForwardChanged.error))
+export const update = (model:Model, action:Action):[Model, Effects<Action>] => {
+  switch (action.type) {
+    case "CanGoForwardChanged":
+      return (
+          action.canGoForwardChanged.isOk ? updateCanGoForward(model, action.canGoForwardChanged.value) : [
+            model, Effects.perform(report(action.canGoForwardChanged.error))
           ]
-        );
-      case "CanGoBackChanged":
-        return (
-          action.canGoBackChanged.isOk
-        ? updateCanGoBack(model, action.canGoBackChanged.value)
-        : [ model
-          , Effects.perform(report(action.canGoBackChanged.error))
+      );
+    case "CanGoBackChanged":
+      return (
+          action.canGoBackChanged.isOk ? updateCanGoBack(model, action.canGoBackChanged.value) : [
+            model, Effects.perform(report(action.canGoBackChanged.error))
           ]
-        );
-      case "LocationChanged":
-        return updateLocation(model, action.uri, action.canGoBack, action.canGoForward)
-      case "Load":
-        return load(model, action.uri)
-      case "Stop":
-        return  [ model
-                , Effects
-                    .perform(stop(model.ref))
-                    .map(Stopped)
-                ];
-      case "Reload":
-        return  [ model
-                , Effects
-                    .perform(reload(model.ref))
-                    .map(Reloaded)
-                ];
-      case "GoBack":
-        return  [ model
-                , Effects
-                    .perform(goBack(model.ref))
-                    .map(WentBack)
-                ];
-      case "GoForward":
-        return  [ model
-                , Effects
-                    .perform(goForward(model.ref))
-                    .map(WentForward)
-                ];
-      case "Stopped":
-        return  updateResponse(model, action.stopped);
-      case "Reloaded":
-        return  updateResponse(model, action.reloaded);
-      case "WentBack":
-        return  updateResponse(model, action.wentBack);
-      case "WentForward":
-        return  updateResponse(model, action.wentForward);
-      default:
-        return Unknown.update(model, action);
-    }
-  };
+      );
+    case "LocationChanged":
+      return updateLocation(model, action.uri, action.canGoBack, action.canGoForward)
+    case "Load":
+      return load(model, action.uri)
+    case "Stop":
+      return [
+        model, Effects
+            .perform(stop(model.ref))
+            .map(Stopped)
+      ];
+    case "Reload":
+      return [
+        model, Effects
+            .perform(reload(model.ref))
+            .map(Reloaded)
+      ];
+    case "GoBack":
+      return [
+        model, Effects
+            .perform(goBack(model.ref))
+            .map(WentBack)
+      ];
+    case "GoForward":
+      return [
+        model, Effects
+            .perform(goForward(model.ref))
+            .map(WentForward)
+      ];
+    case "Stopped":
+      return updateResponse(model, action.stopped);
+    case "Reloaded":
+      return updateResponse(model, action.reloaded);
+    case "WentBack":
+      return updateResponse(model, action.wentBack);
+    case "WentForward":
+      return updateResponse(model, action.wentForward);
+    default:
+      return Unknown.update(model, action);
+  }
+};

--- a/src/browser/Navigators/Navigator/WebView/Navigation.js
+++ b/src/browser/Navigators/Navigator/WebView/Navigation.js
@@ -71,11 +71,11 @@ export class Model {
   src: URI;
   */
   constructor(
-    ref/*: Ref.Model*/
-  , canGoBack/*: boolean*/
-  , canGoForward/*: boolean*/
-  , currentURI/*: URI*/
-  , src/*: URI*/
+    ref:  Ref.Model
+  , canGoBack:  boolean
+  , canGoForward:  boolean
+  , currentURI:  URI
+  , src:  URI
   ) {
     this.ref = ref
     this.canGoBack = canGoBack
@@ -87,18 +87,18 @@ export class Model {
 
 
 // User interaction interaction may also triggered following actions:
-export const Stop/*:Action*/ = {type: "Stop"};
-export const Reload/*:Action*/ = {type: "Reload"};
-export const GoBack/*:Action*/ = {type: "GoBack"};
-export const GoForward/*:Action*/ = {type: "GoForward"};
+export const Stop: Action = {type: "Stop"};
+export const Reload: Action = {type: "Reload"};
+export const GoBack: Action = {type: "GoBack"};
+export const GoForward: Action = {type: "GoForward"};
 
 const NoOp = always({type: "NoOp"});
 export const Load =
-  (uri/*:URI*/)/*:Action*/ =>
+  (uri: URI): Action =>
   ({type: "Load", uri});
 
 export const LocationChanged =
-  (uri/*:URI*/, canGoBack/*:?boolean*/, canGoForward/*:?boolean*/)/*:Action*/ =>
+  (uri: URI, canGoBack: ?boolean, canGoForward: ?boolean): Action =>
   ({type: "LocationChanged", uri, canGoBack, canGoForward});
 
 const CanGoBackChanged =
@@ -142,7 +142,7 @@ const WentForward = result =>
   );
 
 export const canGoBack =
-  (ref/*:Ref.Model*/)/*:Task<Never, Result<Error, boolean>>*/ =>
+  (ref: Ref.Model): Task<Never, Result<Error, boolean>> =>
   Ref
   .deref(ref)
   .chain(elementCanGoBack);
@@ -162,7 +162,7 @@ const elementCanGoBack =
   });
 
 export const canGoForward =
-  (ref/*:Ref.Model*/)/*:Task<Never, Result<Error, boolean>>*/ =>
+  (ref: Ref.Model): Task<Never, Result<Error, boolean>> =>
   Ref
   .deref(ref)
   .chain(elementCanGoForward);
@@ -185,7 +185,7 @@ const elementCanGoForward =
 const invoke =
   name => {
     const elementInvoke = /*::<value>*/
-      (element/*:HTMLElement*/)/*:Task<Never, Result<Error, value>>*/ =>
+      (element: HTMLElement): Task<Never, Result<Error, value>> =>
       new Task((succeed, fail) => {
         try {
           // @FlowIgnore: We know that method may not exist.
@@ -196,7 +196,7 @@ const invoke =
       })
 
     const task = /*::<value>*/
-      (ref/*:Ref.Model*/)/*:Task<Never, Result<Error, value>>*/ =>
+      (ref: Ref.Model): Task<Never, Result<Error, value>> =>
       Ref
       .deref(ref)
       .chain(elementInvoke)
@@ -216,11 +216,11 @@ const report =
   });
 
 export const init =
-  ( ref/*:Ref.Model*/=Ref.create()
-  , uri/*:URI*/='about:blank'
-  , canGoBack/*: boolean*/ = false
-  , canGoForward/*: boolean*/ = false
-  )/*:[Model, Effects<Action>]*/ =>
+  ( ref: Ref.Model=Ref.create()
+  , uri: URI='about:blank'
+  , canGoBack:  boolean = false
+  , canGoForward:  boolean = false
+  ): [Model, Effects<Action>] =>
   [ new Model
     ( ref
     , canGoBack
@@ -304,9 +304,9 @@ const updateLocation =
   );
 
 export const load =
-  ( model/*:Model*/
-  , uri/*:URI*/='about:blank'
-  )/*:[Model, Effects<Action>]*/ =>
+  ( model: Model
+  , uri: URI='about:blank'
+  ): [Model, Effects<Action>] =>
   [ new Model
     ( model.ref
     , false
@@ -322,7 +322,7 @@ export const load =
   ]
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ => {
+  (model: Model, action: Action): [Model, Effects<Action>] => {
     switch (action.type) {
       case "CanGoForwardChanged":
         return  (

--- a/src/browser/Navigators/Navigator/WebView/Page.js
+++ b/src/browser/Navigators/Navigator/WebView/Page.js
@@ -58,15 +58,15 @@ export class Model {
   pallet: Pallet.Model;
   */
   constructor(
-    uri/*: URI*/
-  , title/*: ?string*/
-  , faviconURI/*: ?URI*/
-  , icon/*: ?Icon*/
+    uri:  URI
+  , title:  ?string
+  , faviconURI:  ?URI
+  , icon:  ?Icon
 
-  , themeColor/*: ?string*/
-  , curatedColor/*: ?Pallet.Theme*/
+  , themeColor:  ?string
+  , curatedColor:  ?Pallet.Theme
 
-  , pallet/*: Pallet.Model*/
+  , pallet:  Pallet.Model
   ) {
     this.uri = uri
     this.title = title
@@ -78,48 +78,48 @@ export class Model {
   }
 }
 
-export const DocumentFirstPaint/*:Action*/ =
+export const DocumentFirstPaint: Action =
   {type: "DocumentFirstPaint"};
 
-export const FirstPaint/*:Action*/ =
+export const FirstPaint: Action =
   {type: "FirstPaint"};
 
 export const MetaChanged =
-  (name/*:string*/, content/*:string*/)/*:Action*/ =>
+  (name: string, content: string): Action =>
   ({type: "MetaChanged", name, content});
 
 
 export const TitleChanged =
-  (title/*:string*/)/*:Action*/ =>
+  (title: string): Action =>
  ({type: "TitleChanged", title});
 
 export const IconChanged =
-  (icon/*:Icon*/)/*:Action*/ =>
+  (icon: Icon): Action =>
   ({type: "IconChanged", icon});
 
 export const OverflowChanged =
-  (isOverflown/*:boolean*/)/*:Action*/ =>
+  (isOverflown: boolean): Action =>
   ({type: "OverflowChanged", isOverflown});
 
 export const Scrolled =
-  (detail/*:any*/)/*:Action*/ =>
+  (detail: any): Action =>
   ({type: "Scrolled", detail});
 
 export const CuratedColorUpdate =
-  (color/*:?Pallet.Theme*/)/*:Action*/ =>
+  (color: ?Pallet.Theme): Action =>
   ({type: "CuratedColorUpdate", color});
 
-export const CreatePallet/*:Action*/ =
+export const CreatePallet: Action =
   {type: "CreatePallet"};
 
-export const LoadStart/*:Action*/ =
+export const LoadStart: Action =
   {type: "LoadStart"};
 
-export const LoadEnd/*:Action*/ =
+export const LoadEnd: Action =
   {type: "LoadEnd"};
 
 export const LocationChanged =
-  (uri/*:URI*/)/*:Action*/ =>
+  (uri: URI): Action =>
   ({type: "LocationChanged", uri});
 
 
@@ -183,7 +183,7 @@ const updatePallet = (model, _) =>
   ];
 
 export const init =
-  (uri/*:URI*/)/*:[Model, Effects<Action>]*/ =>
+  (uri: URI): [Model, Effects<Action>] =>
   [ new Model
     ( uri
     , null
@@ -268,7 +268,7 @@ const updateURI =
   );
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ => {
+  (model: Model, action: Action): [Model, Effects<Action>] => {
     switch (action.type) {
       case "LoadStart":
         return loadStart(model);

--- a/src/browser/Navigators/Navigator/WebView/Page.js
+++ b/src/browser/Navigators/Navigator/WebView/Page.js
@@ -4,70 +4,60 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Effects, Task} from 'reflex';
-import {merge} from '../../../../common/prelude';
-import * as Favicon from '../../../../common/favicon';
-import * as Pallet from '../../../../browser/pallet';
-import * as Unknown from '../../../../common/unknown';
-import * as Ref from '../../../../common/ref';
+import { Effects } from 'reflex'
+import * as Favicon from '../../../../common/favicon'
+import * as Pallet from '../../../../browser/pallet'
+import * as Unknown from '../../../../common/unknown'
 
 /*::
-import type {URI} from "../../../../common/prelude"
-import type {Icon} from "../../../../common/favicon"
+ import type {URI} from "../../../../common/prelude"
+ import type {Icon} from "../../../../common/favicon"
 
-export type Action =
-  | { type: "LoadStart" }
-  | { type: "LoadEnd" }
-  | { type: "TitleChanged"
-    , title: string
-    }
-  | { type: "IconChanged"
-    , icon: Icon
-    }
-  | { type: "MetaChanged"
-    , name: string
-    , content: string
-    }
-  | { type: "CuratedColorUpdate"
-    , color: ?Pallet.Theme
-    }
-  | { type: "DocumentFirstPaint" }
-  | { type: "FirstPaint" }
-  | { type: "CreatePallet" }
-  | { type: "OverflowChanged"
-    , isOverflown: boolean
-    }
-  | { type: "Scrolled"
-    , detail: any
-    }
-  | { type: "LocationChanged"
-    , uri: URI
-    }
-*/
+ export type Action =
+ | { type: "LoadStart" }
+ | { type: "LoadEnd" }
+ | { type: "TitleChanged"
+ , title: string
+ }
+ | { type: "IconChanged"
+ , icon: Icon
+ }
+ | { type: "MetaChanged"
+ , name: string
+ , content: string
+ }
+ | { type: "CuratedColorUpdate"
+ , color: ?Pallet.Theme
+ }
+ | { type: "DocumentFirstPaint" }
+ | { type: "FirstPaint" }
+ | { type: "CreatePallet" }
+ | { type: "OverflowChanged"
+ , isOverflown: boolean
+ }
+ | { type: "Scrolled"
+ , detail: any
+ }
+ | { type: "LocationChanged"
+ , uri: URI
+ }
+ */
 
 export class Model {
   /*::
-  uri: URI;
-  title: ?string;
-  faviconURI: ?URI;
-  icon: ?Icon;
+   uri: URI;
+   title: ?string;
+   faviconURI: ?URI;
+   icon: ?Icon;
 
-  themeColor: ?string;
-  curatedColor: ?Pallet.Theme;
+   themeColor: ?string;
+   curatedColor: ?Pallet.Theme;
 
-  pallet: Pallet.Model;
-  */
-  constructor(
-    uri:  URI
-  , title:  ?string
-  , faviconURI:  ?URI
-  , icon:  ?Icon
-
-  , themeColor:  ?string
-  , curatedColor:  ?Pallet.Theme
-
-  , pallet:  Pallet.Model
-  ) {
+   pallet: Pallet.Model;
+   */
+  constructor(uri:URI, title:?string, faviconURI:?URI, icon:?Icon, themeColor:?string, curatedColor:?Pallet.Theme,
+              pallet:Pallet.Model)
+  {
     this.uri = uri
     this.title = title
     this.faviconURI = faviconURI
@@ -78,230 +68,131 @@ export class Model {
   }
 }
 
-export const DocumentFirstPaint: Action =
-  {type: "DocumentFirstPaint"};
+export const DocumentFirstPaint:Action = { type: "DocumentFirstPaint" };
 
-export const FirstPaint: Action =
-  {type: "FirstPaint"};
+export const FirstPaint:Action = { type: "FirstPaint" };
 
-export const MetaChanged =
-  (name: string, content: string): Action =>
-  ({type: "MetaChanged", name, content});
+export const MetaChanged = (name:string, content:string):Action =>({ type: "MetaChanged", name, content });
 
 
-export const TitleChanged =
-  (title: string): Action =>
- ({type: "TitleChanged", title});
+export const TitleChanged = (title:string):Action =>({ type: "TitleChanged", title });
 
-export const IconChanged =
-  (icon: Icon): Action =>
-  ({type: "IconChanged", icon});
+export const IconChanged = (icon:Icon):Action =>({ type: "IconChanged", icon });
 
-export const OverflowChanged =
-  (isOverflown: boolean): Action =>
-  ({type: "OverflowChanged", isOverflown});
+export const OverflowChanged = (isOverflown:boolean):Action =>({ type: "OverflowChanged", isOverflown });
 
-export const Scrolled =
-  (detail: any): Action =>
-  ({type: "Scrolled", detail});
+export const Scrolled = (detail:any):Action =>({ type: "Scrolled", detail });
 
-export const CuratedColorUpdate =
-  (color: ?Pallet.Theme): Action =>
-  ({type: "CuratedColorUpdate", color});
+export const CuratedColorUpdate = (color:?Pallet.Theme):Action =>({ type: "CuratedColorUpdate", color });
 
-export const CreatePallet: Action =
-  {type: "CreatePallet"};
+export const CreatePallet:Action = { type: "CreatePallet" };
 
-export const LoadStart: Action =
-  {type: "LoadStart"};
+export const LoadStart:Action = { type: "LoadStart" };
 
-export const LoadEnd: Action =
-  {type: "LoadEnd"};
+export const LoadEnd:Action = { type: "LoadEnd" };
 
-export const LocationChanged =
-  (uri: URI): Action =>
-  ({type: "LocationChanged", uri});
+export const LocationChanged = (uri:URI):Action =>({ type: "LocationChanged", uri });
 
 
-const updateIcon = (model, {icon}) => {
-  const {bestIcon, faviconURI} =
-    ( model.icon == null
-    ? Favicon.getBestIcon([icon])
-    : Favicon.getBestIcon([model.icon, icon])
-    );
+const updateIcon = (model, { icon }) => {
+  const { bestIcon, faviconURI } =
+      ( model.icon == null ? Favicon.getBestIcon([icon]) : Favicon.getBestIcon([model.icon, icon])
+      );
 
   return [
-    new Model
-    ( model.uri
-    , model.title
-    , faviconURI
-    , bestIcon
-    , model.themeColor
-    , model.curatedColor
-    , model.pallet
-    )
-  , Effects.none
+    new Model(model.uri, model.title, faviconURI, bestIcon, model.themeColor, model.curatedColor, model.pallet),
+    Effects.none
   ];
 };
 
-const updateMeta =
-  (model, {name, content}) =>
-  [ ( name === 'theme-color'
-    ? new Model
-      ( model.uri
-      , model.title
-      , model.faviconURI
-      , model.icon
-      , content
-      , model.curatedColor
-      , model.pallet
-      )
-    : model
-    )
-  , Effects.none
-  ];
+const updateMeta = (model, { name, content }) =>[
+  ( name === 'theme-color'
+          ? new Model(model.uri, model.title, model.faviconURI, model.icon, content, model.curatedColor, model.pallet)
+          : model
+  ), Effects.none
+];
 
-const updatePallet = (model, _) =>
-  [ new Model
-    ( model.uri
-    , model.title
-    , model.faviconURI
-    , model.icon
-    , model.themeColor
-    , model.curatedColor
-    , ( model.curatedColor != null
-      ? Pallet.create
-        ( model.curatedColor.background
-        , model.curatedColor.foreground
-        )
-      : model.themeColor != null
-      ? Pallet.create(...`${model.themeColor}|'`.split('|'))
-      : Pallet.blank
-      )
-    )
-  , Effects.none
-  ];
+const updatePallet = (model, _) =>[
+  new Model(model.uri, model.title, model.faviconURI, model.icon, model.themeColor, model.curatedColor, ( model.curatedColor != null
+          ? Pallet.create(model.curatedColor.background, model.curatedColor.foreground)
+          : model.themeColor != null
+          ? Pallet.create(...`${model.themeColor}|'`.split('|'))
+          : Pallet.blank
+  )), Effects.none
+];
 
-export const init =
-  (uri: URI): [Model, Effects<Action>] =>
-  [ new Model
-    ( uri
-    , null
-    , null
-    , null
+export const init = (uri:URI):[Model, Effects<Action>] =>[
+  new Model(uri, null, null, null
 
-    , null
-    , null
+      , null, null
 
-    , Pallet.blank
-    )
-  , Effects.none
-  ];
+      , Pallet.blank), Effects.none
+];
 
-const loadStart =
-  model =>
-  [ new Model
-    ( model.uri
-    , null
-    , null
-    , null
+const loadStart = model =>[
+  new Model(model.uri, null, null, null
 
-    , null
-    , null
+      , null, null
 
-    , Pallet.blank
-    )
-  , Effects
-    .perform(Pallet.requestCuratedColor(model.uri))
-    .map(CuratedColorUpdate)
-  ];
-
-const updateTitle =
-  (model, title) =>
-  [ new Model
-    ( model.uri
-    , title
-    , model.faviconURI
-    , model.icon
-    , model.themeColor
-    , model.curatedColor
-    , model.pallet
-    )
-  , Effects.none
-  ];
-
-const updateCuratedColor =
-  (model, color) =>
-  [ new Model
-    ( model.uri
-    , model.title
-    , model.faviconURI
-    , model.icon
-    , model.themeColor
-    , color
-    , model.pallet
-    )
-  , Effects.none
-  ];
-
-const updateURI =
-  ( model, uri ) =>
-  // Sometimes location change is triggered even though actual location
-  // remains same. In such case we want to keep extracted colors as we
-  // may not get those this time around.
-  // See: https://github.com/browserhtml/browserhtml/issues/458
-  ( model.uri === uri
-  ? [ model, Effects.none ]
-  : [ new Model
-      ( uri
-      , model.title
-      , model.faviconURI
-      , model.icon
-      , null
-      , null
-      , model.pallet
-      )
-    , Effects
-      .perform(Pallet.requestCuratedColor(uri))
+      , Pallet.blank), Effects
+      .perform(Pallet.requestCuratedColor(model.uri))
       .map(CuratedColorUpdate)
-    ]
-  );
+];
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] => {
-    switch (action.type) {
-      case "LoadStart":
-        return loadStart(model);
-      case "LoadEnd":
-        // If you go back / forward `DocumentFirstPaint` is not fired there for
-        // we schedule a `WebView.Page.DocumentFakePaint` action to be send back
-        // in asynchronously on `LoadEnd` that gives us an opportunity to
-        // re-generate pallet when going back / forward. Also we schedule async
-        // action because colors to generate pallet from are fetched async and
-        // LoadEnd seems to fire occasionaly sooner that colors are feteched.
-        return [ model, Effects.receive(CreatePallet) ];
-      case "TitleChanged":
-        return updateTitle(model, action.title);
-      case "IconChanged":
-        return  updateIcon(model, action);
-      case "MetaChanged":
-        return  updateMeta(model, action);
-      case "CuratedColorUpdate":
-        return updateCuratedColor(model, action.color);
-      case "DocumentFirstPaint":
-        return  [ model, Effects.receive(CreatePallet) ];
-      case "CreatePallet":
-        return  updatePallet(model);
-      case "LocationChanged":
-        return updateURI(model, action.uri);
+const updateTitle = (model, title) =>[
+  new Model(model.uri, title, model.faviconURI, model.icon, model.themeColor, model.curatedColor, model.pallet),
+  Effects.none
+];
+
+const updateCuratedColor = (model, color) =>[
+  new Model(model.uri, model.title, model.faviconURI, model.icon, model.themeColor, color, model.pallet), Effects.none
+];
+
+const updateURI = (model, uri) =>// Sometimes location change is triggered even though actual location
+    // remains same. In such case we want to keep extracted colors as we
+    // may not get those this time around.
+    // See: https://github.com/browserhtml/browserhtml/issues/458
+    ( model.uri === uri ? [model, Effects.none] : [
+          new Model(uri, model.title, model.faviconURI, model.icon, null, null, model.pallet), Effects
+              .perform(Pallet.requestCuratedColor(uri))
+              .map(CuratedColorUpdate)
+        ]
+    );
+
+export const update = (model:Model, action:Action):[Model, Effects<Action>] => {
+  switch (action.type) {
+    case "LoadStart":
+      return loadStart(model);
+    case "LoadEnd":
+      // If you go back / forward `DocumentFirstPaint` is not fired there for
+      // we schedule a `WebView.Page.DocumentFakePaint` action to be send back
+      // in asynchronously on `LoadEnd` that gives us an opportunity to
+      // re-generate pallet when going back / forward. Also we schedule async
+      // action because colors to generate pallet from are fetched async and
+      // LoadEnd seems to fire occasionaly sooner that colors are feteched.
+      return [model, Effects.receive(CreatePallet)];
+    case "TitleChanged":
+      return updateTitle(model, action.title);
+    case "IconChanged":
+      return updateIcon(model, action);
+    case "MetaChanged":
+      return updateMeta(model, action);
+    case "CuratedColorUpdate":
+      return updateCuratedColor(model, action.color);
+    case "DocumentFirstPaint":
+      return [model, Effects.receive(CreatePallet)];
+    case "CreatePallet":
+      return updatePallet(model);
+    case "LocationChanged":
+      return updateURI(model, action.uri);
       // Ignore
-      case "FirstPaint":
-        return  [ model, Effects.none ];
-      case "OverflowChanged":
-        return  [ model, Effects.none ];
-      case "Scrolled":
-        return  [ model, Effects.none ];
-      default:
+    case "FirstPaint":
+      return [model, Effects.none];
+    case "OverflowChanged":
+      return [model, Effects.none];
+    case "Scrolled":
+      return [model, Effects.none];
+    default:
       return Unknown.update(model, action);
-    }
-  };
+  }
+};

--- a/src/browser/Navigators/Navigator/WebView/Security.js
+++ b/src/browser/Navigators/Navigator/WebView/Security.js
@@ -4,87 +4,65 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Effects} from 'reflex';
-import * as Unknown from '../../../../common/unknown';
+import { Effects } from 'reflex'
+import * as Unknown from '../../../../common/unknown'
 
 
 /*::
-export type State =
-  | "broken"
-  | "secure"
-  | "insecure"
+ export type State =
+ | "broken"
+ | "secure"
+ | "insecure"
 
-export type Action =
-  | { type: "LoadStart" }
-  | { type: "SecurityChanged"
-    , state: State
-    , extendedValidation: boolean
-    }
-*/
+ export type Action =
+ | { type: "LoadStart" }
+ | { type: "SecurityChanged"
+ , state: State
+ , extendedValidation: boolean
+ }
+ */
 
 export class Model {
   /*::
-  state: State;
-  secure: boolean;
-  extendedValidation: boolean;
-  */
-  constructor(
-    state: State
-  , secure: boolean
-  , extendedValidation: boolean
-  ) {
+   state: State;
+   secure: boolean;
+   extendedValidation: boolean;
+   */
+  constructor(state:State, secure:boolean, extendedValidation:boolean) {
     this.state = state
     this.secure = secure
     this.extendedValidation = extendedValidation
   }
 }
 
-const insecure = new Model
-  ( 'insecure'
-  , false
-  , false
-  )
+const insecure = new Model('insecure', false, false)
 
-export const LoadStart: Action =
-  { type: "LoadStart"
-  };
+export const LoadStart:Action = {
+  type: "LoadStart"
+};
 
-export const Changed =
-  (state: State, extendedValidation: boolean): Action =>
-  ( { type: "SecurityChanged"
-    , state
-    , extendedValidation
-    }
-  );
+export const Changed = (state:State, extendedValidation:boolean):Action =>( {
+  type: "SecurityChanged", state, extendedValidation
+}
+);
 
-export const init =
-  (): [Model, Effects<Action>] =>
-  [ insecure
-  , Effects.none
-  ]
+export const init = ():[Model, Effects<Action>] =>[
+  insecure, Effects.none
+]
 
-const loadStart =
-  model =>
-  init()
+const loadStart = model =>init()
 
-const updateSecurity =
-  (model, state, extendedValidation) =>
-  [ new Model
-    ( state
-    , state === 'secure'
-    , extendedValidation
-    )
-  , Effects.none
-  ]
+const updateSecurity = (model, state, extendedValidation) =>[
+  new Model(state, state === 'secure', extendedValidation), Effects.none
+]
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] => {
-    switch (action.type) {
-      case "LoadStart":
-        return loadStart(model);
-      case "SecurityChanged":
-        return updateSecurity(model, action.state, action.extendedValidation)
-      default:
-        return Unknown.update(model, action);
-    }
-  };
+export const update = (model:Model, action:Action):[Model, Effects<Action>] => {
+  switch (action.type) {
+    case "LoadStart":
+      return loadStart(model);
+    case "SecurityChanged":
+      return updateSecurity(model, action.state, action.extendedValidation)
+    default:
+      return Unknown.update(model, action);
+  }
+};

--- a/src/browser/Navigators/Navigator/WebView/Security.js
+++ b/src/browser/Navigators/Navigator/WebView/Security.js
@@ -29,9 +29,9 @@ export class Model {
   extendedValidation: boolean;
   */
   constructor(
-    state/*:State*/
-  , secure/*:boolean*/
-  , extendedValidation/*:boolean*/
+    state: State
+  , secure: boolean
+  , extendedValidation: boolean
   ) {
     this.state = state
     this.secure = secure
@@ -45,12 +45,12 @@ const insecure = new Model
   , false
   )
 
-export const LoadStart/*:Action*/ =
+export const LoadStart: Action =
   { type: "LoadStart"
   };
 
 export const Changed =
-  (state/*:State*/, extendedValidation/*:boolean*/)/*:Action*/ =>
+  (state: State, extendedValidation: boolean): Action =>
   ( { type: "SecurityChanged"
     , state
     , extendedValidation
@@ -58,7 +58,7 @@ export const Changed =
   );
 
 export const init =
-  ()/*:[Model, Effects<Action>]*/ =>
+  (): [Model, Effects<Action>] =>
   [ insecure
   , Effects.none
   ]
@@ -78,7 +78,7 @@ const updateSecurity =
   ]
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ => {
+  (model: Model, action: Action): [Model, Effects<Action>] => {
     switch (action.type) {
       case "LoadStart":
         return loadStart(model);

--- a/src/browser/Navigators/Navigator/WebView/Shell.js
+++ b/src/browser/Navigators/Navigator/WebView/Shell.js
@@ -42,10 +42,10 @@ export class Model {
   isFocused: boolean;
   */
   constructor(
-    ref/*:Ref.Model*/
-  , zoom/*:Float*/
-  , isVisible/*:boolean*/
-  , isFocused/*:boolean*/
+    ref: Ref.Model
+  , zoom: Float
+  , isVisible: boolean
+  , isFocused: boolean
   ) {
     this.ref = ref
     this.zoom = zoom
@@ -54,19 +54,19 @@ export class Model {
   }
 }
 
-export const MakeVisible/*:Action*/ =
+export const MakeVisible: Action =
   ({type: "MakeVisible"});
 
-export const MakeNotVisible/*:Action*/ =
+export const MakeNotVisible: Action =
   ({type: "MakeNotVisible"});
 
-export const ZoomIn/*:Action*/ =
+export const ZoomIn: Action =
   ({type: "ZoomIn"});
 
-export const ZoomOut/*:Action*/ =
+export const ZoomOut: Action =
   ({type: "ZoomOut"});
 
-export const ResetZoom/*:Action*/ =
+export const ResetZoom: Action =
   ({type: "ResetZoom"});
 
 const FocusableAction =
@@ -80,8 +80,8 @@ const Panic =
     }
   )
 
-export const Focus/*:Action*/ = Focusable.Focus;
-export const Blur/*:Action*/ = Focusable.Blur;
+export const Focus: Action = Focusable.Focus;
+export const Blur: Action = Focusable.Blur;
 
 const NoOp = always({type: "NoOp"});
 
@@ -100,7 +100,7 @@ const ZoomChanged =
   );
 
 const setZoom =
-  (ref/*:Ref.Model*/, level/*:Float*/)/*:Task<Error, Float>*/ =>
+  (ref: Ref.Model, level: Float): Task<Error, Float> =>
   Ref
   .deref(ref)
   .chain(element => setElementZoom(element, level))
@@ -122,19 +122,19 @@ const ZOOM_MAX = 2;
 const ZOOM_STEP = 0.1;
 
 export const zoomIn =
-  (ref/*:Ref.Model*/, zoom/*:number*/)/*:Task<Error, number>*/ =>
+  (ref: Ref.Model, zoom: number): Task<Error, number> =>
   setZoom(ref, Math.min(ZOOM_MAX, zoom + ZOOM_STEP));
 
 export const zoomOut =
-  (ref/*:Ref.Model*/, zoom/*:number*/)/*:Task<Error, number>*/ =>
+  (ref: Ref.Model, zoom: number): Task<Error, number> =>
   setZoom(ref, Math.max(ZOOM_MIN, zoom - ZOOM_STEP));
 
 export const resetZoom =
-  (ref/*:Ref.Model*/)/*:Task<Error, number>*/ =>
+  (ref: Ref.Model): Task<Error, number> =>
   setZoom(ref, 1);
 
 export const setVisibility =
-  (ref/*:Ref.Model*/, isVisible/*:boolean*/)/*:Task<Error, boolean>*/ =>
+  (ref: Ref.Model, isVisible: boolean): Task<Error, boolean> =>
   Ref
   .deref(ref)
   .chain(target => setElementVisibility(target, isVisible));
@@ -152,13 +152,13 @@ const setElementVisibility =
   })
 
 export const focus = /*::<value>*/
-  (ref/*:Ref.Model*/)/*:Task<Error, value>*/ =>
+  (ref: Ref.Model): Task<Error, value> =>
   Ref
   .deref(ref)
   .chain(focusElement);
 
 const focusElement = /*::<value>*/
-  (element/*:HTMLElement*/)/*:Task<Error, value>*/ =>
+  (element: HTMLElement): Task<Error, value> =>
   new Task((succeed, fail) => {
     try {
       if (element.ownerDocument.activeElement !== element) {
@@ -171,13 +171,13 @@ const focusElement = /*::<value>*/
   });
 
 export const blur = /*::<value>*/
-  (ref/*:Ref.Model*/)/*:Task<Error, value>*/ =>
+  (ref: Ref.Model): Task<Error, value> =>
   Ref
   .deref(ref)
   .chain(blurElement);
 
 const blurElement =/*::<value>*/
-  (element/*:HTMLElement*/)/*:Task<Error, value>*/ =>
+  (element: HTMLElement): Task<Error, value> =>
   new Task((succeed, fail) => {
     try {
       if (element.ownerDocument.activeElement === element) {
@@ -193,15 +193,15 @@ const blurElement =/*::<value>*/
 
 // Reports error as a warning in a console.
 const warn = /*::<value>*/
-  (error/*:Error*/)/*:Task<Never, value>*/ =>
+  (error: Error): Task<Never, value> =>
   new Task((succeed, fail) => {
     console.warn(error);
   });
 
 
 export const init =
-  ( ref/*:Ref.Model*/
-  , isFocused/*:boolean*/)/*:[Model, Effects<Action>]*/ =>
+  ( ref: Ref.Model
+  , isFocused: boolean): [Model, Effects<Action>] =>
   [ new Model
     ( ref
     , 1
@@ -253,7 +253,7 @@ const updateFocus =
 
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ => {
+  (model: Model, action: Action): [Model, Effects<Action>] => {
     switch (action.type) {
       case "ZoomIn":
         return [

--- a/src/browser/Navigators/Navigator/WebView/Shell.js
+++ b/src/browser/Navigators/Navigator/WebView/Shell.js
@@ -4,49 +4,43 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Effects, Task} from "reflex";
-import {merge, always} from "../../../../common/prelude";
-import {cursor} from "../../../../common/cursor";
-import {ok, error} from "../../../../common/result";
-import * as Focusable from "../../../../common/focusable";
-import * as Ref from '../../../../common/ref';
+import { Effects, Task } from 'reflex'
+import { always } from '../../../../common/prelude'
+import { ok, error } from '../../../../common/result'
+import * as Focusable from '../../../../common/focusable'
+import * as Ref from '../../../../common/ref'
 
 /*::
-import type {Result} from "../../../../common/result"
-import type {Never} from "reflex"
-import type {Float} from "../../../../common/prelude"
+ import type {Result} from "../../../../common/result"
+ import type {Never} from "reflex"
+ import type {Float} from "../../../../common/prelude"
 
-export type Action =
-  | { type: "NoOp" }
-  | { type: "Panic", panic: Error }
-  | { type: "ZoomIn" }
-  | { type: "ZoomOut" }
-  | { type: "ResetZoom" }
-  | { type: "MakeVisible" }
-  | { type: "MakeNotVisible" }
-  | { type: "ZoomChanged"
-    , zoomChanged: Result<Error, number>
-    }
-  | { type: "VisibilityChanged"
-    , visibilityChanged: Result<Error, boolean>
-    }
-  | { type: "Focus" }
-  | { type: "Blur" }
-*/
+ export type Action =
+ | { type: "NoOp" }
+ | { type: "Panic", panic: Error }
+ | { type: "ZoomIn" }
+ | { type: "ZoomOut" }
+ | { type: "ResetZoom" }
+ | { type: "MakeVisible" }
+ | { type: "MakeNotVisible" }
+ | { type: "ZoomChanged"
+ , zoomChanged: Result<Error, number>
+ }
+ | { type: "VisibilityChanged"
+ , visibilityChanged: Result<Error, boolean>
+ }
+ | { type: "Focus" }
+ | { type: "Blur" }
+ */
 
 export class Model {
   /*::
-  ref: Ref.Model;
-  zoom: Float;
-  isVisible: boolean;
-  isFocused: boolean;
-  */
-  constructor(
-    ref: Ref.Model
-  , zoom: Float
-  , isVisible: boolean
-  , isFocused: boolean
-  ) {
+   ref: Ref.Model;
+   zoom: Float;
+   isVisible: boolean;
+   isFocused: boolean;
+   */
+  constructor(ref:Ref.Model, zoom:Float, isVisible:boolean, isFocused:boolean) {
     this.ref = ref
     this.zoom = zoom
     this.isVisible = isVisible
@@ -54,292 +48,208 @@ export class Model {
   }
 }
 
-export const MakeVisible: Action =
-  ({type: "MakeVisible"});
+export const MakeVisible:Action = ({ type: "MakeVisible" });
 
-export const MakeNotVisible: Action =
-  ({type: "MakeNotVisible"});
+export const MakeNotVisible:Action = ({ type: "MakeNotVisible" });
 
-export const ZoomIn: Action =
-  ({type: "ZoomIn"});
+export const ZoomIn:Action = ({ type: "ZoomIn" });
 
-export const ZoomOut: Action =
-  ({type: "ZoomOut"});
+export const ZoomOut:Action = ({ type: "ZoomOut" });
 
-export const ResetZoom: Action =
-  ({type: "ResetZoom"});
+export const ResetZoom:Action = ({ type: "ResetZoom" });
 
-const FocusableAction =
-  action =>
-  ({type: "Focusable", action});
+const FocusableAction = action =>({ type: "Focusable", action });
 
-const Panic =
-  error =>
-  ( { type: "Panic"
-    , panic: error
-    }
-  )
+const Panic = error =>( {
+  type: "Panic", panic: error
+}
+)
 
-export const Focus: Action = Focusable.Focus;
-export const Blur: Action = Focusable.Blur;
+export const Focus:Action = Focusable.Focus;
+export const Blur:Action = Focusable.Blur;
 
-const NoOp = always({type: "NoOp"});
+const NoOp = always({ type: "NoOp" });
 
-const VisibilityChanged =
-  result =>
-  ( { type: "VisibilityChanged"
-    , visibilityChanged: result
-    }
-  );
+const VisibilityChanged = result =>( {
+  type: "VisibilityChanged", visibilityChanged: result
+}
+);
 
-const ZoomChanged =
-  result =>
-  ( { type: "ZoomChanged"
-    , zoomChanged: result
-    }
-  );
+const ZoomChanged = result =>( {
+  type: "ZoomChanged", zoomChanged: result
+}
+);
 
-const setZoom =
-  (ref: Ref.Model, level: Float): Task<Error, Float> =>
-  Ref
-  .deref(ref)
-  .chain(element => setElementZoom(element, level))
+const setZoom = (ref:Ref.Model, level:Float):Task<Error, Float> =>Ref
+    .deref(ref)
+    .chain(element => setElementZoom(element, level))
 
-const setElementZoom =
-  ( target, level ) =>
-  new Task((succeed, fail) => {
-    if (typeof(target.zoom) !== 'function') {
-      fail(Error(`.zoom is not supported by runtime`))
-    }
-    else {
-      target.zoom(level);
-      succeed(level);
-    }
-  })
+const setElementZoom = (target, level) =>new Task((succeed, fail) => {
+  if (typeof(target.zoom) !== 'function') {
+    fail(Error(`.zoom is not supported by runtime`))
+  } else {
+    target.zoom(level);
+    succeed(level);
+  }
+})
 
 const ZOOM_MIN = 0.5;
 const ZOOM_MAX = 2;
 const ZOOM_STEP = 0.1;
 
-export const zoomIn =
-  (ref: Ref.Model, zoom: number): Task<Error, number> =>
-  setZoom(ref, Math.min(ZOOM_MAX, zoom + ZOOM_STEP));
+export const zoomIn = (ref:Ref.Model, zoom:number):Task<Error, number> =>setZoom(ref,
+                                                                                 Math.min(ZOOM_MAX, zoom + ZOOM_STEP));
 
-export const zoomOut =
-  (ref: Ref.Model, zoom: number): Task<Error, number> =>
-  setZoom(ref, Math.max(ZOOM_MIN, zoom - ZOOM_STEP));
+export const zoomOut = (ref:Ref.Model, zoom:number):Task<Error, number> =>setZoom(ref,
+                                                                                  Math.max(ZOOM_MIN, zoom - ZOOM_STEP));
 
-export const resetZoom =
-  (ref: Ref.Model): Task<Error, number> =>
-  setZoom(ref, 1);
+export const resetZoom = (ref:Ref.Model):Task<Error, number> =>setZoom(ref, 1);
 
-export const setVisibility =
-  (ref: Ref.Model, isVisible: boolean): Task<Error, boolean> =>
-  Ref
-  .deref(ref)
-  .chain(target => setElementVisibility(target, isVisible));
+export const setVisibility = (ref:Ref.Model, isVisible:boolean):Task<Error, boolean> =>Ref
+    .deref(ref)
+    .chain(target => setElementVisibility(target, isVisible));
 
-const setElementVisibility =
-  (element, isVisible) =>
-  new Task((succeed, fail) => {
-    if (typeof(element.setVisible) !== 'function') {
-      fail(Error(`.setVisible is not supported by runtime`))
-    }
-    else {
-      element.setVisible(isVisible);
-      succeed(isVisible);
-    }
-  })
+const setElementVisibility = (element, isVisible) =>new Task((succeed, fail) => {
+  if (typeof(element.setVisible) !== 'function') {
+    fail(Error(`.setVisible is not supported by runtime`))
+  } else {
+    element.setVisible(isVisible);
+    succeed(isVisible);
+  }
+})
 
 export const focus = /*::<value>*/
-  (ref: Ref.Model): Task<Error, value> =>
-  Ref
-  .deref(ref)
-  .chain(focusElement);
+    (ref:Ref.Model):Task<Error, value> =>Ref
+        .deref(ref)
+        .chain(focusElement);
 
 const focusElement = /*::<value>*/
-  (element: HTMLElement): Task<Error, value> =>
-  new Task((succeed, fail) => {
-    try {
-      if (element.ownerDocument.activeElement !== element) {
-        element.focus()
+    (element:HTMLElement):Task<Error, value> =>new Task((succeed, fail) => {
+      try {
+        if (element.ownerDocument.activeElement !== element) {
+          element.focus()
+        }
+      } catch (error) {
+        fail(error)
       }
-    }
-    catch (error) {
-      fail(error)
-    }
-  });
+    });
 
 export const blur = /*::<value>*/
-  (ref: Ref.Model): Task<Error, value> =>
-  Ref
-  .deref(ref)
-  .chain(blurElement);
+    (ref:Ref.Model):Task<Error, value> =>Ref
+        .deref(ref)
+        .chain(blurElement);
 
-const blurElement =/*::<value>*/
-  (element: HTMLElement): Task<Error, value> =>
-  new Task((succeed, fail) => {
-    try {
-      if (element.ownerDocument.activeElement === element) {
-        element.blur()
+const blurElement = /*::<value>*/
+    (element:HTMLElement):Task<Error, value> =>new Task((succeed, fail) => {
+      try {
+        if (element.ownerDocument.activeElement === element) {
+          element.blur()
+        }
+      } catch (error) {
+        fail(error)
       }
-    }
-    catch (error) {
-      fail(error)
-    }
-  });
-
+    });
 
 
 // Reports error as a warning in a console.
 const warn = /*::<value>*/
-  (error: Error): Task<Never, value> =>
-  new Task((succeed, fail) => {
-    console.warn(error);
-  });
+    (error:Error):Task<Never, value> =>new Task((succeed, fail) => {
+      console.warn(error);
+    });
 
 
-export const init =
-  ( ref: Ref.Model
-  , isFocused: boolean): [Model, Effects<Action>] =>
-  [ new Model
-    ( ref
-    , 1
-    , true
-    , isFocused
-    )
-  , Effects.none
-  ]
+export const init = (ref:Ref.Model, isFocused:boolean):[Model, Effects<Action>] =>[
+  new Model(ref, 1, true, isFocused), Effects.none
+]
 
-const updateVisibility =
-  ( model, isVisible ) =>
-  [ new Model
-    ( model.ref
-    , model.zoom
-    , isVisible
-    , model.isFocused
-    )
-  , Effects.none
-  ]
+const updateVisibility = (model, isVisible) =>[
+  new Model(model.ref, model.zoom, isVisible, model.isFocused), Effects.none
+]
 
-const updateZoom =
-  ( model, zoom ) =>
-  [ new Model
-    ( model.ref
-    , zoom
-    , model.isVisible
-    , model.isFocused
-    )
-  , Effects.none
-  ]
+const updateZoom = (model, zoom) =>[
+  new Model(model.ref, zoom, model.isVisible, model.isFocused), Effects.none
+]
 
-const updateFocus =
-  ( model, isFocused ) =>
-  ( model.isFocused === isFocused
-  ? [ model, Effects.none ]
-  : [ new Model
-      ( model.ref
-      , model.zoom
-      , model.isVisible
-      , isFocused
-      )
-    , Effects.perform
-      ( isFocused
-      ? focus(model.ref).recover(Panic)
-      : blur(model.ref).recover(Panic)
-      )
+const updateFocus = (model, isFocused) =>( model.isFocused === isFocused
+        ? [
+      model,
+      Effects.none
     ]
-  )
+        : [
+      new Model(model.ref, model.zoom, model.isVisible, isFocused),
+      Effects.perform(isFocused ? focus(model.ref).recover(Panic) : blur(model.ref).recover(Panic))
+    ]
+)
 
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] => {
-    switch (action.type) {
-      case "ZoomIn":
-        return [
-          model
-          , Effects
-            .perform
-              ( zoomIn(model.ref, model.zoom)
-                .map(ok)
-                .capture(reason => Task.succeed(error(reason)))
-              )
+export const update = (model:Model, action:Action):[Model, Effects<Action>] => {
+  switch (action.type) {
+    case "ZoomIn":
+      return [
+        model, Effects
+            .perform(zoomIn(model.ref, model.zoom)
+                         .map(ok)
+                         .capture(reason => Task.succeed(error(reason))))
             .map(ZoomChanged)
-          ];
-      case "ZoomOut":
-        return [
-          model
-          , Effects
-              .perform
-              ( zoomOut(model.ref, model.zoom)
-                .map(ok)
-                .capture(reason => Task.succeed(error(reason)))
-              )
-              .map(ZoomChanged)
-          ];
-      case "ResetZoom":
-        return [
-          model
-          , Effects
-              .perform
-              ( resetZoom(model.ref)
-                .map(ok)
-                .capture(reason => Task.succeed(error(reason)))
-              )
-              .map(ZoomChanged)
-          ];
-      case "MakeVisible":
-        return [
-          model
-          , Effects
-              .perform
-              ( setVisibility(model.ref, true)
-                .map(ok)
-                .capture(reason => Task.succeed(error(reason)))
-              )
-              .map(VisibilityChanged)
-          ];
-      case "MakeNotVisible":
-        return [
-          model
-          , Effects
-            .perform
-            ( setVisibility(model.ref, false)
-              .map(ok)
-              .capture(reason => Task.succeed(error(reason)))
-            )
+      ];
+    case "ZoomOut":
+      return [
+        model, Effects
+            .perform(zoomOut(model.ref, model.zoom)
+                         .map(ok)
+                         .capture(reason => Task.succeed(error(reason))))
+            .map(ZoomChanged)
+      ];
+    case "ResetZoom":
+      return [
+        model, Effects
+            .perform(resetZoom(model.ref)
+                         .map(ok)
+                         .capture(reason => Task.succeed(error(reason))))
+            .map(ZoomChanged)
+      ];
+    case "MakeVisible":
+      return [
+        model, Effects
+            .perform(setVisibility(model.ref, true)
+                         .map(ok)
+                         .capture(reason => Task.succeed(error(reason))))
             .map(VisibilityChanged)
-          ];
-      case "VisibilityChanged":
-        return (
-          action.visibilityChanged.isOk
-        ? updateVisibility(model, action.visibilityChanged.value)
-        : [ model
-          , Effects
-            .perform(warn(action.visibilityChanged.error))
+      ];
+    case "MakeNotVisible":
+      return [
+        model, Effects
+            .perform(setVisibility(model.ref, false)
+                         .map(ok)
+                         .capture(reason => Task.succeed(error(reason))))
+            .map(VisibilityChanged)
+      ];
+    case "VisibilityChanged":
+      return (
+          action.visibilityChanged.isOk ? updateVisibility(model, action.visibilityChanged.value) : [
+            model, Effects
+                .perform(warn(action.visibilityChanged.error))
           ]
-        );
-      case "ZoomChanged":
-        return (
-          action.zoomChanged.isOk
-        ? updateZoom(model, action.zoomChanged.value)
-        : [ model
-          , Effects
-            .perform(warn(action.zoomChanged.error))
+      );
+    case "ZoomChanged":
+      return (
+          action.zoomChanged.isOk ? updateZoom(model, action.zoomChanged.value) : [
+            model, Effects
+                .perform(warn(action.zoomChanged.error))
           ]
-        );
+      );
 
-  // Delegate
-      case "Focus":
+      // Delegate
+    case "Focus":
 
-        return updateFocus(model, true);
-      case "Blur":
-        return updateFocus(model, false);
+      return updateFocus(model, true);
+    case "Blur":
+      return updateFocus(model, false);
 
-      case "Panic":
-        return [model, Effects.perform(warn(action.panic))];
+    case "Panic":
+      return [model, Effects.perform(warn(action.panic))];
 
-      default:
-        return [model, Effects.none];
-    }
-  };
+    default:
+      return [model, Effects.none];
+  }
+};

--- a/src/browser/Navigators/Navigator/WebView/Util.js
+++ b/src/browser/Navigators/Navigator/WebView/Util.js
@@ -12,7 +12,7 @@ import * as WebView from "../WebView"
 */
 
 export const readTitle =
-  (model/*:WebView.Model*/, fallback/*:string*/)/*:string*/ =>
+  (model: WebView.Model, fallback: string): string =>
   ( ( model.page != null &&
       model.page.title != null &&
       model.page.title !== ''
@@ -24,23 +24,23 @@ export const readTitle =
   );
 
 export const readFaviconURI =
-  (model/*:WebView.Model*/)/*:string*/ =>
+  (model: WebView.Model): string =>
   ( (model.page && model.page.faviconURI)
   ? model.page.faviconURI
   : Favicon.getFallback(model.navigation.currentURI)
   );
 
 export const isDark =
-  (model/*:WebView.Model*/)/*:boolean*/ =>
+  (model: WebView.Model): boolean =>
   ( model.page != null
   ? model.page.pallet.isDark
   : false
   );
 
 export const canGoBack =
-  (model/*:WebView.Model*/)/*:boolean*/ =>
+  (model: WebView.Model): boolean =>
   model.navigation.canGoBack === true;
 
 export const isSecure =
-  (model/*:WebView.Model*/)/*:boolean*/ =>
+  (model: WebView.Model): boolean =>
   model.security.secure;

--- a/src/browser/Navigators/Navigator/WebView/Util.js
+++ b/src/browser/Navigators/Navigator/WebView/Util.js
@@ -4,43 +4,30 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import * as URI from '../../../../common/url-helper';
-import * as Favicon from '../../../../common/favicon';
+import * as URI from '../../../../common/url-helper'
+import * as Favicon from '../../../../common/favicon'
 
 /*::
-import * as WebView from "../WebView"
-*/
+ import * as WebView from "../WebView"
+ */
 
-export const readTitle =
-  (model: WebView.Model, fallback: string): string =>
-  ( ( model.page != null &&
-      model.page.title != null &&
-      model.page.title !== ''
+export const readTitle = (model:WebView.Model,
+                          fallback:string):string =>( ( model.page != null && model.page.title != null && model.page.title !== ''
     )
-  ? model.page.title
-  : model.navigation.currentURI.search(/^\s*$/)
-  ? URI.prettify(model.navigation.currentURI)
-  : fallback
-  );
+        ? model.page.title
+        : model.navigation.currentURI.search(/^\s*$/)
+        ? URI.prettify(model.navigation.currentURI)
+        : fallback
+);
 
-export const readFaviconURI =
-  (model: WebView.Model): string =>
-  ( (model.page && model.page.faviconURI)
-  ? model.page.faviconURI
-  : Favicon.getFallback(model.navigation.currentURI)
-  );
+export const readFaviconURI = (model:WebView.Model):string =>( (model.page && model.page.faviconURI)
+        ? model.page.faviconURI
+        : Favicon.getFallback(model.navigation.currentURI)
+);
 
-export const isDark =
-  (model: WebView.Model): boolean =>
-  ( model.page != null
-  ? model.page.pallet.isDark
-  : false
-  );
+export const isDark = (model:WebView.Model):boolean =>( model.page != null ? model.page.pallet.isDark : false
+);
 
-export const canGoBack =
-  (model: WebView.Model): boolean =>
-  model.navigation.canGoBack === true;
+export const canGoBack = (model:WebView.Model):boolean =>model.navigation.canGoBack === true;
 
-export const isSecure =
-  (model: WebView.Model): boolean =>
-  model.security.secure;
+export const isSecure = (model:WebView.Model):boolean =>model.security.secure;

--- a/src/browser/Navigators/Overlay.js
+++ b/src/browser/Navigators/Overlay.js
@@ -14,9 +14,9 @@ export type Action =
 const Click = always({ type: "Click" })
 
 export const render =
-  ( isOpen/*:boolean*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  ( isOpen: boolean
+  , address: Address<Action>
+  ): DOM =>
   html.button
   ( { className: "overlay"
     , style: Style.mix
@@ -31,9 +31,9 @@ export const render =
   )
 
 export const view =
-  ( isOpen/*:boolean*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  ( isOpen: boolean
+  , address: Address<Action>
+  ): DOM =>
   thunk
   ( "Browser/NavigatorDeck/Overlay"
   , render

--- a/src/browser/Navigators/Overlay.js
+++ b/src/browser/Navigators/Overlay.js
@@ -1,61 +1,43 @@
 /* @flow */
 
-import {always} from "../../common/prelude"
-import * as Style from "../../common/style"
-import {html, forward, thunk} from "reflex"
+import { always } from '../../common/prelude'
+import * as Style from '../../common/style'
+import { html, forward, thunk } from 'reflex'
 
 /*::
-import type {Address, DOM} from "reflex"
+ import type {Address, DOM} from "reflex"
 
-export type Action =
-  | { type: "Click" }
-*/
+ export type Action =
+ | { type: "Click" }
+ */
 
 const Click = always({ type: "Click" })
 
-export const render =
-  ( isOpen: boolean
-  , address: Address<Action>
-  ): DOM =>
-  html.button
-  ( { className: "overlay"
-    , style: Style.mix
-      ( styleSheet.base
-      , ( isOpen
-        ? styleSheet.open
-        : styleSheet.closed
-        )
-      )
-    , onMouseDown: forward(address, Click)
-    }
-  )
+export const render = (isOpen:boolean, address:Address<Action>):DOM =>html.button({
+                                                                                    className: "overlay",
+                                                                                    style: Style.mix(styleSheet.base,
+                                                                                                     ( isOpen
+                                                                                                             ? styleSheet.open
+                                                                                                             : styleSheet.closed
+                                                                                                     )),
+                                                                                    onMouseDown: forward(address, Click)
+                                                                                  })
 
-export const view =
-  ( isOpen: boolean
-  , address: Address<Action>
-  ): DOM =>
-  thunk
-  ( "Browser/NavigatorDeck/Overlay"
-  , render
-  , isOpen
-  , address
-  )
+export const view = (isOpen:boolean, address:Address<Action>):DOM =>thunk("Browser/NavigatorDeck/Overlay", render,
+                                                                          isOpen, address)
 
-const styleSheet = Style.createSheet
-  ( { base:
-      { position: "absolute"
-      , width: "100%"
-      , height: "100%"
-      , top: 0
-      , left: 0
-      , zIndex: "20"
-      , opacity: 0
-      }
-    , open:
-      { pointerEvents: "auto"
-      }
-    , closed:
-      { pointerEvents: "none"
-      }
-    }
-  )
+const styleSheet = Style.createSheet({
+                                       base: {
+                                         position: "absolute",
+                                         width: "100%",
+                                         height: "100%",
+                                         top: 0,
+                                         left: 0,
+                                         zIndex: "20",
+                                         opacity: 0
+                                       }, open: {
+    pointerEvents: "auto"
+  }, closed: {
+    pointerEvents: "none"
+  }
+                                     })

--- a/src/browser/Sidebar.js
+++ b/src/browser/Sidebar.js
@@ -4,54 +4,45 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, thunk, forward, Effects} from 'reflex';
-import * as Style from '../common/style';
-import * as Toolbar from "./Sidebar/Toolbar";
-import * as Tabs from "./Sidebar/Tabs";
-import {merge, always} from "../common/prelude";
-import {cursor} from "../common/cursor";
-import * as Unknown from "../common/unknown";
-import * as Easing from "eased";
-import * as Display from "./Sidebar/Display";
-import * as Animation from "../common/Animation";
+import { html, thunk, forward, Effects } from 'reflex'
+import * as Style from '../common/style'
+import * as Toolbar from './Sidebar/Toolbar'
+import * as Tabs from './Sidebar/Tabs'
+import { cursor } from '../common/cursor'
+import * as Unknown from '../common/unknown'
+import * as Easing from 'eased'
+import * as Display from './Sidebar/Display'
+import * as Animation from '../common/Animation'
 
 
 /*::
-import type {Integer, Float} from "../common/prelude"
-import type {Address, DOM} from "reflex"
-import type {ID} from "./Sidebar/Tabs"
-import * as Navigator from "./Navigators/Navigator"
-import * as Deck from "../common/Deck"
+ import type {Integer, Float} from "../common/prelude"
+ import type {Address, DOM} from "reflex"
+ import type {ID} from "./Sidebar/Tabs"
+ import * as Navigator from "./Navigators/Navigator"
+ import * as Deck from "../common/Deck"
 
-export type Action =
-  | { type: "CreateWebView" }
-  | { type: "Attach" }
-  | { type: "Detach" }
-  | { type: "Expand" }
-  | { type: "Collapse" }
-  | { type: "Activate" }
-  | { type: "Animation", animation: Animation.Action }
-  | { type: "Tabs", tabs: Tabs.Action }
-  | { type: "Toolbar", toolbar: Toolbar.Action }
-*/
-
-
-
+ export type Action =
+ | { type: "CreateWebView" }
+ | { type: "Attach" }
+ | { type: "Detach" }
+ | { type: "Expand" }
+ | { type: "Collapse" }
+ | { type: "Activate" }
+ | { type: "Animation", animation: Animation.Action }
+ | { type: "Tabs", tabs: Tabs.Action }
+ | { type: "Toolbar", toolbar: Toolbar.Action }
+ */
 
 
 export class Model {
   /*::
-  isAttached: boolean;
-  isExpanded: boolean;
-  animation: Animation.Model<Display.Model>;
-  toolbar: Toolbar.Model;
-  */
-  constructor(
-    isAttached:  boolean
-  , isExpanded:  boolean
-  , toolbar:  Toolbar.Model
-  , animation:  Animation.Model<Display.Model>
-  ) {
+   isAttached: boolean;
+   isExpanded: boolean;
+   animation: Animation.Model<Display.Model>;
+   toolbar: Toolbar.Model;
+   */
+  constructor(isAttached:boolean, isExpanded:boolean, toolbar:Toolbar.Model, animation:Animation.Model<Display.Model>) {
     this.isAttached = isAttached
     this.isExpanded = isExpanded
     this.animation = animation
@@ -61,325 +52,204 @@ export class Model {
 
 
 const styleSheet = Style.createSheet({
-  base:
-  { backgroundColor: '#272822'
-  , height: '100%'
-  , position: 'absolute'
-  , right: 0
-  , top: 0
-  , width: '320px'
-  , boxSizing: 'border-box'
-  , zIndex: 2 // @TODO This is a hack to avoid resizing new tab / edit tab views.
-  , overflow: 'hidden'
-  }
-});
+                                       base: {
+                                         backgroundColor: '#272822',
+                                         height: '100%',
+                                         position: 'absolute',
+                                         right: 0,
+                                         top: 0,
+                                         width: '320px',
+                                         boxSizing: 'border-box',
+                                         zIndex: 2 // @TODO This is a hack to avoid resizing new tab / edit tab views.
+                                         ,
+                                         overflow: 'hidden'
+                                       }
+                                     });
 
 
-export const init =
-  ( isAttached: boolean = false
-  , isExpanded: boolean = false
-  ): [Model, Effects<Action>] => {
-    const display =
-      ( isExpanded
-      ? Display.expanded
-      : isAttached
-      ? Display.attached
-      : Display.collapsed
-      );
-
-    const [toolbar, $toolbar] = Toolbar.init();
-    const [animation, $animation] = Animation.init(display, null);
-
-    const model = new Model
-    ( isAttached
-    , isExpanded
-    , toolbar
-    , animation
-    );
-
-    const fx = Effects.batch
-    ( [ $toolbar.map(tagToolbar)
-      , $animation.map(tagAnimation)
-      ]
-    )
-
-    return [model, fx]
-  }
-
-export const CreateWebView: Action =
-  { type: 'CreateWebView'
-  };
-
-export const Attach: Action =
-  {
-    type: "Attach"
-  };
-
-export const Detach: Action =
-  { type: "Detach"
-  };
-
-export const Expand: Action = {type: "Expand"};
-export const Collapse: Action = {type: "Collapse"};
-
-const tagTabs =
-  action => {
-    switch (action.type) {
-      default:
-        return {
-          type: "Tabs"
-        , tabs: action
-        }
-    }
-  };
-
-
-const tagToolbar =
-  action => {
-    switch (action.type) {
-      case "Attach":
-        return Attach;
-      case "Detach":
-        return Detach;
-      case "CreateWebView":
-        return CreateWebView;
-      default:
-        return {
-          type: "Toolbar"
-        , toolbar: action
-        , action
-        }
-    }
-  };
-
-const tagAnimation =
-  action =>
-  ( { type: "Animation"
-    , animation: action
-    }
+export const init = (isAttached:boolean = false, isExpanded:boolean = false):[Model, Effects<Action>] => {
+  const display = ( isExpanded ? Display.expanded : isAttached ? Display.attached : Display.collapsed
   );
 
-const animate =
-  (animation, action) =>
-  Animation.updateWith
-  ( Easing.easeOutCubic
-  , Display.interpolate
-  , animation
-  , action
-  )
+  const [toolbar, $toolbar] = Toolbar.init();
+  const [animation, $animation] = Animation.init(display, null);
+
+  const model = new Model(isAttached, isExpanded, toolbar, animation);
+
+  const fx = Effects.batch([
+                             $toolbar.map(tagToolbar), $animation.map(tagAnimation)
+                           ])
+
+  return [model, fx]
+}
+
+export const CreateWebView:Action = {
+  type: 'CreateWebView'
+};
+
+export const Attach:Action = {
+  type: "Attach"
+};
+
+export const Detach:Action = {
+  type: "Detach"
+};
+
+export const Expand:Action = { type: "Expand" };
+export const Collapse:Action = { type: "Collapse" };
+
+const tagTabs = action => {
+  switch (action.type) {
+    default:
+      return {
+        type: "Tabs", tabs: action
+      }
+  }
+};
 
 
-const updateToolbar = cursor
-  ( { get: model => model.toolbar
-    , set:
-      (model, toolbar) => new Model
-      ( model.isAttached
-      , model.isExpanded
-      , toolbar
-      , model.animation
-      )
-    , tag: tagToolbar
-    , update: Toolbar.update
-    }
-  );
+const tagToolbar = action => {
+  switch (action.type) {
+    case "Attach":
+      return Attach;
+    case "Detach":
+      return Detach;
+    case "CreateWebView":
+      return CreateWebView;
+    default:
+      return {
+        type: "Toolbar", toolbar: action, action
+      }
+  }
+};
 
-const updateAnimation = cursor
-  ( { get: model => model.animation
-    , set:
-      (model, animation) =>
-      new Model
-      ( model.isAttached
-      , model.isExpanded
-      , model.toolbar
-      , animation
-      )
-    , tag: tagAnimation
-    , update: animate
-    }
-  )
+const tagAnimation = action =>( {
+  type: "Animation", animation: action
+}
+);
+
+const animate = (animation, action) =>Animation.updateWith(Easing.easeOutCubic, Display.interpolate, animation, action)
+
+
+const updateToolbar = cursor({
+                               get: model => model.toolbar,
+                               set: (model,
+                                     toolbar) => new Model(model.isAttached, model.isExpanded, toolbar, model.animation),
+                               tag: tagToolbar,
+                               update: Toolbar.update
+                             });
+
+const updateAnimation = cursor({
+                                 get: model => model.animation,
+                                 set: (model,
+                                       animation) =>new Model(model.isAttached, model.isExpanded, model.toolbar, animation),
+                                 tag: tagAnimation,
+                                 update: animate
+                               })
 
 const nofx = /*::<model, action>*/
-  (model: model): [model, Effects<action>] =>
-  [ model
-  , Effects.none
-  ]
-
-const startAnimation =
-  (isAttached, isExpanded, toolbar, [animation, fx]) =>
-  [ new Model
-    ( isAttached
-    , isExpanded
-    , toolbar
-    , animation
-    )
-  , fx.map(tagAnimation)
-  ]
-
-
-const expand =
-  ( model ) =>
-  ( model.isExpanded
-  ? nofx(model)
-  : startAnimation
-    ( model.isAttached
-    , true
-    , model.toolbar
-    , Animation.transition
-      ( model.animation
-      , Display.expanded
-      , 550
-      )
-    )
-  );
-
-const collapse =
-  (model: Model) =>
-  ( !model.isExpanded
-  ? nofx(model)
-  : startAnimation
-    ( model.isAttached
-    , false
-    , model.toolbar
-    , Animation.transition
-      ( model.animation
-      , ( model.isAttached
-        ? Display.attached
-        : Display.collapsed
-        )
-      , 200
-      )
-    )
-  );
-
-const attach =
-  ( model ) =>
-  ( model.isAttached
-  ? nofx(model)
-  : assemble
-    ( true
-    , false
-    , Toolbar.update(model.toolbar, Toolbar.Attach)
-    , Animation.transition
-      ( model.animation
-      , Display.attached
-      , ( model.isExpanded
-        ? 200
-        : 100
-        )
-      )
-    )
-  )
-
-const detach =
-  ( model ) =>
-  ( !model.isAttached
-  ? nofx(model)
-  : assemble
-    ( false
-    , model.isExpanded
-    , Toolbar.update(model.toolbar, Toolbar.Detach)
-    , ( model.isExpanded
-      ? nofx(model.animation)
-      : Animation.transition
-        ( model.animation
-        , Display.collapsed
-        , ( model.isExpanded
-          ? 200
-          : 100
-          )
-        )
-      )
-    )
-  );
-
-const assemble =
-  ( isAttached
-  , isExpanded
-  , [toolbar, $toolbar]
-  , [animation, $animation]
-  ) =>
-  [ new Model
-    ( isAttached
-    , isExpanded
-    , toolbar
-    , animation
-    )
-  , Effects.batch
-    ( [ $toolbar.map(tagToolbar)
-      , $animation.map(tagAnimation)
-      ]
-    )
-  ]
-
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] => {
-    switch (action.type) {
-      case "Expand":
-        return expand(model);
-      case "Collapse":
-        return collapse(model);
-      case "Attach":
-        return attach(model);
-      case "Detach":
-        return detach(model);
-
-      case "Animation":
-        return updateAnimation(model, action.animation);
-      case "Toolbar":
-        return updateToolbar(model, action.toolbar);
-
-      default:
-        return Unknown.update(model, action);
-    }
-  };
-
-
-export const render =
-  ( model: Model
-  , navigators: Deck.Model<Navigator.Model>
-  , address: Address<Action>
-  ): DOM =>
-  html.menu
-  ( { key: 'sidebar'
-    , className: 'sidebar'
-    , style: Style.mix
-      ( styleSheet.base
-      , styleAnimation(model.animation.state)
-      )
-    }
-  , [ Tabs.view
-      ( navigators
-      , forward(address, tagTabs)
-      , model.animation.state
-      )
-    , thunk
-      ( 'sidebar-toolbar'
-      , Toolbar.view
-      , model.toolbar
-      , forward(address, tagToolbar)
-      , model.animation.state
-      )
+    (model:model):[model, Effects<action>] =>[
+      model, Effects.none
     ]
-  );
 
-export const view =
-  ( model: Model
-  , navigators: Deck.Model<Navigator.Model>
-  , address: Address<Action>
-  ): DOM =>
-  thunk
-  ( 'Browser/Sidebar'
-  , render
-  , model
-  , navigators
-  , address
-  );
+const startAnimation = (isAttached, isExpanded, toolbar, [animation, fx]) =>[
+  new Model(isAttached, isExpanded, toolbar, animation), fx.map(tagAnimation)
+]
 
-const styleAnimation =
-  ({x, shadow, spacing}) =>
-  ( { transform: `translateX(${x}px)`
-    , boxShadow: `rgba(0, 0, 0, ${shadow}) -50px 0 80px`
-    , paddingLeft: `${spacing}px`
-    , paddingRight: `${spacing}px`
-    }
-  )
+
+const expand = (model) =>( model.isExpanded ? nofx(model) : startAnimation(model.isAttached, true, model.toolbar,
+                                                                           Animation.transition(model.animation,
+                                                                                                Display.expanded, 550))
+);
+
+const collapse = (model:Model) =>( !model.isExpanded ? nofx(model) : startAnimation(model.isAttached, false,
+                                                                                    model.toolbar, Animation.transition(
+            model.animation, ( model.isAttached ? Display.attached : Display.collapsed
+            ), 200))
+);
+
+const attach = (model) =>( model.isAttached ? nofx(model) : assemble(true, false,
+                                                                     Toolbar.update(model.toolbar, Toolbar.Attach),
+                                                                     Animation.transition(model.animation,
+                                                                                          Display.attached,
+                                                                                          ( model.isExpanded ? 200 : 100
+                                                                                          )))
+)
+
+const detach = (model) =>( !model.isAttached ? nofx(model) : assemble(false, model.isExpanded,
+                                                                      Toolbar.update(model.toolbar, Toolbar.Detach),
+                                                                      ( model.isExpanded
+                                                                              ? nofx(model.animation)
+                                                                              : Animation.transition(model.animation,
+                                                                                                     Display.collapsed,
+                                                                                                     ( model.isExpanded
+                                                                                                             ? 200
+                                                                                                             : 100
+                                                                                                     ))
+                                                                      ))
+);
+
+const assemble = (isAttached, isExpanded, [toolbar, $toolbar], [animation, $animation]) =>[
+  new Model(isAttached, isExpanded, toolbar, animation), Effects.batch([
+                                                                         $toolbar.map(tagToolbar),
+                                                                         $animation.map(tagAnimation)
+                                                                       ])
+]
+
+export const update = (model:Model, action:Action):[Model, Effects<Action>] => {
+  switch (action.type) {
+    case "Expand":
+      return expand(model);
+    case "Collapse":
+      return collapse(model);
+    case "Attach":
+      return attach(model);
+    case "Detach":
+      return detach(model);
+
+    case "Animation":
+      return updateAnimation(model, action.animation);
+    case "Toolbar":
+      return updateToolbar(model, action.toolbar);
+
+    default:
+      return Unknown.update(model, action);
+  }
+};
+
+
+export const render = (model:Model, navigators:Deck.Model<Navigator.Model>, address:Address<Action>):DOM =>html.menu({
+                                                                                                                       key: 'sidebar',
+                                                                                                                       className: 'sidebar',
+                                                                                                                       style: Style.mix(
+                                                                                                                           styleSheet.base,
+                                                                                                                           styleAnimation(
+                                                                                                                               model.animation.state))
+                                                                                                                     },
+                                                                                                                     [
+                                                                                                                       Tabs.view(
+                                                                                                                           navigators,
+                                                                                                                           forward(
+                                                                                                                               address,
+                                                                                                                               tagTabs),
+                                                                                                                           model.animation.state),
+                                                                                                                       thunk(
+                                                                                                                           'sidebar-toolbar',
+                                                                                                                           Toolbar.view,
+                                                                                                                           model.toolbar,
+                                                                                                                           forward(
+                                                                                                                               address,
+                                                                                                                               tagToolbar),
+                                                                                                                           model.animation.state)
+                                                                                                                     ]);
+
+export const view = (model:Model, navigators:Deck.Model<Navigator.Model>, address:Address<Action>):DOM =>thunk(
+    'Browser/Sidebar', render, model, navigators, address);
+
+const styleAnimation = ({ x, shadow, spacing }) =>( {
+  transform: `translateX(${x}px)`,
+  boxShadow: `rgba(0, 0, 0, ${shadow}) -50px 0 80px`,
+  paddingLeft: `${spacing}px`,
+  paddingRight: `${spacing}px`
+}
+)

--- a/src/browser/Sidebar.js
+++ b/src/browser/Sidebar.js
@@ -47,10 +47,10 @@ export class Model {
   toolbar: Toolbar.Model;
   */
   constructor(
-    isAttached/*: boolean*/
-  , isExpanded/*: boolean*/
-  , toolbar/*: Toolbar.Model*/
-  , animation/*: Animation.Model<Display.Model>*/
+    isAttached:  boolean
+  , isExpanded:  boolean
+  , toolbar:  Toolbar.Model
+  , animation:  Animation.Model<Display.Model>
   ) {
     this.isAttached = isAttached
     this.isExpanded = isExpanded
@@ -76,9 +76,9 @@ const styleSheet = Style.createSheet({
 
 
 export const init =
-  ( isAttached/*:boolean*/ = false
-  , isExpanded/*:boolean*/ = false
-  )/*:[Model, Effects<Action>]*/ => {
+  ( isAttached: boolean = false
+  , isExpanded: boolean = false
+  ): [Model, Effects<Action>] => {
     const display =
       ( isExpanded
       ? Display.expanded
@@ -106,21 +106,21 @@ export const init =
     return [model, fx]
   }
 
-export const CreateWebView/*:Action*/ =
+export const CreateWebView: Action =
   { type: 'CreateWebView'
   };
 
-export const Attach/*:Action*/ =
+export const Attach: Action =
   {
     type: "Attach"
   };
 
-export const Detach/*:Action*/ =
+export const Detach: Action =
   { type: "Detach"
   };
 
-export const Expand/*:Action*/ = {type: "Expand"};
-export const Collapse/*:Action*/ = {type: "Collapse"};
+export const Expand: Action = {type: "Expand"};
+export const Collapse: Action = {type: "Collapse"};
 
 const tagTabs =
   action => {
@@ -199,7 +199,7 @@ const updateAnimation = cursor
   )
 
 const nofx = /*::<model, action>*/
-  (model/*:model*/)/*:[model, Effects<action>]*/ =>
+  (model: model): [model, Effects<action>] =>
   [ model
   , Effects.none
   ]
@@ -233,7 +233,7 @@ const expand =
   );
 
 const collapse =
-  (model/*:Model*/) =>
+  (model: Model) =>
   ( !model.isExpanded
   ? nofx(model)
   : startAnimation
@@ -312,7 +312,7 @@ const assemble =
   ]
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ => {
+  (model: Model, action: Action): [Model, Effects<Action>] => {
     switch (action.type) {
       case "Expand":
         return expand(model);
@@ -335,10 +335,10 @@ export const update =
 
 
 export const render =
-  ( model/*:Model*/
-  , navigators/*:Deck.Model<Navigator.Model>*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  ( model: Model
+  , navigators: Deck.Model<Navigator.Model>
+  , address: Address<Action>
+  ): DOM =>
   html.menu
   ( { key: 'sidebar'
     , className: 'sidebar'
@@ -363,10 +363,10 @@ export const render =
   );
 
 export const view =
-  ( model/*:Model*/
-  , navigators/*:Deck.Model<Navigator.Model>*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  ( model: Model
+  , navigators: Deck.Model<Navigator.Model>
+  , address: Address<Action>
+  ): DOM =>
   thunk
   ( 'Browser/Sidebar'
   , render

--- a/src/browser/Sidebar/Display.js
+++ b/src/browser/Sidebar/Display.js
@@ -4,29 +4,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import * as Easing from "eased";
+import * as Easing from 'eased'
 
 /*::
-import type {Integer, Float} from "../../common/prelude"
-*/
+ import type {Integer, Float} from "../../common/prelude"
+ */
 
 export class Model {
   /*::
-  x: Integer;
-  shadow: Float;
-  spacing: Integer;
-  toolbarOpacity: Float;
-  titleOpacity: Float;
-  tabWidth: Integer;
-  */
-  constructor(
-    x:  Integer
-  , shadow:  Float
-  , spacing:  Integer
-  , toolbarOpacity:  Float
-  , titleOpacity:  Float
-  , tabWidth:  Integer
-  ) {
+   x: Integer;
+   shadow: Float;
+   spacing: Integer;
+   toolbarOpacity: Float;
+   titleOpacity: Float;
+   tabWidth: Integer;
+   */
+  constructor(x:Integer, shadow:Float, spacing:Integer, toolbarOpacity:Float, titleOpacity:Float, tabWidth:Integer) {
     this.x = x
     this.shadow = shadow
     this.spacing = spacing
@@ -37,43 +30,15 @@ export class Model {
 }
 
 
-export const collapsed = new Model
-  ( 550
-  , 0.5
-  , 16
-  , 1
-  , 1
-  , 288
-  )
+export const collapsed = new Model(550, 0.5, 16, 1, 1, 288)
 
-export const attached = new Model
-  ( 270
-  , 0
-  , 9
-  , 0
-  , 0
-  , 32
-  )
+export const attached = new Model(270, 0, 9, 0, 0, 32)
 
-export const expanded = new Model
-  ( 0
-  , 0.5
-  , 16
-  , 1
-  , 1
-  , 288
-  )
+export const expanded = new Model(0, 0.5, 16, 1, 1, 288)
 
-export const interpolate =
-  ( from: Model
-  , to: Model
-  , progress: Float
-  ): Model =>
-  new Model
-  ( Easing.float(from.x, to.x, progress)
-  , Easing.float(from.shadow, to.shadow, progress)
-  , Easing.float(from.spacing, to.spacing, progress)
-  , Easing.float(from.toolbarOpacity, to.toolbarOpacity, progress)
-  , Easing.float(from.titleOpacity, to.titleOpacity, progress)
-  , Easing.float(from.tabWidth, to.tabWidth, progress)
-  )
+export const interpolate = (from:Model, to:Model, progress:Float):Model =>new Model(Easing.float(from.x, to.x,
+                                                                                                 progress), Easing.float(
+    from.shadow, to.shadow, progress), Easing.float(from.spacing, to.spacing, progress), Easing.float(
+    from.toolbarOpacity, to.toolbarOpacity, progress), Easing.float(from.titleOpacity, to.titleOpacity,
+                                                                    progress), Easing.float(from.tabWidth, to.tabWidth,
+                                                                                            progress))

--- a/src/browser/Sidebar/Display.js
+++ b/src/browser/Sidebar/Display.js
@@ -20,12 +20,12 @@ export class Model {
   tabWidth: Integer;
   */
   constructor(
-    x/*: Integer*/
-  , shadow/*: Float*/
-  , spacing/*: Integer*/
-  , toolbarOpacity/*: Float*/
-  , titleOpacity/*: Float*/
-  , tabWidth/*: Integer*/
+    x:  Integer
+  , shadow:  Float
+  , spacing:  Integer
+  , toolbarOpacity:  Float
+  , titleOpacity:  Float
+  , tabWidth:  Integer
   ) {
     this.x = x
     this.shadow = shadow
@@ -65,10 +65,10 @@ export const expanded = new Model
   )
 
 export const interpolate =
-  ( from/*:Model*/
-  , to/*:Model*/
-  , progress/*:Float*/
-  )/*:Model*/ =>
+  ( from: Model
+  , to: Model
+  , progress: Float
+  ): Model =>
   new Model
   ( Easing.float(from.x, to.x, progress)
   , Easing.float(from.shadow, to.shadow, progress)

--- a/src/browser/Sidebar/Tab.js
+++ b/src/browser/Sidebar/Tab.js
@@ -4,39 +4,37 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, thunk, forward, Effects} from 'reflex';
-import * as Style from '../../common/style';
-import * as Image from '../../common/image';
-import * as Target from "../../common/target";
-import * as Unknown from "../../common/unknown";
-
-import {always, merge} from '../../common/prelude';
-import {readTitle, readFaviconURI} from '../Navigators/Navigator/WebView/Util';
-import {cursor} from '../../common/cursor';
+import { html, thunk, forward, Effects } from 'reflex'
+import * as Style from '../../common/style'
+import * as Image from '../../common/image'
+import * as Target from '../../common/target'
+import * as Unknown from '../../common/unknown'
+import { always } from '../../common/prelude'
+import { readTitle, readFaviconURI } from '../Navigators/Navigator/WebView/Util'
 
 
 /*::
-import type {Address, DOM} from "reflex"
-import * as Navigator from "../Navigators/Navigator"
-import type {ID} from "../../common/prelude"
-import * as Target from "../../common/target"
+ import type {Address, DOM} from "reflex"
+ import * as Navigator from "../Navigators/Navigator"
+ import type {ID} from "../../common/prelude"
+ import * as Target from "../../common/target"
 
-export type Context =
-  { tabWidth: number
-  , titleOpacity: number
-  }
+ export type Context =
+ { tabWidth: number
+ , titleOpacity: number
+ }
 
-export type Action =
-  | { type: "Close" }
-  | { type: "Select" }
-  | { type: "Target", source: Target.Action }
-*/
+ export type Action =
+ | { type: "Close" }
+ | { type: "Select" }
+ | { type: "Target", source: Target.Action }
+ */
 
 export class Model {
   /*::
-  isPointerOver: boolean;
-  */
-  constructor(isPointerOver: boolean) {
+   isPointerOver: boolean;
+   */
+  constructor(isPointerOver:boolean) {
     this.isPointerOver = isPointerOver
   }
 }
@@ -46,230 +44,180 @@ const out = new Model(false)
 const transactOver = [over, Effects.none];
 const transactOut = [out, Effects.none];
 
-export const Close = {type: "Close"};
-export const Select = {type: "Select"};
-export const Activate = {type: "Activate"};
+export const Close = { type: "Close" };
+export const Select = { type: "Select" };
+export const Activate = { type: "Activate" };
 
-const TargetAction = action =>
-  ( { type: "Target"
-    , source: action
-    }
-  );
+const TargetAction = action =>( {
+  type: "Target", source: action
+}
+);
 
-const updateTarget =
-  (model, action) =>
-  ( action.type === "Over"
-  ? transactOver
-  : transactOut
-  )
+const updateTarget = (model, action) =>( action.type === "Over" ? transactOver : transactOut
+)
 
 const Out = TargetAction(Target.Out);
 const Over = TargetAction(Target.Over);
 
-export const init =
-  (): [Model, Effects<Action>] =>
-  transactOut;
+export const init = ():[Model, Effects<Action>] =>transactOut;
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] =>
-  ( action.type === "Target"
-  ? updateTarget(model, action.source)
-  : Unknown.update(model, action)
-  );
+export const update = (model:Model, action:Action):[Model, Effects<Action>] =>( action.type === "Target" ? updateTarget(
+        model, action.source) : Unknown.update(model, action)
+);
 
 const tabHeight = '32px';
 
 const styleSheet = Style.createSheet({
-  base: {
-    MozWindowDragging: 'no-drag',
-    WebkitAppRegion: 'no-drag',
-    borderRadius: '5px',
-    height: tabHeight,
-    overflow: 'hidden',
-    color: '#fff'
-  },
+                                       base: {
+                                         MozWindowDragging: 'no-drag',
+                                         WebkitAppRegion: 'no-drag',
+                                         borderRadius: '5px',
+                                         height: tabHeight,
+                                         overflow: 'hidden',
+                                         color: '#fff'
+                                       },
 
-  container: {
-    height: tabHeight,
-    lineHeight: tabHeight,
-    width: '288px',
-    fontSize: '14px',
-    overflow: 'hidden',
-    position: 'relative'
-  },
+                                       container: {
+                                         height: tabHeight,
+                                         lineHeight: tabHeight,
+                                         width: '288px',
+                                         fontSize: '14px',
+                                         overflow: 'hidden',
+                                         position: 'relative'
+                                       },
 
-  selected: {
-    backgroundColor: 'rgb(86,87,81)'
-  },
-  unselected: {
-  },
+                                       selected: {
+                                         backgroundColor: 'rgb(86,87,81)'
+                                       }, unselected: {},
 
-  title: {
-    display: 'block',
-    margin: '0 10px 0 32px',
-    overflow: 'hidden',
-    width: '246px',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap'
-  },
+                                       title: {
+                                         display: 'block',
+                                         margin: '0 10px 0 32px',
+                                         overflow: 'hidden',
+                                         width: '246px',
+                                         textOverflow: 'ellipsis',
+                                         whiteSpace: 'nowrap'
+                                       },
 
 
+                                       closeMask: {
+                                         color: 'inherit',
+                                         fontFamily: 'FontAwesome',
+                                         fontSize: '12px',
+                                         lineHeight: tabHeight,
+                                         textAlign: 'center',
 
-  closeMask: {
-    color: 'inherit',
-    fontFamily: 'FontAwesome',
-    fontSize: '12px',
-    lineHeight: tabHeight,
-    textAlign: 'center',
-
-    background: `linear-gradient(
+                                         background: `linear-gradient(
       to right,
       rgba(39,40,34,0) 0%,
       rgba(39,40,34, 0.8) 20%,
       rgba(39,40,34,1) 100%)`,
-    width: tabHeight,
-    height: tabHeight,
-    position: 'absolute',
-    padding: 0,
-    margin: 0,
-    top: 0,
-    transition: `right 400ms cubic-bezier(0.215, 0.610, 0.355, 1.000),
+                                         width: tabHeight,
+                                         height: tabHeight,
+                                         position: 'absolute',
+                                         padding: 0,
+                                         margin: 0,
+                                         top: 0,
+                                         transition: `right 400ms cubic-bezier(0.215, 0.610, 0.355, 1.000),
                 color 300ms ease-out`
-  },
+                                       },
 
-  closeMaskSelected: {
-    background: `linear-gradient(
+                                       closeMaskSelected: {
+                                         background: `linear-gradient(
       to right,
       rgba(86,87,81,0) 0%,
       rgba(86,87,81, 0.8) 20%,
       rgba(86,87,81,1) 100%)`,
-  },
-  closeMaskUnselected: {
+                                       }, closeMaskUnselected: {},
 
-  },
+                                       closeMaskHidden: {
+                                         right: '-21px',
+                                         pointerEvents: 'none', // Transitioning color or opacity seems to cause
+                                                                // rendering bugs
+                                         // See: https://github.com/browserhtml/browserhtml/issues/1048
+                                         // color: 'rgba(255, 255, 255, 0)'
+                                       },
 
-  closeMaskHidden: {
-    right: '-21px',
-    pointerEvents: 'none',
-    // Transitioning color or opacity seems to cause rendering bugs
-    // See: https://github.com/browserhtml/browserhtml/issues/1048
-    // color: 'rgba(255, 255, 255, 0)'
-  },
+                                       closeMaskVisible: {
+                                         right: 0, // Transitioning color or opacity seems to cause rendering bugs
+                                         // See: https://github.com/browserhtml/browserhtml/issues/1048
+                                         // color: 'rgba(255, 255, 255, 1)'
+                                       },
 
-  closeMaskVisible: {
-    right: 0,
-    // Transitioning color or opacity seems to cause rendering bugs
-    // See: https://github.com/browserhtml/browserhtml/issues/1048
-    // color: 'rgba(255, 255, 255, 1)'
-  },
-
-  closeIcon: {
-    color: 'inherit',
-    fontFamily: 'FontAwesome',
-    fontSize: '12px',
-    width: tabHeight,
-    height: tabHeight,
-    lineHeight: tabHeight,
-    textAlign: 'center'
-  }
-});
+                                       closeIcon: {
+                                         color: 'inherit',
+                                         fontFamily: 'FontAwesome',
+                                         fontSize: '12px',
+                                         width: tabHeight,
+                                         height: tabHeight,
+                                         lineHeight: tabHeight,
+                                         textAlign: 'center'
+                                       }
+                                     });
 
 const viewIcon = Image.view('favicon', Style.createSheet({
-  base: {
-    borderRadius: '3px',
-    left: '8px',
-    position: 'absolute',
-    top: '8px',
-    width: '16px',
-    height: '16px'
-  }
-}));
+                                                           base: {
+                                                             borderRadius: '3px',
+                                                             left: '8px',
+                                                             position: 'absolute',
+                                                             top: '8px',
+                                                             width: '16px',
+                                                             height: '16px'
+                                                           }
+                                                         }));
 
 // TODO: Use button widget instead.
-const viewClose = (isSelected, tab, address) =>
-  html.button
-  ( { className: 'tab-close-mask'
-    , style:
-        Style.mix
-        ( styleSheet.closeMask
-        , ( isSelected
-          ? styleSheet.closeMaskSelected
-          : styleSheet.closeMaskUnselected
-          )
-        , ( tab.isPointerOver
-          ? styleSheet.closeMaskVisible
-          : styleSheet.closeMaskHidden
-          )
-        )
-    , onClick:
-        event => {
-          // Should prevent propagation so that tab won't trigger
-          // Activate action when close button is clicked.
-          event.stopPropagation();
-          address(Close);
-        }
-    }
-  , ['']
-  );
+const viewClose = (isSelected, tab, address) =>html.button({
+                                                             className: 'tab-close-mask',
+                                                             style: Style.mix(styleSheet.closeMask, ( isSelected
+                                                                     ? styleSheet.closeMaskSelected
+                                                                     : styleSheet.closeMaskUnselected
+                                                             ), ( tab.isPointerOver
+                                                                     ? styleSheet.closeMaskVisible
+                                                                     : styleSheet.closeMaskHidden
+                                                                              )),
+                                                             onClick: event => {
+                                                               // Should prevent propagation so that tab won't trigger
+                                                               // Activate action when close button is clicked.
+                                                               event.stopPropagation();
+                                                               address(Close);
+                                                             }
+                                                           }, ['']);
 
-export const render =
-  ( model: Navigator.Model
-  , address: Address<Action>
-  , {tabWidth, titleOpacity}: Context
-  ): DOM =>
-  html.div
-  ( { className: 'sidebar-tab'
-    , style: Style.mix
-      ( styleSheet.base
-      , ( model.isSelected
-        ? styleSheet.selected
-        : styleSheet.unselected
-        )
-      , { width: `${tabWidth}px` }
-      )
-    , onMouseOver: forward(address, always(Over))
-    , onMouseOut: forward(address, always(Out))
-    , onClick: forward(address, always(Select))
-    }
-  , [ html.div
-      ( { className: 'sidebar-tab-inner'
-        , style: styleSheet.container
-        }
-      , [ viewIcon
-          ( { uri: readFaviconURI(model.output) }
-          , address
-          )
-        , html.div
-          ( { className: 'sidebar-tab-title'
-            , style:
-              Style.mix
-              ( styleSheet.title
-              , { opacity: titleOpacity }
-              )
-            }
-            // @TODO localize this string
-          , [ readTitle(model.output, 'Untitled')
-            ]
-          )
-        , ( model.isPinned
-          ? ""
-          : thunk('close', viewClose, model.isSelected, model.output.tab, address)
-          )
-        ]
-      )
-    ]
-  );
+export const render = (model:Navigator.Model, address:Address<Action>,
+    { tabWidth, titleOpacity }: Context):DOM =>html.div({
+                                                          className: 'sidebar-tab',
+                                                          style: Style.mix(styleSheet.base, ( model.isSelected
+                                                                  ? styleSheet.selected
+                                                                  : styleSheet.unselected
+                                                          ), { width: `${tabWidth}px` }),
+                                                          onMouseOver: forward(address, always(Over)),
+                                                          onMouseOut: forward(address, always(Out)),
+                                                          onClick: forward(address, always(Select))
+                                                        }, [
+                                                          html.div({
+                                                                     className: 'sidebar-tab-inner',
+                                                                     style: styleSheet.container
+                                                                   }, [
+                                                                     viewIcon({ uri: readFaviconURI(model.output) },
+                                                                              address),
+                                                                     html.div({
+                                                                                className: 'sidebar-tab-title',
+                                                                                style: Style.mix(styleSheet.title,
+                                                                                                 { opacity: titleOpacity })
+                                                                              }
+                                                                              // @TODO localize this string
+                                                                         , [
+                                                                                readTitle(model.output, 'Untitled')
+                                                                              ]),
+                                                                     ( model.isPinned ? "" : thunk('close', viewClose,
+                                                                                                   model.isSelected,
+                                                                                                   model.output.tab,
+                                                                                                   address)
+                                                                     )
+                                                                   ])
+                                                        ]);
 
 
-export const view =
-  ( model: Navigator.Model
-  , address: Address<Action>
-  , context: Context
-  ): DOM =>
-  thunk
-  ( `${model.output.ref.value}`
-  , render
-  , model
-  , address
-  , context
-  )
+export const view = (model:Navigator.Model, address:Address<Action>, context:Context):DOM =>thunk(
+    `${model.output.ref.value}`, render, model, address, context)

--- a/src/browser/Sidebar/Tab.js
+++ b/src/browser/Sidebar/Tab.js
@@ -36,7 +36,7 @@ export class Model {
   /*::
   isPointerOver: boolean;
   */
-  constructor(isPointerOver/*:boolean*/) {
+  constructor(isPointerOver: boolean) {
     this.isPointerOver = isPointerOver
   }
 }
@@ -67,11 +67,11 @@ const Out = TargetAction(Target.Out);
 const Over = TargetAction(Target.Over);
 
 export const init =
-  ()/*:[Model, Effects<Action>]*/ =>
+  (): [Model, Effects<Action>] =>
   transactOut;
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model: Model, action: Action): [Model, Effects<Action>] =>
   ( action.type === "Target"
   ? updateTarget(model, action.source)
   : Unknown.update(model, action)
@@ -213,10 +213,10 @@ const viewClose = (isSelected, tab, address) =>
   );
 
 export const render =
-  ( model/*:Navigator.Model*/
-  , address/*:Address<Action>*/
-  , {tabWidth, titleOpacity}/*:Context*/
-  )/*:DOM*/ =>
+  ( model: Navigator.Model
+  , address: Address<Action>
+  , {tabWidth, titleOpacity}: Context
+  ): DOM =>
   html.div
   ( { className: 'sidebar-tab'
     , style: Style.mix
@@ -262,10 +262,10 @@ export const render =
 
 
 export const view =
-  ( model/*:Navigator.Model*/
-  , address/*:Address<Action>*/
-  , context/*:Context*/
-  )/*:DOM*/ =>
+  ( model: Navigator.Model
+  , address: Address<Action>
+  , context: Context
+  ): DOM =>
   thunk
   ( `${model.output.ref.value}`
   , render

--- a/src/browser/Sidebar/Tabs.js
+++ b/src/browser/Sidebar/Tabs.js
@@ -46,7 +46,7 @@ const styleSheet = Style.createSheet({
 });
 
 export const Close =
-  (id/*:ID*/)/*:Action*/ =>
+  (id: ID): Action =>
   ( { type: "Close"
     , id
     }
@@ -54,7 +54,7 @@ export const Close =
 
 
 export const Select =
-  (id/*:ID*/)/*:Action*/ =>
+  (id: ID): Action =>
   ( { type: "Select"
     , id
     }
@@ -84,7 +84,7 @@ const settings =
   }
 
 export const render =
-  (model/*:Model*/, address/*:Address<Action>*/, context/*:Context*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>, context: Context): DOM =>
   html.div
   ( settings
   , model
@@ -100,7 +100,7 @@ export const render =
   );
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/, context/*:Context*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>, context: Context): DOM =>
   thunk
   ( 'Browser/Sidebar/Tabs'
   , render

--- a/src/browser/Sidebar/Tabs.js
+++ b/src/browser/Sidebar/Tabs.js
@@ -4,107 +4,71 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, thunk, forward, Effects} from 'reflex';
-import {merge, setIn} from '../../common/prelude';
-import {cursor} from '../../common/cursor';
-import * as Style from '../../common/style';
-import * as Toolbar from './Toolbar';
-import * as Tab from './Tab';
-import * as Unknown from '../../common/unknown';
+import { html, thunk, forward } from 'reflex'
+import * as Style from '../../common/style'
+import * as Toolbar from './Toolbar'
+import * as Tab from './Tab'
 
 /*::
-import type {Address, DOM} from "reflex"
-import * as Tab from "./Tab"
-import * as Navigator from "../Navigators/Navigator"
-import * as Deck from "../../common/Deck"
+ import type {Address, DOM} from "reflex"
+ import * as Tab from "./Tab"
+ import * as Navigator from "../Navigators/Navigator"
+ import * as Deck from "../../common/Deck"
 
-export type ID = string
-export type Context = Tab.Context
-export type Model = Deck.Model<Navigator.Model>
+ export type ID = string
+ export type Context = Tab.Context
+ export type Model = Deck.Model<Navigator.Model>
 
-export type Action =
-  | { type: "Close", id: ID }
-  | { type: "Select", id: ID }
-  | { type: "Modify"
-    , id: ID
-    , modify:
-      { type: "Tab"
-      , tab: Tab.Action
-      }
-    }
-*/
+ export type Action =
+ | { type: "Close", id: ID }
+ | { type: "Select", id: ID }
+ | { type: "Modify"
+ , id: ID
+ , modify:
+ { type: "Tab"
+ , tab: Tab.Action
+ }
+ }
+ */
 
 const styleSheet = Style.createSheet({
-  base: {
-    width: '100%',
-    height: `calc(100% - ${Toolbar.height})`,
-    // This padding matches title bar height.
-    paddingTop: '32px',
-    overflowY: 'scroll',
-    boxSizing: 'border-box'
-  }
-});
+                                       base: {
+                                         width: '100%',
+                                         height: `calc(100% - ${Toolbar.height})`, // This padding matches title bar
+                                                                                   // height.
+                                         paddingTop: '32px',
+                                         overflowY: 'scroll',
+                                         boxSizing: 'border-box'
+                                       }
+                                     });
 
-export const Close =
-  (id: ID): Action =>
-  ( { type: "Close"
-    , id
-    }
-  );
+export const Close = (id:ID):Action =>( {
+  type: "Close", id
+}
+);
 
 
-export const Select =
-  (id: ID): Action =>
-  ( { type: "Select"
-    , id
-    }
-  );
+export const Select = (id:ID):Action =>( {
+  type: "Select", id
+}
+);
 
 
-const ByID =
-  id =>
-  action =>
-  ( action.type === "Close"
-  ? Close(id)
-  : action.type === "Select"
-  ? Select(id)
-  : { type: "Modify"
-    , id
-    , modify:
-      { type: "Tab"
-      , tab: action
+const ByID = id =>action =>( action.type === "Close" ? Close(id) : action.type === "Select" ? Select(id) : {
+      type: "Modify", id, modify: {
+        type: "Tab", tab: action
       }
     }
-  );
+);
 
 
-const settings =
-  { className: 'sidebar-tabs-scrollbox'
-  , style: styleSheet.base
-  }
+const settings = {
+  className: 'sidebar-tabs-scrollbox', style: styleSheet.base
+}
 
-export const render =
-  (model: Model, address: Address<Action>, context: Context): DOM =>
-  html.div
-  ( settings
-  , model
+export const render = (model:Model, address:Address<Action>, context:Context):DOM =>html.div(settings, model
     .index
-    .map
-    ( id =>
-      Tab.view
-      ( model.cards[id]
-      , forward(address, ByID(id))
-      , context
-      )
-    )
-  );
+    .map(id =>Tab.view(model.cards[id], forward(address, ByID(id)), context)));
 
-export const view =
-  (model: Model, address: Address<Action>, context: Context): DOM =>
-  thunk
-  ( 'Browser/Sidebar/Tabs'
-  , render
-  , model
-  , address
-  , context
-  )
+export const view = (model:Model, address:Address<Action>, context:Context):DOM =>thunk('Browser/Sidebar/Tabs', render,
+                                                                                        model, address, context)

--- a/src/browser/Sidebar/Toolbar.js
+++ b/src/browser/Sidebar/Toolbar.js
@@ -31,21 +31,21 @@ export class Model {
   pin: Toggle.Model;
   */
   constructor(
-    pin/*:Toggle.Model*/
+    pin: Toggle.Model
   ) {
     this.pin = pin
   }
 }
 
-export const Attach/*:Action*/ =
+export const Attach: Action =
   { type: "Attach"
   };
 
-export const Detach/*:Action*/ =
+export const Detach: Action =
   { type: "Detach"
   };
 
-export const CreateWebView/*:Action*/ =
+export const CreateWebView: Action =
   { type: "CreateWebView"
   };
 
@@ -68,7 +68,7 @@ const updateToggle = cursor({
   update: Toggle.update
 });
 
-export const init = ()/*:[Model, Effects<Action>]*/ => {
+export const init = (): [Model, Effects<Action>] => {
   const [pin, pinFX] = Toggle.init();
   return [
     new Model(pin),
@@ -81,7 +81,7 @@ export const init = ()/*:[Model, Effects<Action>]*/ => {
 }
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model: Model, action: Action): [Model, Effects<Action>] =>
   ( action.type === "Attach"
   ? updateToggle(model, Toggle.Check)
   : action.type === "Detach"
@@ -131,7 +131,7 @@ const viewPin = Toggle.view('pin-button', Style.createSheet({
 }));
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/, display/*:Context*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>, display: Context): DOM =>
   html.div({
     key: 'sidebar-toolbar',
     className: 'sidebar-toolbar',

--- a/src/browser/Sidebar/Toolbar.js
+++ b/src/browser/Sidebar/Toolbar.js
@@ -4,145 +4,124 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, thunk, forward, Effects} from 'reflex';
-import * as Style from '../../common/style';
-import * as Toggle from "../../common/toggle";
-import * as Button from "../../common/button";
-import {merge} from "../../common/prelude";
-import {cursor} from "../../common/cursor";
-import * as Unknown from "../../common/unknown";
+import { html, thunk, forward, Effects } from 'reflex'
+import * as Style from '../../common/style'
+import * as Toggle from '../../common/toggle'
+import { cursor } from '../../common/cursor'
+import * as Unknown from '../../common/unknown'
 
 /*::
-import type {Address, DOM} from "reflex"
+ import type {Address, DOM} from "reflex"
 
-export type Context =
-  { toolbarOpacity: number
-  }
+ export type Context =
+ { toolbarOpacity: number
+ }
 
-export type Action =
-  | { type: "Attach" }
-  | { type: "Detach" }
-  | { type: "CreateWebView" }
-  | { type: "Toggle", toggle: Toggle.Action }
-*/
+ export type Action =
+ | { type: "Attach" }
+ | { type: "Detach" }
+ | { type: "CreateWebView" }
+ | { type: "Toggle", toggle: Toggle.Action }
+ */
 
 export class Model {
   /*::
-  pin: Toggle.Model;
-  */
-  constructor(
-    pin: Toggle.Model
-  ) {
+   pin: Toggle.Model;
+   */
+  constructor(pin:Toggle.Model) {
     this.pin = pin
   }
 }
 
-export const Attach: Action =
-  { type: "Attach"
-  };
+export const Attach:Action = {
+  type: "Attach"
+};
 
-export const Detach: Action =
-  { type: "Detach"
-  };
+export const Detach:Action = {
+  type: "Detach"
+};
 
-export const CreateWebView: Action =
-  { type: "CreateWebView"
-  };
+export const CreateWebView:Action = {
+  type: "CreateWebView"
+};
 
-const ToggleAction =
-  action => {
-    switch (action.type) {
-      case "Check":
-        return Attach
-      case "Uncheck":
-        return Detach
-      default:
-        return { type: "Toggle", toggle: action }
-    }
-  };
+const ToggleAction = action => {
+  switch (action.type) {
+    case "Check":
+      return Attach
+    case "Uncheck":
+      return Detach
+    default:
+      return { type: "Toggle", toggle: action }
+  }
+};
 
 const updateToggle = cursor({
-  get: model => model.pin,
-  set: (model, pin) => new Model(pin),
-  tag: ToggleAction,
-  update: Toggle.update
-});
+                              get: model => model.pin,
+                              set: (model, pin) => new Model(pin),
+                              tag: ToggleAction,
+                              update: Toggle.update
+                            });
 
-export const init = (): [Model, Effects<Action>] => {
+export const init = ():[Model, Effects<Action>] => {
   const [pin, pinFX] = Toggle.init();
   return [
-    new Model(pin),
-    Effects.batch
-    ( [ pinFX.map(ToggleAction)
-      ]
-    )
+    new Model(pin), Effects.batch([
+                                    pinFX.map(ToggleAction)
+                                  ])
 
   ]
 }
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] =>
-  ( action.type === "Attach"
-  ? updateToggle(model, Toggle.Check)
-  : action.type === "Detach"
-  ? updateToggle(model, Toggle.Uncheck)
+export const update = (model:Model, action:Action):[Model, Effects<Action>] =>( action.type === "Attach" ? updateToggle(
+        model, Toggle.Check) : action.type === "Detach" ? updateToggle(model, Toggle.Uncheck)
 
-  : action.type === "Toggle"
-  ? updateToggle(model, action.toggle)
+        : action.type === "Toggle" ? updateToggle(model, action.toggle)
 
-  : Unknown.update(model, action)
-  );
+        : Unknown.update(model, action)
+);
 
 export const height = '48px';
 
 export const styleSheet = Style.createSheet({
-  base: {
-    left: '0',
-    height,
-    position: 'absolute',
-    bottom: '0',
-    width: '100%'
-  },
-  invisible: {
-    opacity: 0,
-    pointerEvents: 'none'
+                                              base: {
+                                                left: '0', height, position: 'absolute', bottom: '0', width: '100%'
+                                              }, invisible: {
+    opacity: 0, pointerEvents: 'none'
   }
-});
+                                            });
 
 const viewPin = Toggle.view('pin-button', Style.createSheet({
-  base: {
-    cursor: 'pointer',
-    height: '32px',
-    width: '32px',
-    margin: '8px',
-    borderRadius: '5px',
-    backgroundRepeat: 'no-repeat',
-    backgroundColor: 'transparent',
-    backgroundPosition: 'center',
-    backgroundImage: 'url(css/pin.png)',
-    backgroundSize:
-        window.devicePixelRatio == null
-      ? '24px 36px'
-      : `${24 / window.devicePixelRatio}px ${36 / window.devicePixelRatio}px`
-  },
-  checked: {
+                                                              base: {
+                                                                cursor: 'pointer',
+                                                                height: '32px',
+                                                                width: '32px',
+                                                                margin: '8px',
+                                                                borderRadius: '5px',
+                                                                backgroundRepeat: 'no-repeat',
+                                                                backgroundColor: 'transparent',
+                                                                backgroundPosition: 'center',
+                                                                backgroundImage: 'url(css/pin.png)',
+                                                                backgroundSize: window.devicePixelRatio == null
+                                                                    ? '24px 36px'
+                                                                    : `${24 / window.devicePixelRatio}px ${36 / window.devicePixelRatio}px`
+                                                              }, checked: {
     backgroundColor: '#3D91F2'
   }
-}));
+                                                            }));
 
-export const view =
-  (model: Model, address: Address<Action>, display: Context): DOM =>
-  html.div({
-    key: 'sidebar-toolbar',
-    className: 'sidebar-toolbar',
-    style:
-    Style.mix
-    ( styleSheet.base
-    , ( display.toolbarOpacity === 0
-      ? styleSheet.invisible
-      : { opacity: display.toolbarOpacity }
-      )
-    )
-  }, [
-    thunk('pin', viewPin, model.pin, forward(address, ToggleAction))
-  ]);
+export const view = (model:Model, address:Address<Action>, display:Context):DOM =>html.div({
+                                                                                             key: 'sidebar-toolbar',
+                                                                                             className: 'sidebar-toolbar',
+                                                                                             style: Style.mix(
+                                                                                                 styleSheet.base,
+                                                                                                 ( display.toolbarOpacity === 0
+                                                                                                         ? styleSheet.invisible
+                                                                                                         : { opacity: display.toolbarOpacity }
+                                                                                                 ))
+                                                                                           }, [
+                                                                                             thunk('pin', viewPin,
+                                                                                                   model.pin,
+                                                                                                   forward(address,
+                                                                                                           ToggleAction))
+                                                                                           ]);

--- a/src/browser/pallet.js
+++ b/src/browser/pallet.js
@@ -5,42 +5,39 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-
-import tinycolor from 'tinycolor2';
-import {Effects, Task} from 'reflex';
-import {getDomainName} from '../common/url-helper';
+import tinycolor from 'tinycolor2'
+import { Task } from 'reflex'
+import { getDomainName } from '../common/url-helper'
 
 /*::
-import type {Address, DOM, Never} from "reflex"
-import type {URI, HexColor, Color, Model, Theme} from "./pallet";
-*/
+ import type {Address, DOM, Never} from "reflex"
+ import type {URI, HexColor, Color, Model, Theme} from "./pallet";
+ */
 
 // Hand-curated themes for popular websites.
 const curated = {
-  'facebook.com': {background: '#3a5795', foreground: '#fff'},
-  'sina.com.cn': {background: '#ff8500', foreground: '#fff'},
-  'reddit.com': {background: '#f0f0f0', foreground: '#336699'},
-  'instagram.com': {background: '#125688', foreground: '#fff'},
-  'imgur.com': {background: '#2b2b2b', foreground: '#fff'},
-  'cnn.com': {background: '#0c0c0c', foreground: '#fff'},
-  'slideshare.net': {background: '#313131', foreground: '#fff'},
-  'deviantart.com': {background: '#475c4d', foreground: '#fff'},
-  'soundcloud.com': {background: '#333333', foreground: '#FF5500'},
-  'mashable.com': {background: '#00aeef', foreground: '#fff'},
-  'daringfireball.net': {background: '#4a525a', foreground: '#fff'},
-  'firewatchgame.com': {background: '#2d102b', foreground: '#ef4338'},
-  'whatliesbelow.com': {background: '#74888b', foreground: '#fff'},
-  'supertimeforce.com': {background: '#051224', foreground: '#2ebcec'},
-  'github.com': {background: 'rgb(245, 245, 245)', foreground: 'rgb(51, 51, 51)'},
+  'facebook.com': { background: '#3a5795', foreground: '#fff' },
+  'sina.com.cn': { background: '#ff8500', foreground: '#fff' },
+  'reddit.com': { background: '#f0f0f0', foreground: '#336699' },
+  'instagram.com': { background: '#125688', foreground: '#fff' },
+  'imgur.com': { background: '#2b2b2b', foreground: '#fff' },
+  'cnn.com': { background: '#0c0c0c', foreground: '#fff' },
+  'slideshare.net': { background: '#313131', foreground: '#fff' },
+  'deviantart.com': { background: '#475c4d', foreground: '#fff' },
+  'soundcloud.com': { background: '#333333', foreground: '#FF5500' },
+  'mashable.com': { background: '#00aeef', foreground: '#fff' },
+  'daringfireball.net': { background: '#4a525a', foreground: '#fff' },
+  'firewatchgame.com': { background: '#2d102b', foreground: '#ef4338' },
+  'whatliesbelow.com': { background: '#74888b', foreground: '#fff' },
+  'supertimeforce.com': { background: '#051224', foreground: '#2ebcec' },
+  'github.com': { background: 'rgb(245, 245, 245)', foreground: 'rgb(51, 51, 51)' },
 };
 
 // Calculate the distance from white, returning a boolean.
 // This is a pretty primitive check.
-const isHexBright =
-  (hexcolor: HexColor): boolean =>
-  parseInt(hexcolor, 16) > 0xffffff/2;
+const isHexBright = (hexcolor:HexColor):boolean =>parseInt(hexcolor, 16) > 0xffffff / 2;
 
-export const isDark = (color: Color): boolean => {
+export const isDark = (color:Color):boolean => {
   const tcolor = tinycolor(color);
   // tinycolor uses YIQ for brightness calculation, we also throw more
   // primitive hex based calculation and treat background as dark if any
@@ -48,27 +45,16 @@ export const isDark = (color: Color): boolean => {
   return (tcolor.isDark() || !isHexBright(tcolor.toHex()));
 }
 
-export const blank: Model = {
-  isDark: false,
-  foreground: null,
-  background: null
+export const blank:Model = {
+  isDark: false, foreground: null, background: null
 };
 
-export const create =
-  (background: Color, foreground: Color): Model =>
-  ( { background
-    , foreground
-    , isDark: isDark(background)
-    }
-  );
+export const create = (background:Color, foreground:Color):Model =>( {
+  background, foreground, isDark: isDark(background)
+}
+);
 
-export const requestCuratedColor =
-  (uri: URI): Task<Never, ?Theme> =>
-  new Task((succeed, fail) => {
-    const hostname = getDomainName(uri);
-    Promise.resolve
-    ( hostname == null
-    ? null
-    : curated[hostname]
-    ).then(succeed, fail)
-  });
+export const requestCuratedColor = (uri:URI):Task<Never, ?Theme> =>new Task((succeed, fail) => {
+  const hostname = getDomainName(uri);
+  Promise.resolve(hostname == null ? null : curated[hostname]).then(succeed, fail)
+});

--- a/src/browser/pallet.js
+++ b/src/browser/pallet.js
@@ -37,10 +37,10 @@ const curated = {
 // Calculate the distance from white, returning a boolean.
 // This is a pretty primitive check.
 const isHexBright =
-  (hexcolor/*:HexColor*/)/*:boolean*/ =>
+  (hexcolor: HexColor): boolean =>
   parseInt(hexcolor, 16) > 0xffffff/2;
 
-export const isDark = (color/*:Color*/)/*:boolean*/ => {
+export const isDark = (color: Color): boolean => {
   const tcolor = tinycolor(color);
   // tinycolor uses YIQ for brightness calculation, we also throw more
   // primitive hex based calculation and treat background as dark if any
@@ -48,14 +48,14 @@ export const isDark = (color/*:Color*/)/*:boolean*/ => {
   return (tcolor.isDark() || !isHexBright(tcolor.toHex()));
 }
 
-export const blank/*:Model*/ = {
+export const blank: Model = {
   isDark: false,
   foreground: null,
   background: null
 };
 
 export const create =
-  (background/*:Color*/, foreground/*:Color*/)/*:Model*/ =>
+  (background: Color, foreground: Color): Model =>
   ( { background
     , foreground
     , isDark: isDark(background)
@@ -63,7 +63,7 @@ export const create =
   );
 
 export const requestCuratedColor =
-  (uri/*:URI*/)/*:Task<Never, ?Theme>*/ =>
+  (uri: URI): Task<Never, ?Theme> =>
   new Task((succeed, fail) => {
     const hostname = getDomainName(uri);
     Promise.resolve

--- a/src/browser/shell.js
+++ b/src/browser/shell.js
@@ -23,7 +23,7 @@ const fetchFocus =
   new Task((succeed, fail) => succeed(document.hasFocus()));
 
 export const init =
-  ()/*:[Model, Effects<Action>]*/ => {
+  (): [Model, Effects<Action>] => {
   const [controls, fx] = Controls.init(false, false, false);
   return [
     ( { isFocused: false
@@ -43,23 +43,23 @@ export const init =
   ]
 }
 
-export const Focus/*:Action*/ =
+export const Focus: Action =
   { type: "Focus"
   };
 
-export const Blur/*:Action*/ =
+export const Blur: Action =
   { type: "Blur"
   };
 
-export const Close/*:Action*/ =
+export const Close: Action =
   { type: "Close"
   };
 
-export const Minimize/*:Action*/ =
+export const Minimize: Action =
   { type: "Minimize"
   };
 
-export const ToggleFullscreen/*:Action*/ =
+export const ToggleFullscreen: Action =
   { type: "ToggleFullscreen"
   };
 
@@ -159,7 +159,7 @@ const toggleFullscreen = model =>
 
 
 export const update =
-  (model/*:Model*/, action/*:Action*/) =>
+  (model: Model, action: Action) =>
   ( action.type === "Focus"
   ? focus(model)
   : action.type === "Blur"
@@ -188,7 +188,7 @@ export const update =
   );
 
 export const render =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ => {
+  (model: Model, address: Address<Action>): DOM => {
     if (!Runtime.useNativeTitlebar()) {
       return Controls.view(model.controls, forward(address, ControlsAction));
     } else {
@@ -197,7 +197,7 @@ export const render =
   }
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>): DOM =>
   thunk
   ( "Browser/Shell"
   , render

--- a/src/browser/shell.js
+++ b/src/browser/shell.js
@@ -4,203 +4,178 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Effects, Task, html, thunk, forward} from "reflex";
-import {merge, always} from "../common/prelude";
-import {cursor} from "../common/cursor";
-import * as Focusable from "../common/focusable";
-import * as Target from "../common/target";
-import * as Runtime from "../common/runtime";
-import * as Controls from "./shell/controls";
-import * as Unknown from "../common/unknown";
+import { Effects, Task, thunk, forward } from 'reflex'
+import { merge } from '../common/prelude'
+import { cursor } from '../common/cursor'
+import * as Runtime from '../common/runtime'
+import * as Controls from './shell/controls'
+import * as Unknown from '../common/unknown'
 
 /*::
-import type {Address, DOM} from "reflex"
-import type {Model, Action} from "./shell"
-*/
+ import type {Address, DOM} from "reflex"
+ import type {Model, Action} from "./shell"
+ */
 
 // @TODO: IO stuff should probably live elsewhere.
-const fetchFocus =
-  new Task((succeed, fail) => succeed(document.hasFocus()));
+const fetchFocus = new Task((succeed, fail) => succeed(document.hasFocus()));
 
-export const init =
-  (): [Model, Effects<Action>] => {
+export const init = ():[Model, Effects<Action>] => {
   const [controls, fx] = Controls.init(false, false, false);
   return [
-    ( { isFocused: false
-      , isMinimized: false
-      , isMaximized: false
-      , controls: controls
-      }
-    )
-  , Effects.batch
-    ( [ fx.map(ControlsAction)
-      , // Check if window is actually focused
-        Effects
-        .perform(fetchFocus)
-        .map(isFocused => isFocused ? Focus : Blur)
-      ]
-    )
+    ( {
+      isFocused: false, isMinimized: false, isMaximized: false, controls: controls
+    }
+    ), Effects.batch([
+                       fx.map(ControlsAction), // Check if window is actually focused
+                       Effects
+                           .perform(fetchFocus)
+                           .map(isFocused => isFocused ? Focus : Blur)
+                     ])
   ]
 }
 
-export const Focus: Action =
-  { type: "Focus"
-  };
+export const Focus:Action = {
+  type: "Focus"
+};
 
-export const Blur: Action =
-  { type: "Blur"
-  };
+export const Blur:Action = {
+  type: "Blur"
+};
 
-export const Close: Action =
-  { type: "Close"
-  };
+export const Close:Action = {
+  type: "Close"
+};
 
-export const Minimize: Action =
-  { type: "Minimize"
-  };
+export const Minimize:Action = {
+  type: "Minimize"
+};
 
-export const ToggleFullscreen: Action =
-  { type: "ToggleFullscreen"
-  };
+export const ToggleFullscreen:Action = {
+  type: "ToggleFullscreen"
+};
 
-const Closed = result =>
-  ( { type: "Closed"
-    , result
+const Closed = result =>( {
+  type: "Closed", result
+}
+)
+
+const Minimized = result =>( {
+  type: "Minimized", result
+}
+);
+
+const FullscreenToggled = result =>( {
+  type: "FullscreenToggled", result
+}
+);
+
+
+const ControlsAction = action =>( action.type === 'CloseWindow'
+        ? Close
+        : action.type === 'MinimizeWindow'
+        ? Minimize
+        : action.type === 'ToggleWindowFullscreen'
+        ? ToggleFullscreen
+        : {
+      type: "Controls",
+      source: action
     }
-  )
+);
 
-const Minimized = result =>
-  ( { type: "Minimized"
-    , result
-    }
-  );
-
-const FullscreenToggled = result =>
-  ( { type: "FullscreenToggled"
-    , result
-    }
-  );
+const updateControls = cursor({
+                                get: model => model.controls,
+                                set: (model, controls) => merge(model, { controls }),
+                                update: Controls.update,
+                                tag: ControlsAction
+                              });
 
 
-const ControlsAction = action =>
-  ( action.type === 'CloseWindow'
-  ? Close
-  : action.type === 'MinimizeWindow'
-  ? Minimize
-  : action.type === 'ToggleWindowFullscreen'
-  ? ToggleFullscreen
-  : { type: "Controls"
-    , source: action
-    }
-  );
+const focus = model =>updateControls(merge(model, { isFocused: true, isMinimized: false }), Controls.Enable);
 
-const updateControls = cursor
-  ( { get: model => model.controls
-    , set: (model, controls) => merge(model, {controls})
-    , update: Controls.update
-    , tag: ControlsAction
-    }
-  );
+const blur = model =>updateControls(merge(model, { isFocused: false }), Controls.Disable);
 
+const minimized = (model, result) =>( result.isOk
+        ? [
+      merge(model, { isMinimized: true }),
+      Effects.none
+    ]
+        : [
+      model,
+      Effects.perform(Unknown.error(result.error))
+    ]
+);
 
-const focus = model =>
-  updateControls
-  ( merge(model, {isFocused: true, isMinimized: false})
-  , Controls.Enable
-  );
+const fullscreenToggled = (model, result) =>( result.isOk
+        ? updateControls(merge(model, { isMaximized: !model.isMaximized }), Controls.FullscreenToggled)
+        : [
+      model,
+      Effects.perform(Unknown.error(result.error))
+    ]
+);
 
-const blur = model =>
-  updateControls
-  ( merge(model, {isFocused: false})
-  , Controls.Disable
-  );
+const closed = (model, result) =>( result.isOk
+        ? [
+      model,
+      Effects.none
+    ]
+        : [
+      model,
+      Effects.perform(Unknown.error(result.error))
+    ]
+);
 
-const minimized = (model, result) =>
-  ( result.isOk
-  ? [ merge(model, {isMinimized: true}), Effects.none ]
-  : [ model, Effects.perform(Unknown.error(result.error)) ]
-  );
+const close = model =>[
+  model, Effects
+      .perform(Runtime.quit)
+      .map(Closed)
+];
 
-const fullscreenToggled = (model, result) =>
-  ( result.isOk
-  ? updateControls
-    ( merge(model, {isMaximized: !model.isMaximized})
-    , Controls.FullscreenToggled
-    )
-  : [ model, Effects.perform(Unknown.error(result.error)) ]
-  );
+const minimize = model =>[
+  model, Effects
+      .perform(Runtime.minimize)
+      .map(Minimized)
+];
 
-const closed = (model, result) =>
-  ( result.isOk
-  ? [ model, Effects.none ]
-  : [ model, Effects.perform(Unknown.error(result.error)) ]
-  );
-
-const close = model =>
-  [ model
-  , Effects
-    .perform(Runtime.quit)
-    .map(Closed)
-  ];
-
-const minimize = model =>
-  [ model
-  , Effects
-    .perform(Runtime.minimize)
-    .map(Minimized)
-  ];
-
-const toggleFullscreen = model =>
-  [ model
-  , Effects
-    .perform(Runtime.toggleFullscreen)
-    .map(FullscreenToggled)
-  ];
+const toggleFullscreen = model =>[
+  model, Effects
+      .perform(Runtime.toggleFullscreen)
+      .map(FullscreenToggled)
+];
 
 
-export const update =
-  (model: Model, action: Action) =>
-  ( action.type === "Focus"
-  ? focus(model)
-  : action.type === "Blur"
-  ? blur(model)
+export const update = (model:Model, action:Action) =>( action.type === "Focus"
+        ? focus(model)
+        : action.type === "Blur"
+        ? blur(model)
 
-  : action.type === "Minimize"
-  ? minimize(model)
-  : action.type === "Minimized"
-  ? minimized(model, action.result)
+        : action.type === "Minimize"
+        ? minimize(model)
+        : action.type === "Minimized"
+        ? minimized(model, action.result)
 
-  : action.type === "Close"
-  ? close(model)
-  : action.type === "Closed"
-  ? closed(model, action.result)
+        : action.type === "Close"
+        ? close(model)
+        : action.type === "Closed"
+        ? closed(model, action.result)
 
-  : action.type === "ToggleFullscreen"
-  ? toggleFullscreen(model)
-  : action.type === "FullscreenToggled"
-  ? fullscreenToggled(model, action.result)
+        : action.type === "ToggleFullscreen"
+        ? toggleFullscreen(model)
+        : action.type === "FullscreenToggled"
+        ? fullscreenToggled(model, action.result)
 
 
-  : action.type === "Controls"
-  ? updateControls(model, action.source)
+        : action.type === "Controls"
+        ? updateControls(model, action.source)
 
-  : Unknown.update(model, action)
-  );
+        : Unknown.update(model, action)
+);
 
-export const render =
-  (model: Model, address: Address<Action>): DOM => {
-    if (!Runtime.useNativeTitlebar()) {
-      return Controls.view(model.controls, forward(address, ControlsAction));
-    } else {
-      return "";
-    }
+export const render = (model:Model, address:Address<Action>):DOM => {
+  if (!Runtime.useNativeTitlebar()) {
+    return Controls.view(model.controls, forward(address, ControlsAction));
+  } else {
+    return "";
   }
+}
 
-export const view =
-  (model: Model, address: Address<Action>): DOM =>
-  thunk
-  ( "Browser/Shell"
-  , render
-  , model
-  , address
-  );
+export const view = (model:Model, address:Address<Action>):DOM =>thunk("Browser/Shell", render, model, address);

--- a/src/browser/shell/controls.js
+++ b/src/browser/shell/controls.js
@@ -20,16 +20,16 @@ import type {Address, DOM} from "reflex"
 import type {Model, Action} from "./controls"
 */
 
-export const CloseWindow/*:Action*/ = {type: "CloseWindow"};
-export const MinimizeWindow/*:Action*/ = {type: "MinimizeWindow"};
-export const ToggleWindowFullscreen/*:Action*/ = {type: "ToggleWindowFullscreen"};
+export const CloseWindow: Action = {type: "CloseWindow"};
+export const MinimizeWindow: Action = {type: "MinimizeWindow"};
+export const ToggleWindowFullscreen: Action = {type: "ToggleWindowFullscreen"};
 
-export const FullscreenToggled/*:Action*/ = {type: "FullscreenToggled"};
-export const Ignore/*:Action*/ = {type: "Ignore"};
-export const Over/*:Action*/ = {type: "Over"};
-export const Out/*:Action*/ = {type: "Out"};
-export const Enable/*:Action*/ = {type: "Enable"};
-export const Disable/*:Action*/ = {type: "Disable"};
+export const FullscreenToggled: Action = {type: "FullscreenToggled"};
+export const Ignore: Action = {type: "Ignore"};
+export const Over: Action = {type: "Over"};
+export const Out: Action = {type: "Out"};
+export const Enable: Action = {type: "Enable"};
+export const Disable: Action = {type: "Disable"};
 
 const ignore = action =>
   ( action.type === "Target"
@@ -105,7 +105,7 @@ const updateToggle = cursor({
 });
 
 export const init =
-  (isDisabled/*:boolean*/, isPointerOver/*:boolean*/, isMaximized/*:boolean*/)/*:[Model, Effects<Action>]*/ => {
+  (isDisabled: boolean, isPointerOver: boolean, isMaximized: boolean): [Model, Effects<Action>] => {
   const [isFocused, isActive] = [false, false];
 
   const [close, closeFX] = Button.init
@@ -165,7 +165,7 @@ const updateButtons = (model, action) => {
 }
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model: Model, action: Action): [Model, Effects<Action>] =>
   ( action.type === 'Over'
   ? updateButtons(model, Button.Over)
   : action.type === 'Out'
@@ -262,7 +262,7 @@ const viewToggle = Toggle.view('window-toggle-fullscreen-button', StyleSheet.cre
 
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>): DOM =>
   html.div({
     key: 'window-controls',
     className: 'window-controls',

--- a/src/browser/shell/controls.js
+++ b/src/browser/shell/controls.js
@@ -4,146 +4,97 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, forward, Effects} from 'reflex';
-import {Style, StyleSheet} from '../../common/style';
-import * as Target from '../../common/target';
-import * as Button from '../../common/button';
-import * as Toggle from '../../common/toggle';
-import * as Unknown from '../../common/unknown';
-import {compose} from '../../lang/functional';
-import {always, merge} from '../../common/prelude';
-import {cursor} from '../../common/cursor';
+import { html, forward, Effects } from 'reflex'
+import { Style, StyleSheet } from '../../common/style'
+import * as Target from '../../common/target'
+import * as Button from '../../common/button'
+import * as Toggle from '../../common/toggle'
+import * as Unknown from '../../common/unknown'
+import { compose } from '../../lang/functional'
+import { always, merge } from '../../common/prelude'
+import { cursor } from '../../common/cursor'
 
 
 /*::
-import type {Address, DOM} from "reflex"
-import type {Model, Action} from "./controls"
-*/
+ import type {Address, DOM} from "reflex"
+ import type {Model, Action} from "./controls"
+ */
 
-export const CloseWindow: Action = {type: "CloseWindow"};
-export const MinimizeWindow: Action = {type: "MinimizeWindow"};
-export const ToggleWindowFullscreen: Action = {type: "ToggleWindowFullscreen"};
+export const CloseWindow:Action = { type: "CloseWindow" };
+export const MinimizeWindow:Action = { type: "MinimizeWindow" };
+export const ToggleWindowFullscreen:Action = { type: "ToggleWindowFullscreen" };
 
-export const FullscreenToggled: Action = {type: "FullscreenToggled"};
-export const Ignore: Action = {type: "Ignore"};
-export const Over: Action = {type: "Over"};
-export const Out: Action = {type: "Out"};
-export const Enable: Action = {type: "Enable"};
-export const Disable: Action = {type: "Disable"};
+export const FullscreenToggled:Action = { type: "FullscreenToggled" };
+export const Ignore:Action = { type: "Ignore" };
+export const Over:Action = { type: "Over" };
+export const Out:Action = { type: "Out" };
+export const Enable:Action = { type: "Enable" };
+export const Disable:Action = { type: "Disable" };
 
-const ignore = action =>
-  ( action.type === "Target"
-  ? Ignore
-  : action.type === "Focusable"
-  ? Ignore
-  : action
-  );
+const ignore = action =>( action.type === "Target" ? Ignore : action.type === "Focusable" ? Ignore : action
+);
 
 
-const CloseButtonAction = compose
-  ( action =>
-    ( action === Ignore
-    ? Ignore
-    : action.type === "Press"
-    ? CloseWindow
-    : ( { type: "CloseButton"
-        , source: action
-        }
-      )
+const CloseButtonAction = compose(action =>( action === Ignore ? Ignore : action.type === "Press" ? CloseWindow : ( {
+      type: "CloseButton", source: action
+    }
     )
-  , ignore
-  );
+), ignore);
 
-const MinimizeButtonAction = compose
-  ( action =>
-    ( action === Ignore
-    ? Ignore
-    : action.type === "Press"
-    ? MinimizeWindow
-    : ( { type: "MinimizeButton"
-        , source: action
+const MinimizeButtonAction = compose(
+    action =>( action === Ignore ? Ignore : action.type === "Press" ? MinimizeWindow : ( {
+          type: "MinimizeButton", source: action
         }
-      )
-    )
-  , ignore
-  );
+        )
+    ), ignore);
 
-const ToggleButtonAction = compose
-  ( action =>
-    ( action === Ignore
-    ? Ignore
-    : action.type === "Press"
-    ? ToggleWindowFullscreen
-    : ( { type: "ToggleButton"
-        , source: action
+const ToggleButtonAction = compose(
+    action =>( action === Ignore ? Ignore : action.type === "Press" ? ToggleWindowFullscreen : ( {
+          type: "ToggleButton", source: action
         }
-      )
-    )
-  , ignore
-  );
+        )
+    ), ignore);
 
 
 const updateClose = cursor({
-  get: model => model.close,
-  set: (model, close) => merge(model, {close}),
-  update: Button.update,
-  tag: CloseButtonAction
-});
+                             get: model => model.close,
+                             set: (model, close) => merge(model, { close }),
+                             update: Button.update,
+                             tag: CloseButtonAction
+                           });
 
 const updateMinimize = cursor({
-  get: model => model.minimize,
-  set: (model, minimize) => merge(model, {minimize}),
-  update: Button.update,
-  tag: MinimizeButtonAction
-});
+                                get: model => model.minimize,
+                                set: (model, minimize) => merge(model, { minimize }),
+                                update: Button.update,
+                                tag: MinimizeButtonAction
+                              });
 
 const updateToggle = cursor({
-  get: model => model.toggle,
-  set: (model, toggle) => merge(model, {toggle}),
-  update: Toggle.update,
-  tag: ToggleButtonAction
-});
+                              get: model => model.toggle,
+                              set: (model, toggle) => merge(model, { toggle }),
+                              update: Toggle.update,
+                              tag: ToggleButtonAction
+                            });
 
-export const init =
-  (isDisabled: boolean, isPointerOver: boolean, isMaximized: boolean): [Model, Effects<Action>] => {
+export const init = (isDisabled:boolean, isPointerOver:boolean, isMaximized:boolean):[Model, Effects<Action>] => {
   const [isFocused, isActive] = [false, false];
 
-  const [close, closeFX] = Button.init
-    ( isDisabled
-    , isPointerOver
-    , isFocused
-    , isActive
-    , ''
-    );
+  const [close, closeFX] = Button.init(isDisabled, isPointerOver, isFocused, isActive, '');
 
-  const [minimize, minimizeFX] = Button.init
-    ( isDisabled
-    , isPointerOver
-    , isFocused
-    , isActive
-    , ''
-    );
+  const [minimize, minimizeFX] = Button.init(isDisabled, isPointerOver, isFocused, isActive, '');
 
-  const [toggle, toggleFX] = Toggle.init
-    ( isDisabled
-    , isFocused
-    , isActive
-    , isPointerOver
-    , isMaximized
-    );
+  const [toggle, toggleFX] = Toggle.init(isDisabled, isFocused, isActive, isPointerOver, isMaximized);
 
-  const model =
-    { close
-    , minimize
-    , toggle
-    };
+  const model = {
+    close, minimize, toggle
+  };
 
-  const fx = Effects.batch
-    ( [ closeFX.map(CloseButtonAction)
-      , minimizeFX.map(MinimizeButtonAction)
-      , toggleFX.map(ToggleButtonAction)
-      ]
-    );
+  const fx = Effects.batch([
+                             closeFX.map(CloseButtonAction),
+                             minimizeFX.map(MinimizeButtonAction),
+                             toggleFX.map(ToggleButtonAction)
+                           ]);
 
   return [model, fx];
 }
@@ -151,126 +102,126 @@ export const init =
 const updateButtons = (model, action) => {
   const [close, closeFx] = Button.update(model.close, action);
   const [minimize, minimizeFx] = Button.update(model.minimize, action);
-  const [toggle, toggleFx] = Toggle.update(model.toggle, {type: "Button", action});
+  const [toggle, toggleFx] = Toggle.update(model.toggle, { type: "Button", action });
 
   return [
-    merge(model, {close, minimize, toggle})
-  , Effects.batch(
-      [ closeFx.map(CloseButtonAction)
-      , minimizeFx.map(MinimizeButtonAction)
-      , toggleFx.map(ToggleButtonAction)
-      ]
-    )
+    merge(model, { close, minimize, toggle }), Effects.batch([
+                                                               closeFx.map(CloseButtonAction),
+                                                               minimizeFx.map(MinimizeButtonAction),
+                                                               toggleFx.map(ToggleButtonAction)
+                                                             ])
   ]
 }
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] =>
-  ( action.type === 'Over'
-  ? updateButtons(model, Button.Over)
-  : action.type === 'Out'
-  ? updateButtons(model, Button.Out)
-  : action.type === 'Enable'
-  ? updateButtons(model, Button.Enable)
-  : action.type === 'Disable'
-  ? updateButtons(model, Button.Disable)
-  : action.type === 'FullscreenToggled'
-  ? updateToggle(model, Toggle.Press)
-  : action.type === 'Ignore'
-  ? [model, Effects.none]
-  : action.type === 'CloseButton'
-  ? updateClose(model, action.source)
-  : action.type === 'MinimizeButton'
-  ? updateMinimize(model, action.source)
-  : action.type === 'ToggleButton'
-  ? [model, Effects.none]
-  : Unknown.update(model, action)
-  );
+export const update = (model:Model, action:Action):[Model, Effects<Action>] =>( action.type === 'Over'
+        ? updateButtons(model, Button.Over)
+        : action.type === 'Out'
+        ? updateButtons(model, Button.Out)
+        : action.type === 'Enable'
+        ? updateButtons(model, Button.Enable)
+        : action.type === 'Disable'
+        ? updateButtons(model, Button.Disable)
+        : action.type === 'FullscreenToggled'
+        ? updateToggle(model, Toggle.Press)
+        : action.type === 'Ignore'
+        ? [
+      model,
+      Effects.none
+    ]
+        : action.type === 'CloseButton'
+        ? updateClose(model, action.source)
+        : action.type === 'MinimizeButton'
+        ? updateMinimize(model, action.source)
+        : action.type === 'ToggleButton'
+        ? [
+      model,
+      Effects.none
+    ]
+        : Unknown.update(model, action)
+);
 
 
 // style
 
 const styleSheet = StyleSheet.create({
-  container: {
-    height: '12px',
-    position: 'absolute',
-    width: '52px',
-    top: '8px',
-    left: '8px',
-    zIndex: 200
-  },
-  button: {
+                                       container: {
+                                         height: '12px',
+                                         position: 'absolute',
+                                         width: '52px',
+                                         top: '8px',
+                                         left: '8px',
+                                         zIndex: 200
+                                       }, button: {
     backgroundColor: 'transparent',
     backgroundImage: 'url(css/window-controls.sprite.png)',
-    backgroundRepeat: 'no-repeat',
-    // Scale sprite by 1/2 for retina.
+    backgroundRepeat: 'no-repeat', // Scale sprite by 1/2 for retina.
     backgroundSize: '25px auto',
     width: '12px',
     height: '12px',
     left: 0,
     position: 'absolute',
     top: 0
-  },
-  disabledButton: {
+  }, disabledButton: {
     backgroundPosition: '0 -300px'
-  },
-  closeButton: {
+  }, closeButton: {
     left: 0
-  },
-  minimizeButton: {
+  }, minimizeButton: {
     left: '20px'
-  },
-  toggleButton: {
+  }, toggleButton: {
     left: '40px'
   }
-});
+                                     });
 
 const viewClose = Button.view('window-close-button', StyleSheet.create({
-  base: Style(styleSheet.button, styleSheet.closeButton),
-  disabled: styleSheet.disabledButton,
-  enabled: {
-    backgroundPosition: '0 -150px',
-  },
-  over: {
-    backgroundPosition: '0 0'
-  }
-}));
+                                                                         base: Style(styleSheet.button,
+                                                                                     styleSheet.closeButton),
+                                                                         disabled: styleSheet.disabledButton,
+                                                                         enabled: {
+                                                                           backgroundPosition: '0 -150px',
+                                                                         },
+                                                                         over: {
+                                                                           backgroundPosition: '0 0'
+                                                                         }
+                                                                       }));
 
 const viewMinimize = Button.view('window-minimize-button', StyleSheet.create({
-  base: Style(styleSheet.button, styleSheet.minimizeButton),
-  disabled: styleSheet.disabledButton,
-  enabled: {
-    backgroundPosition: '0 -200px',
-  },
-  over: {
-    backgroundPosition: '0 -50px'
-  }
-}));
+                                                                               base: Style(styleSheet.button,
+                                                                                           styleSheet.minimizeButton),
+                                                                               disabled: styleSheet.disabledButton,
+                                                                               enabled: {
+                                                                                 backgroundPosition: '0 -200px',
+                                                                               },
+                                                                               over: {
+                                                                                 backgroundPosition: '0 -50px'
+                                                                               }
+                                                                             }));
 
 // @TODO Checked and uncheked versions should be styled differently.
 const viewToggle = Toggle.view('window-toggle-fullscreen-button', StyleSheet.create({
-  base: Style(styleSheet.button, styleSheet.toggleButton),
-  disabled: styleSheet.disabledButton,
-  enabled: {
-    backgroundPosition: '0 -250px'
-  },
-  over: {
-    backgroundPosition: '0 -100px'
-  }
-}));
+                                                                                      base: Style(styleSheet.button,
+                                                                                                  styleSheet.toggleButton),
+                                                                                      disabled: styleSheet.disabledButton,
+                                                                                      enabled: {
+                                                                                        backgroundPosition: '0 -250px'
+                                                                                      },
+                                                                                      over: {
+                                                                                        backgroundPosition: '0 -100px'
+                                                                                      }
+                                                                                    }));
 
 
-
-export const view =
-  (model: Model, address: Address<Action>): DOM =>
-  html.div({
-    key: 'window-controls',
-    className: 'window-controls',
-    style: styleSheet.container,
-    onMouseOver: forward(address, always(Over)),
-    onMouseOut: forward(address, always(Out)),
-  }, [
-    viewClose(model.close, forward(address, CloseButtonAction)),
-    viewMinimize(model.minimize, forward(address, MinimizeButtonAction)),
-    viewToggle(model.toggle, forward(address, ToggleButtonAction))
-  ]);
+export const view = (model:Model, address:Address<Action>):DOM =>html.div({
+                                                                            key: 'window-controls',
+                                                                            className: 'window-controls',
+                                                                            style: styleSheet.container,
+                                                                            onMouseOver: forward(address, always(Over)),
+                                                                            onMouseOut: forward(address, always(Out)),
+                                                                          }, [
+                                                                            viewClose(model.close, forward(address,
+                                                                                                           CloseButtonAction)),
+                                                                            viewMinimize(model.minimize,
+                                                                                         forward(address,
+                                                                                                 MinimizeButtonAction)),
+                                                                            viewToggle(model.toggle, forward(address,
+                                                                                                             ToggleButtonAction))
+                                                                          ]);

--- a/src/common/Animation.js
+++ b/src/common/Animation.js
@@ -1,33 +1,27 @@
 /* @flow */
 
-import * as Unknown from "./unknown"
-import {Task, Effects} from "reflex"
-import {ease} from "eased"
+import * as Unknown from './unknown'
+import { Task, Effects } from 'reflex'
+import { ease } from 'eased'
 
 /*::
-export type Time = number
-export type Action =
-  | { type: "Tick", time: Time }
-  | { type: "End", time: Time }
+ export type Time = number
+ export type Action =
+ | { type: "Tick", time: Time }
+ | { type: "End", time: Time }
 
-import type {Interpolation, Easing} from "eased"
-*/
+ import type {Interpolation, Easing} from "eased"
+ */
 
 class Transition /*::<model>*/ {
   /*::
-  duration: Time;
-  now: Time;
-  elapsed: Time;
-  from: model;
-  to: model;
-  */
-  constructor(
-    from: model
-  , to: model
-  , now: Time
-  , elapsed: Time
-  , duration: Time
-  ) {
+   duration: Time;
+   now: Time;
+   elapsed: Time;
+   from: model;
+   to: model;
+   */
+  constructor(from:model, to:model, now:Time, elapsed:Time, duration:Time) {
     this.from = from
     this.to = to
     this.now = now
@@ -38,159 +32,83 @@ class Transition /*::<model>*/ {
 
 export class Model /*::<model>*/ {
   /*::
-  state: model;
-  transition: ?Transition<model>;
-  */
-  constructor(
-    state: model
-  , transition: ?Transition<model>
-  ) {
+   state: model;
+   transition: ?Transition<model>;
+   */
+  constructor(state:model, transition:?Transition<model>) {
     this.state = state
     this.transition = transition
   }
 }
 
 export const transition = /*::<action, model>*/
-  ( model: Model<model>
-  , to: model
-  , duration: Time
-  ): [Model<model>, Effects<Action>] =>
-  ( model.transition == null
-  ? startTransition
-    ( model.state
-    , to
-    , 0
-    , duration
+    (model:Model<model>, to:model, duration:Time):[Model<model>, Effects<Action>] =>( model.transition == null
+            ? startTransition(model.state, to, 0, duration)
+            : model.transition.to === to
+            ? nofx(model)
+            : startTransition(model.state, to,
+                              duration - (duration * model.transition.elapsed / model.transition.duration), duration)
     )
-  : model.transition.to === to
-  ? nofx(model)
-  : startTransition
-    ( model.state
-    , to
-    , duration - (duration * model.transition.elapsed / model.transition.duration)
-    , duration
-    )
-  )
 
 const nofx = /*::<model, action>*/
-  (model: model): [model, Effects<action>] =>
-  [model, Effects.none]
+    (model:model):[model, Effects<action>] =>[model, Effects.none]
 
-const Tick =
-  time =>
-  ( { type: "Tick"
-    , time
-    }
-  );
+const Tick = time =>( {
+  type: "Tick", time
+}
+);
 
-const End =
-  time =>
-  ( { type: "End"
-    , time
-    }
-  );
+const End = time =>( {
+  type: "End", time
+}
+);
 
 
 const startTransition = /*::<model>*/
-  ( from: model
-  , to: model
-  , elapsed: Time
-  , duration: Time
-  ): [Model<model>, Effects<Action>] =>
-  [ new Model
-    ( from
-    , new Transition
-      ( from
-      , to
-      , 0
-      , elapsed
-      , duration
-      )
-    )
-  , Effects.perform
-    (Task.requestAnimationFrame().map(Tick))
-  ]
+    (from:model, to:model, elapsed:Time, duration:Time):[Model<model>, Effects<Action>] =>[
+      new Model(from, new Transition(from, to, 0, elapsed, duration)),
+      Effects.perform(Task.requestAnimationFrame().map(Tick))
+    ]
 
 const endTransition = /*::<model>*/
-  ( model: Model<model>
-  ): [Model<model>, Effects<Action>] =>
-  [ new Model
-    ( model.state
-    , null
-    )
-  , Effects.perform
-    (Task.requestAnimationFrame().map(End))
-  ]
+    (model:Model<model>):[Model<model>, Effects<Action>] =>[
+      new Model(model.state, null), Effects.perform(Task.requestAnimationFrame().map(End))
+    ]
 
 const tickTransitionWith = /*::<model>*/
-  ( easing: Easing
-  , interpolation: Interpolation<model>
-  , model: Model<model>
-  , now/*Time*/
-  ): [Model<model>, Effects<Action>] =>
-  ( model.transition == null
-  ? nofx(model)
-  : interpolateTransitionWith
-    ( easing
-    , interpolation
-    , model.transition
-    , ( model.transition.now === 0
-      ? 0
-      : now - model.transition.now + model.transition.elapsed
-      )
-    , now
+    (easing:Easing, interpolation:Interpolation<model>, model:Model<model>, now
+     /*Time*/):[Model<model>, Effects<Action>] =>( model.transition == null ? nofx(model) : interpolateTransitionWith(
+            easing, interpolation, model.transition,
+            ( model.transition.now === 0 ? 0 : now - model.transition.now + model.transition.elapsed
+            ), now)
     )
-  )
 
 const interpolateTransitionWith = /*::<model>*/
-  ( easing: Easing
-  , interpolation: Interpolation<model>
-  , transition: Transition<model>
-  , elapsed: Time
-  , now: Time
-  ): [Model<model>, Effects<Action>] =>
-  ( elapsed >= transition.duration
-  ? [ new Model(transition.to, null)
-    , Effects.receive(End(now))
-    ]
-  : [ new Model
-      ( ease
-        ( easing
-        , interpolation
-        , transition.from
-        , transition.to
-        , transition.duration
-        , elapsed
-        )
-      , new Transition
-        ( transition.from
-        , transition.to
-        , now
-        , elapsed
-        , transition.duration
-        )
-      )
-    , Effects.perform
-      (Task.requestAnimationFrame().map(Tick))
-    ]
-  )
+    (easing:Easing, interpolation:Interpolation<model>, transition:Transition<model>, elapsed:Time,
+     now:Time):[Model<model>, Effects<Action>] =>( elapsed >= transition.duration
+            ? [
+          new Model(transition.to, null),
+          Effects.receive(End(now))
+        ]
+            : [
+          new Model(ease(easing, interpolation, transition.from, transition.to, transition.duration,
+                         elapsed), new Transition(transition.from, transition.to, now, elapsed, transition.duration)),
+          Effects.perform(Task.requestAnimationFrame().map(Tick))
+        ]
+    )
 
 export const updateWith = /*::<model>*/
-  ( easing: Easing
-  , interpolation: Interpolation<model>
-  , model: Model<model>
-  , action: Action
-  ): [Model<model>, Effects<Action>] => {
-    switch (action.type) {
-      case "Tick":
-        return tickTransitionWith(easing, interpolation, model, action.time);
-      case "End":
-        return nofx(model);
-      default:
-        return Unknown.update(model, action);
+    (easing:Easing, interpolation:Interpolation<model>, model:Model<model>,
+     action:Action):[Model<model>, Effects<Action>] => {
+      switch (action.type) {
+        case "Tick":
+          return tickTransitionWith(easing, interpolation, model, action.time);
+        case "End":
+          return nofx(model);
+        default:
+          return Unknown.update(model, action);
+      }
     }
-  }
 
 export const init = /*::<model>*/
-  ( state: model ): [Model<model>, Effects<Action>] =>
-  nofx(new Model(state, null))
+    (state:model):[Model<model>, Effects<Action>] =>nofx(new Model(state, null))

--- a/src/common/Animation.js
+++ b/src/common/Animation.js
@@ -22,11 +22,11 @@ class Transition /*::<model>*/ {
   to: model;
   */
   constructor(
-    from/*:model*/
-  , to/*:model*/
-  , now/*:Time*/
-  , elapsed/*:Time*/
-  , duration/*:Time*/
+    from: model
+  , to: model
+  , now: Time
+  , elapsed: Time
+  , duration: Time
   ) {
     this.from = from
     this.to = to
@@ -42,8 +42,8 @@ export class Model /*::<model>*/ {
   transition: ?Transition<model>;
   */
   constructor(
-    state/*:model*/
-  , transition/*:?Transition<model>*/
+    state: model
+  , transition: ?Transition<model>
   ) {
     this.state = state
     this.transition = transition
@@ -51,10 +51,10 @@ export class Model /*::<model>*/ {
 }
 
 export const transition = /*::<action, model>*/
-  ( model/*:Model<model>*/
-  , to/*:model*/
-  , duration/*:Time*/
-  )/*:[Model<model>, Effects<Action>]*/ =>
+  ( model: Model<model>
+  , to: model
+  , duration: Time
+  ): [Model<model>, Effects<Action>] =>
   ( model.transition == null
   ? startTransition
     ( model.state
@@ -73,7 +73,7 @@ export const transition = /*::<action, model>*/
   )
 
 const nofx = /*::<model, action>*/
-  (model/*:model*/)/*:[model, Effects<action>]*/ =>
+  (model: model): [model, Effects<action>] =>
   [model, Effects.none]
 
 const Tick =
@@ -92,11 +92,11 @@ const End =
 
 
 const startTransition = /*::<model>*/
-  ( from/*:model*/
-  , to/*:model*/
-  , elapsed/*:Time*/
-  , duration/*:Time*/
-  )/*:[Model<model>, Effects<Action>]*/ =>
+  ( from: model
+  , to: model
+  , elapsed: Time
+  , duration: Time
+  ): [Model<model>, Effects<Action>] =>
   [ new Model
     ( from
     , new Transition
@@ -112,8 +112,8 @@ const startTransition = /*::<model>*/
   ]
 
 const endTransition = /*::<model>*/
-  ( model/*:Model<model>*/
-  )/*:[Model<model>, Effects<Action>]*/ =>
+  ( model: Model<model>
+  ): [Model<model>, Effects<Action>] =>
   [ new Model
     ( model.state
     , null
@@ -123,11 +123,11 @@ const endTransition = /*::<model>*/
   ]
 
 const tickTransitionWith = /*::<model>*/
-  ( easing/*:Easing*/
-  , interpolation/*:Interpolation<model>*/
-  , model/*:Model<model>*/
+  ( easing: Easing
+  , interpolation: Interpolation<model>
+  , model: Model<model>
   , now/*Time*/
-  )/*:[Model<model>, Effects<Action>]*/ =>
+  ): [Model<model>, Effects<Action>] =>
   ( model.transition == null
   ? nofx(model)
   : interpolateTransitionWith
@@ -143,12 +143,12 @@ const tickTransitionWith = /*::<model>*/
   )
 
 const interpolateTransitionWith = /*::<model>*/
-  ( easing/*:Easing*/
-  , interpolation/*:Interpolation<model>*/
-  , transition/*:Transition<model>*/
-  , elapsed/*:Time*/
-  , now/*:Time*/
-  )/*:[Model<model>, Effects<Action>]*/ =>
+  ( easing: Easing
+  , interpolation: Interpolation<model>
+  , transition: Transition<model>
+  , elapsed: Time
+  , now: Time
+  ): [Model<model>, Effects<Action>] =>
   ( elapsed >= transition.duration
   ? [ new Model(transition.to, null)
     , Effects.receive(End(now))
@@ -176,11 +176,11 @@ const interpolateTransitionWith = /*::<model>*/
   )
 
 export const updateWith = /*::<model>*/
-  ( easing/*:Easing*/
-  , interpolation/*:Interpolation<model>*/
-  , model/*:Model<model>*/
-  , action/*:Action*/
-  )/*:[Model<model>, Effects<Action>]*/ => {
+  ( easing: Easing
+  , interpolation: Interpolation<model>
+  , model: Model<model>
+  , action: Action
+  ): [Model<model>, Effects<Action>] => {
     switch (action.type) {
       case "Tick":
         return tickTransitionWith(easing, interpolation, model, action.time);
@@ -192,5 +192,5 @@ export const updateWith = /*::<model>*/
   }
 
 export const init = /*::<model>*/
-  ( state/*:model*/ )/*:[Model<model>, Effects<Action>]*/ =>
+  ( state: model ): [Model<model>, Effects<Action>] =>
   nofx(new Model(state, null))

--- a/src/common/Deck.js
+++ b/src/common/Deck.js
@@ -4,69 +4,64 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Effects, Task, html, forward, thunk} from "reflex"
-import {merge} from "../common/prelude"
-import * as Unknown from "../common/unknown"
-import {indexOfOffset} from "../common/selector"
+import { Effects, Task, forward, thunk } from 'reflex'
+import { merge } from '../common/prelude'
+import * as Unknown from '../common/unknown'
+import { indexOfOffset } from '../common/selector'
 
 /*::
-import type {Address, DOM, Never} from "reflex"
-export type Integer = number
-export type ID = string
+ import type {Address, DOM, Never} from "reflex"
+ export type Integer = number
+ export type ID = string
 
-export type Dictionary <key, value> =
-  {[key:key]: value}
+ export type Dictionary <key, value> =
+ {[key:key]: value}
 
-export type Maybe <value> =
-  ?value
+ export type Maybe <value> =
+ ?value
 
-export type Flags <flags> =
-  { inBackground: boolean
-  , flags: flags
-  }
+ export type Flags <flags> =
+ { inBackground: boolean
+ , flags: flags
+ }
 
-export type Action <action, flags> =
-  | { type: "Open", open: flags }
-  | { type: "Close", id: ID }
-  | { type: "Remove", id: ID }
-  | { type: "Select", id: ID }
-  | { type: "Modify", id: ID, modify: action }
-  | { type: "SelectNext" }
-  | { type: "SelectPrevious" }
+ export type Action <action, flags> =
+ | { type: "Open", open: flags }
+ | { type: "Close", id: ID }
+ | { type: "Remove", id: ID }
+ | { type: "Select", id: ID }
+ | { type: "Modify", id: ID, modify: action }
+ | { type: "SelectNext" }
+ | { type: "SelectPrevious" }
 
-export type Transaction <action, model> =
-  [model, Effects<action>]
+ export type Transaction <action, model> =
+ [model, Effects<action>]
 
-export type Init <action, model, flags> =
-  (flags:flags) =>
-  Transaction<action, model>
+ export type Init <action, model, flags> =
+ (flags:flags) =>
+ Transaction<action, model>
 
-export type Update <action, model> =
-  (model:model, action:action) =>
-  Transaction<action, model>
+ export type Update <action, model> =
+ (model:model, action:action) =>
+ Transaction<action, model>
 
-export type Card <action, model, flags> =
-  { init: (flags:flags) => [model, Effects<action>]
-  , update: (model:model, action:action) => [model, Effects<action>]
-  , close: (model:model) => [model, Effects<action>]
-  , select: (model:model) => [model, Effects<action>]
-  , deselect: (model:model) => [model, Effects<action>]
-  }
-*/
+ export type Card <action, model, flags> =
+ { init: (flags:flags) => [model, Effects<action>]
+ , update: (model:model, action:action) => [model, Effects<action>]
+ , close: (model:model) => [model, Effects<action>]
+ , select: (model:model) => [model, Effects<action>]
+ , deselect: (model:model) => [model, Effects<action>]
+ }
+ */
 
 export class Model /*::<model>*/ {
   /*::
-  nextID: Integer;
-  index: Array<ID>;
-  cards: Dictionary<ID, model>;
-  selected: Maybe<ID>;
-  */
-  constructor(
-    nextID: Integer
-  , index: Array<ID>
-  , cards: Dictionary<ID, model>
-  , selected: Maybe<ID>
-  ) {
+   nextID: Integer;
+   index: Array<ID>;
+   cards: Dictionary<ID, model>;
+   selected: Maybe<ID>;
+   */
+  constructor(nextID:Integer, index:Array<ID>, cards:Dictionary<ID, model>, selected:Maybe<ID>) {
     this.nextID = nextID
     this.index = index
     this.cards = cards
@@ -76,317 +71,206 @@ export class Model /*::<model>*/ {
 
 
 export const init = /*::<action, model, flags>*/
-  ( nextID: Integer=0
-  , index: Array<ID>=[]
-  , cards: Dictionary<ID, model>={}
-  , selected: Maybe<ID>=null
-  ): Transaction<Action<action, flags>, Model<model>> =>
-  [ new Model(nextID, index, cards, selected)
-  , Effects.none
-  ];
+    (nextID:Integer = 0, index:Array<ID> = [], cards:Dictionary<ID, model> = {},
+     selected:Maybe<ID> = null):Transaction<Action<action, flags>, Model<model>> =>[
+      new Model(nextID, index, cards, selected), Effects.none
+    ];
 
 export const update = /*::<action, model, flags>*/
-  ( card: Card<action, model, flags>
-  , model: Model<model>
-  , action: Action<action, flags>
-  ): Transaction<Action<action, flags>, Model<model>> => {
-    switch (action.type) {
-      case "NoOp":
-        return nofx(model);
-      case "Open":
-        return open(card, model, action.open);
-      case "Close":
-        return closeByID(card, model, action.id);
-      case "Select":
-        return selectByID(card, model, action.id, true);
-      case "SelectNext":
-        return selectNext(card, model);
-      case "SelectPrevious":
-        return selectPrevious(card, model);
-      case "Remove":
-        return removeByID(card, model, action.id);
-      case "Modify":
-        return updateByID(card, model, action.id, action.modify)
-      default:
-        return Unknown.update(model, action);
+    (card:Card<action, model, flags>, model:Model<model>,
+     action:Action<action, flags>):Transaction<Action<action, flags>, Model<model>> => {
+      switch (action.type) {
+        case "NoOp":
+          return nofx(model);
+        case "Open":
+          return open(card, model, action.open);
+        case "Close":
+          return closeByID(card, model, action.id);
+        case "Select":
+          return selectByID(card, model, action.id, true);
+        case "SelectNext":
+          return selectNext(card, model);
+        case "SelectPrevious":
+          return selectPrevious(card, model);
+        case "Remove":
+          return removeByID(card, model, action.id);
+        case "Modify":
+          return updateByID(card, model, action.id, action.modify)
+        default:
+          return Unknown.update(model, action);
+      }
     }
-  }
 
 const nofx = /*::<model, action>*/
-  ( model: model ): [model, Effects<action>] =>
-  [ model
-  , Effects.none
-  ]
+    (model:model):[model, Effects<action>] =>[
+      model, Effects.none
+    ]
 
 
 const updateByID = /*::<model, action, flags>*/
-  ( api: Card<action, model, flags>
-  , model: Model<model>
-  , id: ID
-  , action: action
-  ): Transaction<Action<action, flags>, Model<model>> => {
-    if (id in model.cards) {
-      const [card, $card] = api.update(model.cards[id], action);
-      const cards = merge(model.cards, {[id]: card});
-      return [
-        new Model
-        ( model.nextID
-        , model.index
-        , cards
-        , model.selected
-        )
-      , $card.map(Tag.modify(id))
-      ]
+    (api:Card<action, model, flags>, model:Model<model>, id:ID,
+     action:action):Transaction<Action<action, flags>, Model<model>> => {
+      if (id in model.cards) {
+        const [card, $card] = api.update(model.cards[id], action);
+        const cards = merge(model.cards, { [id]: card });
+        return [
+          new Model(model.nextID, model.index, cards, model.selected), $card.map(Tag.modify(id))
+        ]
+      } else {
+        return [model, Effects.none]
+      }
     }
-    else {
-      return [model, Effects.none]
-    }
-  }
 
 export const open = /*::<action, model, flags>*/
-  ( api: Card<action, model, flags>
-  , model: Model<model>
-  , flags: flags
-  ): Transaction<Action<action, flags>, Model<model>> => {
-    const id = `${model.nextID}`;
-    const [card, $card] = api.init(flags);
+    (api:Card<action, model, flags>, model:Model<model>,
+     flags:flags):Transaction<Action<action, flags>, Model<model>> => {
+      const id = `${model.nextID}`;
+      const [card, $card] = api.init(flags);
 
-    const [model2, fx2] =
-      ( model.selected == null
-      ? nofx(model)
-      : card.isSelected
-      ? deselectByID(api, model, model.selected)
-      : nofx(model)
-      );
+      const [model2, fx2] =
+          ( model.selected == null ? nofx(model) : card.isSelected ? deselectByID(api, model, model.selected) : nofx(
+                  model)
+          );
 
 
-    const model3 = new Model
-      ( model.nextID + 1
-      , model2
-        .index
-        .slice(0, 1)
-        .concat([id])
-        .concat(model2.index.slice(1))
-      , merge(model2.cards, {[id]: card})
-      , ( card.isSelected
-        ? id
-        : model2.selected
-        )
-      );
+      const model3 = new Model(model.nextID + 1, model2
+          .index
+          .slice(0, 1)
+          .concat([id])
+          .concat(model2.index.slice(1)), merge(model2.cards, { [id]: card }), ( card.isSelected ? id : model2.selected
+      ));
 
-    const fx3 = Effects.batch
-      ( [ fx2
-        , $card.map(Tag.modify(id))
-        ]
-      )
+      const fx3 = Effects.batch([
+                                  fx2, $card.map(Tag.modify(id))
+                                ])
 
-    return [model3, fx3]
-  }
+      return [model3, fx3]
+    }
 
 const closeByID = /*::<action, model, flags>*/
-  ( api: Card<action, model, flags>
-  , model: Model<model>
-  , id: ID
-  ): Transaction<Action<action, flags>, Model<model>> => {
-    const [available, $available] =
-      ( model.selected === id
-      ? selectBeneficiaryByID(api, model, id)
-      : [ model, Effects.none ]
-      )
-
-    if (id in available.cards) {
-      const [card, $card] =
-        api.close(available.cards[id]);
-
-      const transaction =
-        [ merge
-          ( available
-          , { cards: merge
-              ( available.cards
-              , {[id]: card}
-              )
-            }
+    (api:Card<action, model, flags>, model:Model<model>, id:ID):Transaction<Action<action, flags>, Model<model>> => {
+      const [available, $available] =
+          ( model.selected === id ? selectBeneficiaryByID(api, model, id) : [model, Effects.none]
           )
-        , Effects.batch
-          ( [ $available
-            , $card.map(Tag.modify(id))
-            ]
-          )
+
+      if (id in available.cards) {
+        const [card, $card] =
+            api.close(available.cards[id]);
+
+        const transaction = [
+          merge(available, {
+            cards: merge(available.cards, { [id]: card })
+          }), Effects.batch([
+                              $available, $card.map(Tag.modify(id))
+                            ])
         ]
 
-      return transaction;
+        return transaction;
+      } else {
+        return cardNotFound(model, id);
+      }
     }
-    else {
-      return cardNotFound(model, id);
-    }
-  }
 
 export const removeByID = /*::<action, model, flags>*/
-  ( card: Card<action, model, flags>
-  , model: Model<model>
-  , id: ID
-  ): Transaction<Action<action, flags>, Model<model>> => {
-    const [available, $available] =
-      ( model.selected === id
-      ? selectBeneficiaryByID(card, model, id)
-      : [model, Effects.none]
-      )
-
-    if (id in available.cards) {
-      const transaction =
-        [ merge
-          ( available
-          , { index: available.index.filter(x => x !== id)
-            , cards: merge
-                ( available.cards
-                , {[id]: void(0)}
-                )
-            }
+    (card:Card<action, model, flags>, model:Model<model>, id:ID):Transaction<Action<action, flags>, Model<model>> => {
+      const [available, $available] =
+          ( model.selected === id ? selectBeneficiaryByID(card, model, id) : [model, Effects.none]
           )
-        , $available
+
+      if (id in available.cards) {
+        const transaction = [
+          merge(available, {
+            index: available.index.filter(x => x !== id), cards: merge(available.cards, { [id]: void(0) })
+          }), $available
         ];
 
-      return transaction
+        return transaction
+      } else {
+        return cardNotFound(model, id)
+      }
     }
-    else {
-      return cardNotFound(model, id)
-    }
-  }
 
 const cardNotFound = /*::<model, action>*/
-  ( model: model, id: ID): [model, Effects<action>] =>
-  nofx(model)
+    (model:model, id:ID):[model, Effects<action>] =>nofx(model)
 
 export const selectByID = /*::<action, model, flags>*/
-  ( api: Card<action, model, flags>
-  , model: Model<model>
-  , id: ID
-  , isSelectionChange: boolean=true
-  ): Transaction<Action<action, flags>, Model<model>> => {
-    if (id === model.selected) {
-      return nofx(model)
-    }
-    else if (id in model.cards) {
-      const [deselected, $deselected] =
-        ( ( isSelectionChange && model.selected != null )
-        ? deselectByID(api, model, model.selected)
-        : nofx(model)
-        )
+    (api:Card<action, model, flags>, model:Model<model>, id:ID,
+     isSelectionChange:boolean = true):Transaction<Action<action, flags>, Model<model>> => {
+      if (id === model.selected) {
+        return nofx(model)
+      } else if (id in model.cards) {
+        const [deselected, $deselected] =
+            ( ( isSelectionChange && model.selected != null ) ? deselectByID(api, model, model.selected) : nofx(model)
+            )
 
-      const [card, $card] = api.select(model.cards[id]);
+        const [card, $card] = api.select(model.cards[id]);
 
-      const transaction =
-        [ merge
-          ( deselected
-          , { selected: id
-            , cards: merge
-              ( deselected.cards
-              , { [id]: card }
-              )
-            }
-          )
-        , Effects.batch
-          ( [ $deselected
-            , $card.map(Tag.modify(id))
-            ]
-          )
+        const transaction = [
+          merge(deselected, {
+            selected: id, cards: merge(deselected.cards, { [id]: card })
+          }), Effects.batch([
+                              $deselected, $card.map(Tag.modify(id))
+                            ])
         ]
 
-      return transaction
+        return transaction
+      } else {
+        return cardNotFound(model, id)
+      }
     }
-    else {
-      return cardNotFound(model, id)
-    }
-  }
 
 export const deselectByID = /*::<action, model, flags>*/
-  ( api: Card<action, model, flags>
-  , model: Model<model>
-  , id: ID
-  ): Transaction<Action<action, flags>, Model<model>> => {
-    if (model.selected !== id) {
-      return nofx(model)
-    }
-    else if (id in model.cards) {
-      const [card, $card] =
-        api.deselect(model.cards[id]);
+    (api:Card<action, model, flags>, model:Model<model>, id:ID):Transaction<Action<action, flags>, Model<model>> => {
+      if (model.selected !== id) {
+        return nofx(model)
+      } else if (id in model.cards) {
+        const [card, $card] =
+            api.deselect(model.cards[id]);
 
-      const transaction =
-        [ merge
-          ( model
-          , { selected: null
-            , cards: merge
-              ( model.cards
-              , { [id]: card }
-              )
-            }
-          )
-        , $card.map(Tag.modify(id))
+        const transaction = [
+          merge(model, {
+            selected: null, cards: merge(model.cards, { [id]: card })
+          }), $card.map(Tag.modify(id))
         ]
 
-      return transaction
+        return transaction
+      } else {
+        return cardNotFound(model, id)
+      }
     }
-    else {
-      return cardNotFound(model, id)
-    }
-  }
 
 const selectBeneficiaryByID = /*::<action, model, flags>*/
-  ( api: Card<action, model, flags>
-  , model: Model<model>
-  , id: ID
-  ): Transaction<Action<action, flags>, Model<model>> => {
-    const selected = beneficiaryOf(id, model.index);
-    if (selected != null) {
-      return selectByID(api, model, selected, false)
+    (api:Card<action, model, flags>, model:Model<model>, id:ID):Transaction<Action<action, flags>, Model<model>> => {
+      const selected = beneficiaryOf(id, model.index);
+      if (selected != null) {
+        return selectByID(api, model, selected, false)
+      } else {
+        return nofx(model)
+      }
     }
-    else {
-      return nofx(model)
-    }
-  }
 
 export const selectByOffset = /*::<action, model, flags>*/
-  ( api: Card<action, model, flags>
-  , model: Model<model>
-  , offset: Integer
-  ): Transaction<Action<action, flags>, Model<model>> =>
-  ( model.index.length === 0
-  ? nofx(model)
-  : model.selected == null
-  ? [ model
-    , Effects.perform
-      ( warn(Error(`Unable to change selected WebView if no WebView is seleted`))
-      )
-    ]
-  : selectByID
-    ( api
-    , model
-    , relativeOf(offset, model.selected, model.index)
-    )
-  );
+    (api:Card<action, model, flags>, model:Model<model>,
+     offset:Integer):Transaction<Action<action, flags>, Model<model>> =>( model.index.length === 0
+            ? nofx(model)
+            : model.selected == null
+            ? [
+          model,
+          Effects.perform(warn(Error(`Unable to change selected WebView if no WebView is seleted`)))
+        ]
+            : selectByID(api, model, relativeOf(offset, model.selected, model.index))
+    );
 
-export const selectNext =/*::<action, model, flags>*/
-  ( api: Card<action, model, flags>
-  , model: Model<model>
-  ): Transaction<Action<action, flags>, Model<model>> =>
-  selectByOffset(api, model, 1)
+export const selectNext = /*::<action, model, flags>*/
+    (api:Card<action, model, flags>,
+     model:Model<model>):Transaction<Action<action, flags>, Model<model>> =>selectByOffset(api, model, 1)
 
 export const selectPrevious = /*::<action, model, flags>*/
-  ( api: Card<action, model, flags>
-  , model: Model<model>
-  ): Transaction<Action<action, flags>, Model<model>> =>
-  selectByOffset(api, model, -1)
+    (api:Card<action, model, flags>,
+     model:Model<model>):Transaction<Action<action, flags>, Model<model>> =>selectByOffset(api, model, -1)
 
-const relativeOf =
-  (offset, id, index) =>
-  index
-  [ indexOfOffset
-    ( index.indexOf(id)
-    , offset
-    , index.length
-    , true
-    )
-  ]
+const relativeOf = (offset, id, index) =>index
+    [indexOfOffset(index.indexOf(id), offset, index.length, true)]
 
 // Function is used to decide which tab should get a selection if currently
 // selected tab is to be closed. The given `id` represents currently selected
@@ -402,57 +286,40 @@ const relativeOf =
 //   array (should not happen but, if somehow it does we just select first tab).
 // - The second element, if the given `id` is the first item in the `array`.
 // - Is the tab `id` preceding the given `id` otherwise.
-const beneficiaryOf =
-  (id, array) => {
-    const count = array.length;
-    if (count === 0) {
-      return undefined;
-    }
-
-    const from = array.indexOf(id);
-    if (from === -1) {
-      return array[0];
-    }
-    if (count === 1) {
-      return undefined;
-    }
-    if (from === 0) {
-      return array[1];
-    }
-    return array[from - 1];
+const beneficiaryOf = (id, array) => {
+  const count = array.length;
+  if (count === 0) {
+    return undefined;
   }
+
+  const from = array.indexOf(id);
+  if (from === -1) {
+    return array[0];
+  }
+  if (count === 1) {
+    return undefined;
+  }
+  if (from === 0) {
+    return array[1];
+  }
+  return array[from - 1];
+}
 
 const Tag = {
   modify: /*::<action, flags>*/
-    ( id: ID )/*:(action:action) => Action<action, flags>*/ =>
-    ( action ) =>
-    ( { type: "Modify"
-      , id
-      , modify: action
+      (id:ID)/*:(action:action) => Action<action, flags>*/ =>(action) =>( {
+        type: "Modify", id, modify: action
       }
-    )
+      )
 }
 
 export const renderCards = /*::<action, model, flags>*/
-  ( renderCard/*:(model:model, address:Address<action>) => DOM*/
-  , model: Model<model>
-  , address: Address<Action<action, flags>>
-  ): Array<DOM> =>
-  model
-  .index
-  .map
-  ( id =>
-    thunk
-    ( `${id}`
-    , renderCard
-    , model.cards[id]
-    , forward(address, Tag.modify(id))
-    )
-  )
+    (renderCard/*:(model:model, address:Address<action>) => DOM*/, model:Model<model>,
+     address:Address<Action<action, flags>>):Array<DOM> =>model
+        .index
+        .map(id =>thunk(`${id}`, renderCard, model.cards[id], forward(address, Tag.modify(id))))
 
 const warn = /*::<message>*/
-  (message: message): Task<Never, any> =>
-  new Task
-  ((succeed, fail) => {
-    console.warn(message)
-  })
+    (message:message):Task<Never, any> =>new Task((succeed, fail) => {
+      console.warn(message)
+    })

--- a/src/common/Deck.js
+++ b/src/common/Deck.js
@@ -62,10 +62,10 @@ export class Model /*::<model>*/ {
   selected: Maybe<ID>;
   */
   constructor(
-    nextID/*:Integer*/
-  , index/*:Array<ID>*/
-  , cards/*:Dictionary<ID, model>*/
-  , selected/*:Maybe<ID>*/
+    nextID: Integer
+  , index: Array<ID>
+  , cards: Dictionary<ID, model>
+  , selected: Maybe<ID>
   ) {
     this.nextID = nextID
     this.index = index
@@ -76,20 +76,20 @@ export class Model /*::<model>*/ {
 
 
 export const init = /*::<action, model, flags>*/
-  ( nextID/*:Integer*/=0
-  , index/*:Array<ID>*/=[]
-  , cards/*:Dictionary<ID, model>*/={}
-  , selected/*:Maybe<ID>*/=null
-  )/*:Transaction<Action<action, flags>, Model<model>>*/ =>
+  ( nextID: Integer=0
+  , index: Array<ID>=[]
+  , cards: Dictionary<ID, model>={}
+  , selected: Maybe<ID>=null
+  ): Transaction<Action<action, flags>, Model<model>> =>
   [ new Model(nextID, index, cards, selected)
   , Effects.none
   ];
 
 export const update = /*::<action, model, flags>*/
-  ( card/*:Card<action, model, flags>*/
-  , model/*:Model<model>*/
-  , action/*:Action<action, flags>*/
-  )/*:Transaction<Action<action, flags>, Model<model>>*/ => {
+  ( card: Card<action, model, flags>
+  , model: Model<model>
+  , action: Action<action, flags>
+  ): Transaction<Action<action, flags>, Model<model>> => {
     switch (action.type) {
       case "NoOp":
         return nofx(model);
@@ -113,18 +113,18 @@ export const update = /*::<action, model, flags>*/
   }
 
 const nofx = /*::<model, action>*/
-  ( model/*:model*/ )/*:[model, Effects<action>]*/ =>
+  ( model: model ): [model, Effects<action>] =>
   [ model
   , Effects.none
   ]
 
 
 const updateByID = /*::<model, action, flags>*/
-  ( api/*:Card<action, model, flags>*/
-  , model/*:Model<model>*/
-  , id/*:ID*/
-  , action/*:action*/
-  )/*:Transaction<Action<action, flags>, Model<model>>*/ => {
+  ( api: Card<action, model, flags>
+  , model: Model<model>
+  , id: ID
+  , action: action
+  ): Transaction<Action<action, flags>, Model<model>> => {
     if (id in model.cards) {
       const [card, $card] = api.update(model.cards[id], action);
       const cards = merge(model.cards, {[id]: card});
@@ -144,10 +144,10 @@ const updateByID = /*::<model, action, flags>*/
   }
 
 export const open = /*::<action, model, flags>*/
-  ( api/*:Card<action, model, flags>*/
-  , model/*:Model<model>*/
-  , flags/*:flags*/
-  )/*:Transaction<Action<action, flags>, Model<model>>*/ => {
+  ( api: Card<action, model, flags>
+  , model: Model<model>
+  , flags: flags
+  ): Transaction<Action<action, flags>, Model<model>> => {
     const id = `${model.nextID}`;
     const [card, $card] = api.init(flags);
 
@@ -184,10 +184,10 @@ export const open = /*::<action, model, flags>*/
   }
 
 const closeByID = /*::<action, model, flags>*/
-  ( api/*:Card<action, model, flags>*/
-  , model/*:Model<model>*/
-  , id/*:ID*/
-  )/*:Transaction<Action<action, flags>, Model<model>>*/ => {
+  ( api: Card<action, model, flags>
+  , model: Model<model>
+  , id: ID
+  ): Transaction<Action<action, flags>, Model<model>> => {
     const [available, $available] =
       ( model.selected === id
       ? selectBeneficiaryByID(api, model, id)
@@ -222,10 +222,10 @@ const closeByID = /*::<action, model, flags>*/
   }
 
 export const removeByID = /*::<action, model, flags>*/
-  ( card/*:Card<action, model, flags>*/
-  , model/*:Model<model>*/
-  , id/*:ID*/
-  )/*:Transaction<Action<action, flags>, Model<model>>*/ => {
+  ( card: Card<action, model, flags>
+  , model: Model<model>
+  , id: ID
+  ): Transaction<Action<action, flags>, Model<model>> => {
     const [available, $available] =
       ( model.selected === id
       ? selectBeneficiaryByID(card, model, id)
@@ -254,15 +254,15 @@ export const removeByID = /*::<action, model, flags>*/
   }
 
 const cardNotFound = /*::<model, action>*/
-  ( model/*:model*/, id/*:ID*/)/*:[model, Effects<action>]*/ =>
+  ( model: model, id: ID): [model, Effects<action>] =>
   nofx(model)
 
 export const selectByID = /*::<action, model, flags>*/
-  ( api/*:Card<action, model, flags>*/
-  , model/*:Model<model>*/
-  , id/*:ID*/
-  , isSelectionChange/*:boolean*/=true
-  )/*:Transaction<Action<action, flags>, Model<model>>*/ => {
+  ( api: Card<action, model, flags>
+  , model: Model<model>
+  , id: ID
+  , isSelectionChange: boolean=true
+  ): Transaction<Action<action, flags>, Model<model>> => {
     if (id === model.selected) {
       return nofx(model)
     }
@@ -300,10 +300,10 @@ export const selectByID = /*::<action, model, flags>*/
   }
 
 export const deselectByID = /*::<action, model, flags>*/
-  ( api/*:Card<action, model, flags>*/
-  , model/*:Model<model>*/
-  , id/*:ID*/
-  )/*:Transaction<Action<action, flags>, Model<model>>*/ => {
+  ( api: Card<action, model, flags>
+  , model: Model<model>
+  , id: ID
+  ): Transaction<Action<action, flags>, Model<model>> => {
     if (model.selected !== id) {
       return nofx(model)
     }
@@ -332,10 +332,10 @@ export const deselectByID = /*::<action, model, flags>*/
   }
 
 const selectBeneficiaryByID = /*::<action, model, flags>*/
-  ( api/*:Card<action, model, flags>*/
-  , model/*:Model<model>*/
-  , id/*:ID*/
-  )/*:Transaction<Action<action, flags>, Model<model>>*/ => {
+  ( api: Card<action, model, flags>
+  , model: Model<model>
+  , id: ID
+  ): Transaction<Action<action, flags>, Model<model>> => {
     const selected = beneficiaryOf(id, model.index);
     if (selected != null) {
       return selectByID(api, model, selected, false)
@@ -346,10 +346,10 @@ const selectBeneficiaryByID = /*::<action, model, flags>*/
   }
 
 export const selectByOffset = /*::<action, model, flags>*/
-  ( api/*:Card<action, model, flags>*/
-  , model/*:Model<model>*/
-  , offset/*:Integer*/
-  )/*:Transaction<Action<action, flags>, Model<model>>*/ =>
+  ( api: Card<action, model, flags>
+  , model: Model<model>
+  , offset: Integer
+  ): Transaction<Action<action, flags>, Model<model>> =>
   ( model.index.length === 0
   ? nofx(model)
   : model.selected == null
@@ -366,15 +366,15 @@ export const selectByOffset = /*::<action, model, flags>*/
   );
 
 export const selectNext =/*::<action, model, flags>*/
-  ( api/*:Card<action, model, flags>*/
-  , model/*:Model<model>*/
-  )/*:Transaction<Action<action, flags>, Model<model>>*/ =>
+  ( api: Card<action, model, flags>
+  , model: Model<model>
+  ): Transaction<Action<action, flags>, Model<model>> =>
   selectByOffset(api, model, 1)
 
 export const selectPrevious = /*::<action, model, flags>*/
-  ( api/*:Card<action, model, flags>*/
-  , model/*:Model<model>*/
-  )/*:Transaction<Action<action, flags>, Model<model>>*/ =>
+  ( api: Card<action, model, flags>
+  , model: Model<model>
+  ): Transaction<Action<action, flags>, Model<model>> =>
   selectByOffset(api, model, -1)
 
 const relativeOf =
@@ -424,7 +424,7 @@ const beneficiaryOf =
 
 const Tag = {
   modify: /*::<action, flags>*/
-    ( id/*:ID*/ )/*:(action:action) => Action<action, flags>*/ =>
+    ( id: ID )/*:(action:action) => Action<action, flags>*/ =>
     ( action ) =>
     ( { type: "Modify"
       , id
@@ -435,9 +435,9 @@ const Tag = {
 
 export const renderCards = /*::<action, model, flags>*/
   ( renderCard/*:(model:model, address:Address<action>) => DOM*/
-  , model/*:Model<model>*/
-  , address/*:Address<Action<action, flags>>*/
-  )/*:Array<DOM>*/ =>
+  , model: Model<model>
+  , address: Address<Action<action, flags>>
+  ): Array<DOM> =>
   model
   .index
   .map
@@ -451,7 +451,7 @@ export const renderCards = /*::<action, model, flags>*/
   )
 
 const warn = /*::<message>*/
-  (message/*:message*/)/*:Task<Never, any>*/ =>
+  (message: message): Task<Never, any> =>
   new Task
   ((succeed, fail) => {
     console.warn(message)

--- a/src/common/button.js
+++ b/src/common/button.js
@@ -73,12 +73,12 @@ const updateControl = cursor
   );
 
 export const init =
-  ( isDisabled/*:boolean*/
-  , isFocused/*:boolean*/
-  , isActive/*:boolean*/
-  , isPointerOver/*:boolean*/
-  , text/*:string*/=''
-  )/*:[Model, Effects<Action>]*/ =>
+  ( isDisabled: boolean
+  , isFocused: boolean
+  , isActive: boolean
+  , isPointerOver: boolean
+  , text: string=''
+  ): [Model, Effects<Action>] =>
   [ ({isDisabled: false
     , isFocused: false
     , isActive: false
@@ -89,7 +89,7 @@ export const init =
   ]
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model: Model, action: Action): [Model, Effects<Action>] =>
   ( action.type === "Down"
   ? [merge(model, {isActive: true}), Effects.none]
   : action.type === "Up"
@@ -107,11 +107,11 @@ export const update =
 
 
 export const view =
-  (key/*:string*/, styleSheet/*:StyleSheet*/)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>
-  ( model/*:Model*/
-  , address/*:Address<Action>*/
+  (key: string, styleSheet: StyleSheet)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>
+  ( model: Model
+  , address: Address<Action>
   , contextStyle/*?:ContextStyle*/
-  )/*:DOM*/ =>
+  ): DOM =>
   html.button({
     key: key,
     className: key,

--- a/src/common/button.js
+++ b/src/common/button.js
@@ -5,40 +5,34 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {merge, always, tag} from "../common/prelude"
-import {cursor} from "../common/cursor"
-import * as Unknown from "../common/unknown"
-import * as Target from "../common/target"
-import * as Focusable from "../common/focusable"
-import * as Control from "../common/control"
-import {Style} from "../common/style"
-import {html, Effects, forward} from "reflex"
+import { merge, always } from '../common/prelude'
+import { cursor } from '../common/cursor'
+import * as Unknown from '../common/unknown'
+import * as Target from '../common/target'
+import * as Focusable from '../common/focusable'
+import * as Control from '../common/control'
+import { Style } from '../common/style'
+import { html, Effects, forward } from 'reflex'
 
 /*::
-import type {Model, Action, StyleSheet, ContextStyle} from "./button"
-import type {Address, DOM} from "reflex"
-*/
+ import type {Model, Action, StyleSheet, ContextStyle} from "./button"
+ import type {Address, DOM} from "reflex"
+ */
 
-const TargetAction =
-  action =>
-  ( { type: "Target"
-    , source: action
-    }
-  );
+const TargetAction = action =>( {
+  type: "Target", source: action
+}
+);
 
-const FocusableAction =
-  action =>
-  ( { type: "Focusable"
-    , source: action
-    }
-  );
+const FocusableAction = action =>( {
+  type: "Focusable", source: action
+}
+);
 
-const ControlAction =
-  action =>
-  ( { type: "Control"
-    , source: action
-    }
-  );
+const ControlAction = action =>( {
+  type: "Control", source: action
+}
+);
 
 export const Down = { type: "Down" };
 export const Press = { type: "Press" };
@@ -54,96 +48,77 @@ export const Blur = FocusableAction(Focusable.Blur);
 export const Over = TargetAction(Target.Over);
 export const Out = TargetAction(Target.Out);
 
-const updateFocusable = cursor
-  ( { tag: FocusableAction
-    , update: Focusable.update
-    }
-  );
+const updateFocusable = cursor({
+                                 tag: FocusableAction, update: Focusable.update
+                               });
 
-const updateTarget = cursor
-  ( { tag: TargetAction
-    , update: Target.update
-    }
-  );
+const updateTarget = cursor({
+                              tag: TargetAction, update: Target.update
+                            });
 
-const updateControl = cursor
-  ( { tag: ControlAction
-    , update: Control.update
-    }
-  );
+const updateControl = cursor({
+                               tag: ControlAction, update: Control.update
+                             });
 
-export const init =
-  ( isDisabled: boolean
-  , isFocused: boolean
-  , isActive: boolean
-  , isPointerOver: boolean
-  , text: string=''
-  ): [Model, Effects<Action>] =>
-  [ ({isDisabled: false
-    , isFocused: false
-    , isActive: false
-    , isPointerOver: false
-    , text
-    })
-  , Effects.none
-  ]
+export const init = (isDisabled:boolean, isFocused:boolean, isActive:boolean, isPointerOver:boolean,
+                     text:string = ''):[Model, Effects<Action>] =>[
+  ({
+    isDisabled: false, isFocused: false, isActive: false, isPointerOver: false, text
+  }), Effects.none
+]
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] =>
-  ( action.type === "Down"
-  ? [merge(model, {isActive: true}), Effects.none]
-  : action.type === "Up"
-  ? [merge(model, {isActive: false}), Effects.none]
-  : action.type === "Press"
-  ? [model, Effects.none]
-  : action.type === "Control"
-  ? updateControl(model, action.source)
-  : action.type === "Target"
-  ? updateTarget(model, action.source)
-  : action.type === "Focusable"
-  ? updateFocusable(model, action.source)
-  : Unknown.update(model, action)
-  );
+export const update = (model:Model, action:Action):[Model, Effects<Action>] =>( action.type === "Down"
+        ? [
+      merge(model, { isActive: true }),
+      Effects.none
+    ]
+        : action.type === "Up"
+        ? [
+      merge(model, { isActive: false }),
+      Effects.none
+    ]
+        : action.type === "Press"
+        ? [
+      model,
+      Effects.none
+    ]
+        : action.type === "Control"
+        ? updateControl(model, action.source)
+        : action.type === "Target"
+        ? updateTarget(model, action.source)
+        : action.type === "Focusable"
+        ? updateFocusable(model, action.source)
+        : Unknown.update(model, action)
+);
 
 
-export const view =
-  (key: string, styleSheet: StyleSheet)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>
-  ( model: Model
-  , address: Address<Action>
-  , contextStyle/*?:ContextStyle*/
-  ): DOM =>
-  html.button({
-    key: key,
-    className: key,
-    style: Style
-      (  styleSheet.base
+export const view = (key:string,
+                     styleSheet:StyleSheet)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>(model:Model,
+                                                                                                                             address:Address<Action>,
+                                                                                                                             contextStyle
+                                                                                                                             /*?:ContextStyle*/):DOM =>html.button(
+    {
+      key: key,
+      className: key,
+      style: Style(styleSheet.base
 
-      ,   model.isFocused
-        ? styleSheet.focused
-        : styleSheet.blured
+          , model.isFocused ? styleSheet.focused : styleSheet.blured
 
-      ,   model.isDisabled
-        ? styleSheet.disabled
-        : styleSheet.enabled
+          , model.isDisabled ? styleSheet.disabled : styleSheet.enabled
 
-      ,  model.isPointerOver
-        ? styleSheet.over
-        : styleSheet.out
+          , model.isPointerOver ? styleSheet.over : styleSheet.out
 
-      ,  model.isActive
-        ? styleSheet.active
-        : styleSheet.inactive
+          , model.isActive ? styleSheet.active : styleSheet.inactive
 
-      , contextStyle
-      ),
+          , contextStyle),
 
-    onFocus: forward(address, always(Focus)),
-    onBlur: forward(address, always(Blur)),
+      onFocus: forward(address, always(Focus)),
+      onBlur: forward(address, always(Blur)),
 
-    onMouseOver: forward(address, always(Over)),
-    onMouseOut: forward(address, always(Out)),
+      onMouseOver: forward(address, always(Over)),
+      onMouseOut: forward(address, always(Out)),
 
-    onMouseDown: forward(address, always(Down)),
-    onClick: forward(address, always(Press)),
-    onMouseUp: forward(address, always(Up))
-  }, [model.text || '']);
+      onMouseDown: forward(address, always(Down)),
+      onClick: forward(address, always(Press)),
+      onMouseUp: forward(address, always(Up))
+    }, [model.text || '']);

--- a/src/common/control.js
+++ b/src/common/control.js
@@ -17,28 +17,28 @@ import {html, Effects, forward} from "reflex"
 import type {Model, Action} from "./control"
 */
 
-export const Disable/*:Action*/ =
+export const Disable: Action =
   { type: "Disable"
   };
 
-export const Enable/*:Action*/ =
+export const Enable: Action =
   { type: "Enable"
   };
 
 const enable = /*::<model:Model>*/
-  (model/*:model*/)/*:[model, Effects<Action>]*/ =>
+  (model: model): [model, Effects<Action>] =>
   [ merge(model, {isDisabled: false})
   , Effects.none
   ];
 
 const disable = /*::<model:Model>*/
-  (model/*:model*/)/*:[model, Effects<Action>]*/ =>
+  (model: model): [model, Effects<Action>] =>
   [ merge(model, {isDisabled: true})
   , Effects.none
   ];
 
 export const update = /*::<model:Model>*/
-  (model/*:model*/, action/*:Action*/)/*:[model, Effects<Action>]*/ =>
+  (model: model, action: Action): [model, Effects<Action>] =>
   ( action.type === "Enable"
   ? enable(model)
   : action.type === "Disable"

--- a/src/common/control.js
+++ b/src/common/control.js
@@ -5,43 +5,36 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {merge, always} from "../common/prelude"
-import {cursor} from "../common/cursor"
-import * as Unknown from "../common/unknown"
-import * as Target from "../common/target"
-import * as Focusable from "../common/focusable"
-import {Style} from "../common/style"
-import {html, Effects, forward} from "reflex"
+import { merge } from '../common/prelude'
+import * as Unknown from '../common/unknown'
+import { Effects } from 'reflex'
 
 /*::
-import type {Model, Action} from "./control"
-*/
+ import type {Model, Action} from "./control"
+ */
 
-export const Disable: Action =
-  { type: "Disable"
-  };
+export const Disable:Action = {
+  type: "Disable"
+};
 
-export const Enable: Action =
-  { type: "Enable"
-  };
+export const Enable:Action = {
+  type: "Enable"
+};
 
 const enable = /*::<model:Model>*/
-  (model: model): [model, Effects<Action>] =>
-  [ merge(model, {isDisabled: false})
-  , Effects.none
-  ];
+    (model:model):[model, Effects<Action>] =>[
+      merge(model, { isDisabled: false }), Effects.none
+    ];
 
 const disable = /*::<model:Model>*/
-  (model: model): [model, Effects<Action>] =>
-  [ merge(model, {isDisabled: true})
-  , Effects.none
-  ];
+    (model:model):[model, Effects<Action>] =>[
+      merge(model, { isDisabled: true }), Effects.none
+    ];
 
 export const update = /*::<model:Model>*/
-  (model: model, action: Action): [model, Effects<Action>] =>
-  ( action.type === "Enable"
-  ? enable(model)
-  : action.type === "Disable"
-  ? disable(model)
-  : Unknown.update(model, action)
-  );
+    (model:model, action:Action):[model, Effects<Action>] =>( action.type === "Enable"
+            ? enable(model)
+            : action.type === "Disable"
+            ? disable(model)
+            : Unknown.update(model, action)
+    );

--- a/src/common/cursor.js
+++ b/src/common/cursor.js
@@ -12,8 +12,7 @@ import type {Cursor} from "./cursor"
 export type {Cursor}
 */
 
-export const cursor = /*::<from, to, in, out>*/
-  (config/*:Cursor*/)/*:(model:from, action:in) => [from, Effects<out>]*/ => {
+export function cursor<from, to, input, output>(config: Cursor):(model:from, action:input) => [from, Effects<output>] {
   const get = config.get;
   const set = config.set;
   const update = config.update;

--- a/src/common/cursor.js
+++ b/src/common/cursor.js
@@ -5,30 +5,24 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {Effects} from "reflex";
+import { Effects } from 'reflex'
 
 /*::
-import type {Cursor} from "./cursor"
-export type {Cursor}
-*/
+ import type {Cursor} from "./cursor"
+ export type {Cursor}
+ */
 
-export function cursor<from, to, input, output>(config: Cursor):(model:from, action:input) => [from, Effects<output>] {
+export function cursor<from, to, input, output>(config:Cursor):(model:from, action:input) => [from, Effects<output>] {
   const get = config.get;
   const set = config.set;
   const update = config.update;
   const tag = config.tag;
 
   return (model, action) => {
-    const previous
-      = get == null
-      ? model
-      : get(model, action);
+    const previous = get == null ? model : get(model, action);
 
     const [next, fx] = update(previous, action);
-    const state
-      = set == null
-      ? next
-      : set(model, next);
+    const state = set == null ? next : set(model, next);
 
     return [state, tag == null ? fx : fx.map(tag)]
   }

--- a/src/common/devtools.js
+++ b/src/common/devtools.js
@@ -6,285 +6,240 @@
 
 
 /*::
-import type {Address, DOM} from "reflex"
-import type {Model, Action} from './devtools'
-import type {Result} from "./result"
-*/
+ import type {Address, DOM} from "reflex"
+ import type {Model, Action} from './devtools'
+ import type {Result} from "./result"
+ */
 
-import * as Settings from '../common/settings';
-import * as Runtime from '../common/runtime';
-import * as Unknown from '../common/unknown';
-import {merge, always} from '../common/prelude';
-import {cursor} from '../common/cursor';
-import {Effects, html, thunk, forward} from 'reflex';
-import {Style, StyleSheet} from '../common/style';
-
-
-const descriptions =
-  { 'debugger.remote-mode': 'Enable Remote DevTools'
-  , 'apz.overscroll.enabled': 'Enable overscroll effect'
-  , 'debug.fps.enabled': 'FPS'
-  , 'debug.paint-flashing.enabled': 'Paint flashing'
-  , 'layers.low-precision': 'Low precision buffer & paint'
-  , 'layers.low-opacity': 'Low precision opacity'
-  , 'layers.draw-borders': 'Draw layer borders'
-  , 'layers.draw-tile-borders': 'Draw tile borders'
-  , 'layers.dump': 'Layers dump'
-  , 'layers.enable-tiles': 'Enable tiles'
-  , 'layers.async-pan-zoom.enabled': 'Enable APZC (restart required)'
-  };
-
-const writeValue = (key, value) =>
-  ( key === 'debugger.remote-mode'
-  ? ( value === true
-    ? 'adb-devtools'
-    : 'disabled'
-    )
-  : value
-  );
-
-const readValue = (key, value) =>
-  ( key === 'debugger.remote-mode'
-  ? ( value === 'adb-devtools'
-    ? true
-    : false
-    )
-  : value
-  );
-
-export const Toggle: Action =
-  { type: "Toggle"
-  };
-
-export const Restart: Action =
-  { type: "Restart"
-  };
-
-const Report = result =>
-  ( { type: "Report"
-    , result: result
-    }
-  );
-
-export const CleanRestart: Action =
-  { type: "CleanRestart"
-  };
-
-export const CleanReload: Action =
-  { type: "CleanReload"
-  };
-
-const Change = (name, value) =>
-  ( { type: "Change"
-    , name
-    , value
-    }
-  );
-
-const NoOP = () =>
-  ( { type: "NoOp"
-    }
-  );
-
-const SettingsAction = action =>
-  ( { type: 'Settings'
-    , action
-    }
-  );
-
-const updateSettings = cursor
-  ( { get: model => model.settings
-    , set: (model, settings) => merge(model, {settings})
-    , tag: SettingsAction
-    , update: Settings.update
-    }
-  );
-
-const toggle = model =>
-  [ merge(model, {isActive: !model.isActive})
-  , Effects.none
-  ];
-
-const restart = model =>
-  [ model
-  , Effects
-    .perform(Runtime.restart)
-    .map(Report)
-  ];
-
-const cleanRestart = model =>
-  [ model
-  , Effects
-    .perform(Runtime.cleanRestart)
-    .map(Report)
-  ];
-
-const cleanReload = model =>
-  [ model
-  , Effects
-    .perform(Runtime.cleanReload)
-    .map(Report)
-  ];
-
-const changeSetting = (model, {name, value}) =>
-  [ model
-  , Effects
-    .perform(Settings.change({[name]: value}))
-    .map(Settings.Changed)
-    .map(SettingsAction)
-  ];
+import * as Settings from '../common/settings'
+import * as Runtime from '../common/runtime'
+import * as Unknown from '../common/unknown'
+import { merge, always } from '../common/prelude'
+import { cursor } from '../common/cursor'
+import { Effects, html, thunk, forward } from 'reflex'
+import { Style, StyleSheet } from '../common/style'
 
 
-const report =
-  (model: Model, result: Result<any, any>): [Model, Effects<Action>] =>
-  [ model
-  , ( result.isOk
-    ? Effects.none
-    : Effects
-      .perform(Unknown.error(result.error))
-      .map(NoOP)
-    )
-  ];
+const descriptions = {
+  'debugger.remote-mode': 'Enable Remote DevTools',
+  'apz.overscroll.enabled': 'Enable overscroll effect',
+  'debug.fps.enabled': 'FPS',
+  'debug.paint-flashing.enabled': 'Paint flashing',
+  'layers.low-precision': 'Low precision buffer & paint',
+  'layers.low-opacity': 'Low precision opacity',
+  'layers.draw-borders': 'Draw layer borders',
+  'layers.draw-tile-borders': 'Draw tile borders',
+  'layers.dump': 'Layers dump',
+  'layers.enable-tiles': 'Enable tiles',
+  'layers.async-pan-zoom.enabled': 'Enable APZC (restart required)'
+};
+
+const writeValue = (key, value) =>( key === 'debugger.remote-mode' ? ( value === true ? 'adb-devtools' : 'disabled'
+    ) : value
+);
+
+const readValue = (key, value) =>( key === 'debugger.remote-mode' ? ( value === 'adb-devtools' ? true : false
+    ) : value
+);
+
+export const Toggle:Action = {
+  type: "Toggle"
+};
+
+export const Restart:Action = {
+  type: "Restart"
+};
+
+const Report = result =>( {
+  type: "Report", result: result
+}
+);
+
+export const CleanRestart:Action = {
+  type: "CleanRestart"
+};
+
+export const CleanReload:Action = {
+  type: "CleanReload"
+};
+
+const Change = (name, value) =>( {
+  type: "Change", name, value
+}
+);
+
+const NoOP = () =>( {
+  type: "NoOp"
+}
+);
+
+const SettingsAction = action =>( {
+  type: 'Settings', action
+}
+);
+
+const updateSettings = cursor({
+                                get: model => model.settings,
+                                set: (model, settings) => merge(model, { settings }),
+                                tag: SettingsAction,
+                                update: Settings.update
+                              });
+
+const toggle = model =>[
+  merge(model, { isActive: !model.isActive }), Effects.none
+];
+
+const restart = model =>[
+  model, Effects
+      .perform(Runtime.restart)
+      .map(Report)
+];
+
+const cleanRestart = model =>[
+  model, Effects
+      .perform(Runtime.cleanRestart)
+      .map(Report)
+];
+
+const cleanReload = model =>[
+  model, Effects
+      .perform(Runtime.cleanReload)
+      .map(Report)
+];
+
+const changeSetting = (model, { name, value }) =>[
+  model, Effects
+      .perform(Settings.change({ [name]: value }))
+      .map(Settings.Changed)
+      .map(SettingsAction)
+];
 
 
-export const init =
-  ({isActive}/*:{isActive:boolean}*/): [Model, Effects<Action>] => {
+const report = (model:Model, result:Result<any, any>):[Model, Effects<Action>] =>[
+  model, ( result.isOk ? Effects.none : Effects
+          .perform(Unknown.error(result.error))
+          .map(NoOP)
+  )
+];
+
+
+export const init = ({ isActive }/*:{isActive:boolean}*/):[Model, Effects<Action>] => {
   const [settings, fx] =
-    Settings.init(Object.keys(descriptions));
+      Settings.init(Object.keys(descriptions));
 
-  const result =
-    [ { isActive
-      , settings
-      }
-    , fx.map(SettingsAction)
-    ];
+  const result = [
+    {
+      isActive, settings
+    }, fx.map(SettingsAction)
+  ];
 
   return result;
 };
 
 
+export const update = (model:Model, action:Action):[Model, Effects<Action>] =>( action.type === 'Toggle'
+        ? toggle(model)
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] =>
-  ( action.type === 'Toggle'
-  ? toggle(model)
+        // Button actions
+        : action.type === 'Restart'
+        ? restart(model)
+        : action.type === 'CleanRestart'
+        ? cleanRestart(model)
+        : action.type === 'CleanReload'
+        ? cleanReload(model)
+        : action.type === 'Report'
+        ? report(model, action.result)
 
-  // Button actions
-  : action.type === 'Restart'
-  ? restart(model)
-  : action.type === 'CleanRestart'
-  ? cleanRestart(model)
-  : action.type === 'CleanReload'
-  ? cleanReload(model)
-  : action.type === 'Report'
-  ? report(model, action.result)
+        : action.type === 'Change'
+        ? changeSetting(model, action)
 
-  : action.type === 'Change'
-  ? changeSetting(model, action)
+        : action.type === 'Settings'
+        ? updateSettings(model, action.action)
 
-  : action.type === 'Settings'
-  ? updateSettings(model, action.action)
-
-  : Unknown.update(model, action)
-  );
+        : Unknown.update(model, action)
+);
 
 
-
-
-const styleSheet = StyleSheet.create
-  ( { checkbox:
-      { marginRight: '6px'
-      , MozAppearance: 'checkbox'
-      }
-    , label:
-      { padding: '6px'
-      , MozUserSelect: 'none'
-      , display: 'block'
-      }
-    , button:
-      { display: 'block'
-      , border: '1px solid #AAA'
-      , padding: '3px 6px'
-      , margin: '6px'
-      , borderRadius: '3px'
-      }
-    , toolbox:
-      { padding: '10px'
-      , position: 'absolute'
-      , bottom: '10px'
-      , left: '10px'
-      , width: '300px'
-      , height: '400px'
-      , color: 'black'
-      , backgroundColor: 'white'
-      , border: '2px solid #F06'
-      , overflow: 'scroll'
-      , zIndex: 3
-      }
-    , initializing:
-      { display: 'none'
-      }
-    , hidden:
-      { display: 'none'
-      }
-    , visible:
-      { display: 'block'
-      }
-    }
-  );
+const styleSheet = StyleSheet.create({
+                                       checkbox: {
+                                         marginRight: '6px', MozAppearance: 'checkbox'
+                                       }, label: {
+    padding: '6px', MozUserSelect: 'none', display: 'block'
+  }, button: {
+    display: 'block', border: '1px solid #AAA', padding: '3px 6px', margin: '6px', borderRadius: '3px'
+  }, toolbox: {
+    padding: '10px',
+    position: 'absolute',
+    bottom: '10px',
+    left: '10px',
+    width: '300px',
+    height: '400px',
+    color: 'black',
+    backgroundColor: 'white',
+    border: '2px solid #F06',
+    overflow: 'scroll',
+    zIndex: 3
+  }, initializing: {
+    display: 'none'
+  }, hidden: {
+    display: 'none'
+  }, visible: {
+    display: 'block'
+  }
+                                     });
 
 const viewSetting = (key, value, address) => {
   const isChecked = readValue(key, value);
 
   return html.label({
-    key: key,
-    style: styleSheet.label,
-  }, [
-    html.input({
-      type: 'checkbox',
-      checked: isChecked,
-      style: styleSheet.checkbox,
-      onChange: forward(address, () => Change(key, writeValue(key, !isChecked)))
-    }),
-    descriptions[key]
-  ]);
+                      key: key, style: styleSheet.label,
+                    }, [
+                      html.input({
+                                   type: 'checkbox',
+                                   checked: isChecked,
+                                   style: styleSheet.checkbox,
+                                   onChange: forward(address, () => Change(key, writeValue(key, !isChecked)))
+                                 }), descriptions[key]
+                    ]);
 };
 
-const viewSettings = (settings, address) =>
-  html.div({
-    key: 'devtools-settings',
-    className: 'devtools settings',
-  }, Object.keys(settings || {})
-           .map(key => thunk(key, viewSetting, key, settings[key], address)))
+const viewSettings = (settings, address) =>html.div({
+                                                      key: 'devtools-settings', className: 'devtools settings',
+                                                    }, Object.keys(settings || {})
+                                                             .map(key => thunk(key, viewSetting, key, settings[key],
+                                                                               address)))
 
-export const view =
-  (model: Model, address: Address<Action>): DOM =>
-  html.div({
-    className: 'devtools toolbox',
-    key: 'devtools-toolbox',
-    style: Style
-            ( styleSheet.toolbox,
+export const view = (model:Model, address:Address<Action>):DOM =>html.div({
+                                                                            className: 'devtools toolbox',
+                                                                            key: 'devtools-toolbox',
+                                                                            style: Style(styleSheet.toolbox,
 
-              ( model.isActive
-              ? styleSheet.visible
-              : styleSheet.hidden
-              )
-            )
-  }, [
-    ( model.settings == null
-    ? html.div({}, ['Initializing'])
-    : thunk('settings', viewSettings, model.settings, address)
-    ),
-    html.button({
-      style: styleSheet.button,
-      onClick: forward(address, always(Restart))
-    }, ['Restart']),
-    html.button({
-      style: styleSheet.button,
-      onClick: forward(address, always(CleanRestart))
-    }, ['Clear cache and restart']),
-    html.button({
-      style: styleSheet.button,
-      onClick: forward(address, always(CleanReload))
-    }, ['Clear cache and reload'])
-  ]);
+                                                                                         ( model.isActive
+                                                                                                 ? styleSheet.visible
+                                                                                                 : styleSheet.hidden
+                                                                                         ))
+                                                                          }, [
+                                                                            ( model.settings == null
+                                                                                    ? html.div({}, ['Initializing'])
+                                                                                    : thunk('settings', viewSettings,
+                                                                                            model.settings, address)
+                                                                            ),
+                                                                            html.button({
+                                                                                          style: styleSheet.button,
+                                                                                          onClick: forward(address,
+                                                                                                           always(
+                                                                                                               Restart))
+                                                                                        }, ['Restart']),
+                                                                            html.button({
+                                                                                          style: styleSheet.button,
+                                                                                          onClick: forward(address,
+                                                                                                           always(
+                                                                                                               CleanRestart))
+                                                                                        }, ['Clear cache and restart']),
+                                                                            html.button({
+                                                                                          style: styleSheet.button,
+                                                                                          onClick: forward(address,
+                                                                                                           always(
+                                                                                                               CleanReload))
+                                                                                        }, ['Clear cache and reload'])
+                                                                          ]);

--- a/src/common/devtools.js
+++ b/src/common/devtools.js
@@ -52,11 +52,11 @@ const readValue = (key, value) =>
   : value
   );
 
-export const Toggle/*:Action*/ =
+export const Toggle: Action =
   { type: "Toggle"
   };
 
-export const Restart/*:Action*/ =
+export const Restart: Action =
   { type: "Restart"
   };
 
@@ -66,11 +66,11 @@ const Report = result =>
     }
   );
 
-export const CleanRestart/*:Action*/ =
+export const CleanRestart: Action =
   { type: "CleanRestart"
   };
 
-export const CleanReload/*:Action*/ =
+export const CleanReload: Action =
   { type: "CleanReload"
   };
 
@@ -136,7 +136,7 @@ const changeSetting = (model, {name, value}) =>
 
 
 const report =
-  (model/*:Model*/, result/*:Result<any, any>*/)/*:[Model, Effects<Action>]*/ =>
+  (model: Model, result: Result<any, any>): [Model, Effects<Action>] =>
   [ model
   , ( result.isOk
     ? Effects.none
@@ -148,7 +148,7 @@ const report =
 
 
 export const init =
-  ({isActive}/*:{isActive:boolean}*/)/*:[Model, Effects<Action>]*/ => {
+  ({isActive}/*:{isActive:boolean}*/): [Model, Effects<Action>] => {
   const [settings, fx] =
     Settings.init(Object.keys(descriptions));
 
@@ -165,7 +165,7 @@ export const init =
 
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model: Model, action: Action): [Model, Effects<Action>] =>
   ( action.type === 'Toggle'
   ? toggle(model)
 
@@ -258,7 +258,7 @@ const viewSettings = (settings, address) =>
            .map(key => thunk(key, viewSetting, key, settings[key], address)))
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model: Model, address: Address<Action>): DOM =>
   html.div({
     className: 'devtools toolbox',
     key: 'devtools-toolbox',

--- a/src/common/editable.js
+++ b/src/common/editable.js
@@ -5,56 +5,54 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {merge} from "../common/prelude";
-import * as Unknown from "../common/unknown";
-import {Effects} from "reflex";
+import { merge } from '../common/prelude'
+import * as Unknown from '../common/unknown'
+import { Effects } from 'reflex'
 
 /*::
-import type {Address, DOM} from "reflex";
-import type {Model, Action, Selection} from "./editable"
-*/
+ import type {Address, DOM} from "reflex";
+ import type {Model, Action, Selection} from "./editable"
+ */
 
 // Actions
 
-export const Clear: Action = {type: "Clear"};
+export const Clear:Action = { type: "Clear" };
 
-export const Select =
-  (range: Selection): Action =>
-  ({type: "Select", range});
+export const Select = (range:Selection):Action =>({ type: "Select", range });
 
-export const Change =
-  (value: string, selection: Selection): Action =>
-  ({type: "Change", value, selection});
-
+export const Change = (value:string, selection:Selection):Action =>({ type: "Change", value, selection });
 
 
 const select = /*::<model:Model>*/
-  (model: model, selection: Selection): model =>
-  merge(model, {selection});
+    (model:model, selection:Selection):model =>merge(model, { selection });
 
 const change = /*::<model:Model>*/
-  (model: model, value: string, selection: Selection): model =>
-  merge(model, {selection, value});
+    (model:model, value:string, selection:Selection):model =>merge(model, { selection, value });
 
 const clear = /*::<model:Model>*/
-  (model: model): model =>
-  merge(model, {value: "", selection: null});
+    (model:model):model =>merge(model, { value: "", selection: null });
 
-export const init =
-  (value: string, selection: ?Selection=null): [Model, Effects<Action>] =>
-  [ { value
-    , selection
-    }
-  , Effects.none
-  ]
+export const init = (value:string, selection:?Selection = null):[Model, Effects<Action>] =>[
+  {
+    value, selection
+  }, Effects.none
+]
 
 export const update = /*::<model:Model>*/
-  (model: model, action: Action): [model, Effects<Action>] =>
-  ( action.type === "Clear"
-  ? [clear(model), Effects.none]
-  : action.type === "Select"
-  ? [select(model, action.range), Effects.none]
-  : action.type === "Change"
-  ? [change(model, action.value, action.selection), Effects.none]
-  : Unknown.update(model, action)
-  );
+    (model:model, action:Action):[model, Effects<Action>] =>( action.type === "Clear"
+            ? [
+          clear(model),
+          Effects.none
+        ]
+            : action.type === "Select"
+            ? [
+          select(model, action.range),
+          Effects.none
+        ]
+            : action.type === "Change"
+            ? [
+          change(model, action.value, action.selection),
+          Effects.none
+        ]
+            : Unknown.update(model, action)
+    );

--- a/src/common/editable.js
+++ b/src/common/editable.js
@@ -16,32 +16,32 @@ import type {Model, Action, Selection} from "./editable"
 
 // Actions
 
-export const Clear/*:Action*/ = {type: "Clear"};
+export const Clear: Action = {type: "Clear"};
 
 export const Select =
-  (range/*:Selection*/)/*:Action*/ =>
+  (range: Selection): Action =>
   ({type: "Select", range});
 
 export const Change =
-  (value/*:string*/, selection/*:Selection*/)/*:Action*/ =>
+  (value: string, selection: Selection): Action =>
   ({type: "Change", value, selection});
 
 
 
 const select = /*::<model:Model>*/
-  (model/*:model*/, selection/*:Selection*/)/*:model*/ =>
+  (model: model, selection: Selection): model =>
   merge(model, {selection});
 
 const change = /*::<model:Model>*/
-  (model/*:model*/, value/*:string*/, selection/*:Selection*/)/*:model*/ =>
+  (model: model, value: string, selection: Selection): model =>
   merge(model, {selection, value});
 
 const clear = /*::<model:Model>*/
-  (model/*:model*/)/*:model*/ =>
+  (model: model): model =>
   merge(model, {value: "", selection: null});
 
 export const init =
-  (value/*:string*/, selection/*:?Selection*/=null)/*:[Model, Effects<Action>]*/ =>
+  (value: string, selection: ?Selection=null): [Model, Effects<Action>] =>
   [ { value
     , selection
     }
@@ -49,7 +49,7 @@ export const init =
   ]
 
 export const update = /*::<model:Model>*/
-  (model/*:model*/, action/*:Action*/)/*:[model, Effects<Action>]*/ =>
+  (model: model, action: Action): [model, Effects<Action>] =>
   ( action.type === "Clear"
   ? [clear(model), Effects.none]
   : action.type === "Select"

--- a/src/common/favicon.js
+++ b/src/common/favicon.js
@@ -4,17 +4,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {getOrigin} from '../common/url-helper';
+import { getOrigin } from '../common/url-helper'
 
 /*::
-import type {Icon, URI} from "./favicon"
-*/
+ import type {Icon, URI} from "./favicon"
+ */
 
 const constructFaviconURI = (href, size) => `${href}#-moz-resolution=${size},${size}`;
 
-export const getFallback =
-  (pageURI: URI): URI =>
-  constructFaviconURI(getOrigin(pageURI) + '/favicon.ico', FAVICON_SIZE);
+export const getFallback = (pageURI:URI):URI =>constructFaviconURI(getOrigin(pageURI) + '/favicon.ico', FAVICON_SIZE);
 
 // Ideal size for a favicon.
 const FAVICON_SIZE = 16 * window.devicePixelRatio;
@@ -27,8 +25,7 @@ const FAVICON_SIZE = 16 * window.devicePixelRatio;
  *  rel: Maybe(String)   // "shortcut icon", "icon"
  * }
  */
-export const getBestIcon =
-  (icons: Array<Icon>)/*:{ bestIcon: ?Icon, faviconURI: ?URI}*/ => {
+export const getBestIcon = (icons:Array<Icon>)/*:{ bestIcon: ?Icon, faviconURI: ?URI}*/ => {
 
   const allSizes = new Map(); // store icons per size
   const others = new Set();   // store icons without sizes or non-shortcut icons
@@ -80,18 +77,16 @@ export const getBestIcon =
     const size = bestFit[0];
     const href = bestFit[1].href;
     return {
-      bestIcon: bestFit[1],
-      faviconURI: constructFaviconURI(href, size),
+      bestIcon: bestFit[1], faviconURI: constructFaviconURI(href, size),
     }
   }
 
   if (bestFitForOthers) {
     const href = bestFitForOthers.href;
     return {
-      bestIcon: bestFitForOthers,
-      faviconURI: constructFaviconURI(href, FAVICON_SIZE),
+      bestIcon: bestFitForOthers, faviconURI: constructFaviconURI(href, FAVICON_SIZE),
     }
   }
 
-  return {bestIcon: null, faviconURI: null};
+  return { bestIcon: null, faviconURI: null };
 }

--- a/src/common/favicon.js
+++ b/src/common/favicon.js
@@ -13,7 +13,7 @@ import type {Icon, URI} from "./favicon"
 const constructFaviconURI = (href, size) => `${href}#-moz-resolution=${size},${size}`;
 
 export const getFallback =
-  (pageURI/*:URI*/)/*:URI*/ =>
+  (pageURI: URI): URI =>
   constructFaviconURI(getOrigin(pageURI) + '/favicon.ico', FAVICON_SIZE);
 
 // Ideal size for a favicon.
@@ -28,7 +28,7 @@ const FAVICON_SIZE = 16 * window.devicePixelRatio;
  * }
  */
 export const getBestIcon =
-  (icons/*:Array<Icon>*/)/*:{ bestIcon: ?Icon, faviconURI: ?URI}*/ => {
+  (icons: Array<Icon>)/*:{ bestIcon: ?Icon, faviconURI: ?URI}*/ => {
 
   const allSizes = new Map(); // store icons per size
   const others = new Set();   // store icons without sizes or non-shortcut icons

--- a/src/common/focusable.js
+++ b/src/common/focusable.js
@@ -13,17 +13,17 @@ import {Effects} from "reflex";
 import type {Model, Action} from "./focusable"
 */
 
-export const Focus/*:Action*/ =
+export const Focus: Action =
   { type:"Focus"
   };
 
-export const Blur/*:Action*/ =
+export const Blur: Action =
   { type: "Blur"
   };
 
 
 export const update = /*::<model:Model>*/
-  ( model/*:model*/, action/*:Action*/)/*:[model, Effects<Action>]*/ =>
+  ( model: model, action: Action): [model, Effects<Action>] =>
   ( action.type === "Focus"
   ? [ merge
       ( model

--- a/src/common/focusable.js
+++ b/src/common/focusable.js
@@ -5,40 +5,31 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {merge} from "../common/prelude";
-import * as Unknown from "../common/unknown";
-import {Effects} from "reflex";
+import { merge } from '../common/prelude'
+import * as Unknown from '../common/unknown'
+import { Effects } from 'reflex'
 
 /*::
-import type {Model, Action} from "./focusable"
-*/
+ import type {Model, Action} from "./focusable"
+ */
 
-export const Focus: Action =
-  { type:"Focus"
-  };
+export const Focus:Action = {
+  type: "Focus"
+};
 
-export const Blur: Action =
-  { type: "Blur"
-  };
+export const Blur:Action = {
+  type: "Blur"
+};
 
 
 export const update = /*::<model:Model>*/
-  ( model: model, action: Action): [model, Effects<Action>] =>
-  ( action.type === "Focus"
-  ? [ merge
-      ( model
-      , { isFocused: true
-        }
-      )
-    , Effects.none
-    ]
-  : action.type === "Blur"
-  ? [ merge
-      ( model
-      , { isFocused: false
-        }
-      )
-    , Effects.none
-    ]
-  : Unknown.update(model, action)
-  );
+    (model:model, action:Action):[model, Effects<Action>] =>( action.type === "Focus" ? [
+          merge(model, {
+            isFocused: true
+          }), Effects.none
+        ] : action.type === "Blur" ? [
+          merge(model, {
+            isFocused: false
+          }), Effects.none
+        ] : Unknown.update(model, action)
+    );

--- a/src/common/history.js
+++ b/src/common/history.js
@@ -11,11 +11,11 @@ import type {Integer} from "../common/prelude"
 */
 
 export const readTitle = /*::<value, model:{title?:string}>*/
-  (model/*:model*/, fallback/*:value*/)/*: string | value*/ =>
+  (model: model, fallback: value)/*: string | value*/ =>
   model.title ? model.title : fallback;
 
 export const query = /*::<action>*/
-  (input/*:string*/, limit/*:Integer*/)/*:Effects<action>*/ =>
+  (input: string, limit: Integer): Effects<action> =>
   Effects.perform(new Task(deliver => {
 
   }))

--- a/src/common/history.js
+++ b/src/common/history.js
@@ -4,18 +4,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Task, Effects} from "reflex"
+import { Task, Effects } from 'reflex'
 
 /*::
-import type {Integer} from "../common/prelude"
-*/
+ import type {Integer} from "../common/prelude"
+ */
 
 export const readTitle = /*::<value, model:{title?:string}>*/
-  (model: model, fallback: value)/*: string | value*/ =>
-  model.title ? model.title : fallback;
+    (model:model, fallback:value)/*: string | value*/ =>model.title ? model.title : fallback;
 
 export const query = /*::<action>*/
-  (input: string, limit: Integer): Effects<action> =>
-  Effects.perform(new Task(deliver => {
+    (input:string, limit:Integer):Effects<action> =>Effects.perform(new Task(deliver => {
 
-  }))
+    }))

--- a/src/common/image.js
+++ b/src/common/image.js
@@ -12,7 +12,7 @@ import type {Address, DOM} from "reflex"
 import type {Action, Model, StyleSheet, ContextStyle} from "./image"
 */
 
-const baseStyleSheet/*:StyleSheet*/ = Style.createSheet
+const baseStyleSheet: StyleSheet = Style.createSheet
   ( { base:
       { backgroundSize: 'cover'
       , backgroundPosition: 'center center'
@@ -23,11 +23,11 @@ const baseStyleSheet/*:StyleSheet*/ = Style.createSheet
   );
 
 export const view =
-  (key/*:string*/, styleSheet/*:StyleSheet*/)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>
-  ( model/*:Model*/
-  , address/*:Address<Action>*/
+  (key: string, styleSheet: StyleSheet)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>
+  ( model: Model
+  , address: Address<Action>
   , contextStyle/*?:ContextStyle*/
-  )/*:DOM*/ =>
+  ): DOM =>
   html.figure
   ( { style: Style.mix
         ( baseStyleSheet.base

--- a/src/common/image.js
+++ b/src/common/image.js
@@ -4,37 +4,30 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, thunk, forward, Effects} from 'reflex';
-import * as Style from '../common/style';
+import { html } from 'reflex'
+import * as Style from '../common/style'
 
 /*::
-import type {Address, DOM} from "reflex"
-import type {Action, Model, StyleSheet, ContextStyle} from "./image"
-*/
+ import type {Address, DOM} from "reflex"
+ import type {Action, Model, StyleSheet, ContextStyle} from "./image"
+ */
 
-const baseStyleSheet: StyleSheet = Style.createSheet
-  ( { base:
-      { backgroundSize: 'cover'
-      , backgroundPosition: 'center center'
-      , backgroundRepeat: 'no-repeat'
-      , border: 'none'
-      }
-    }
-  );
+const baseStyleSheet:StyleSheet = Style.createSheet({
+                                                      base: {
+                                                        backgroundSize: 'cover',
+                                                        backgroundPosition: 'center center',
+                                                        backgroundRepeat: 'no-repeat',
+                                                        border: 'none'
+                                                      }
+                                                    });
 
-export const view =
-  (key: string, styleSheet: StyleSheet)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>
-  ( model: Model
-  , address: Address<Action>
-  , contextStyle/*?:ContextStyle*/
-  ): DOM =>
-  html.figure
-  ( { style: Style.mix
-        ( baseStyleSheet.base
-        , styleSheet.base
-        , { backgroundImage: `url(${model.uri})`
-          }
-        , contextStyle
-        )
-    }
-  )
+export const view = (key:string,
+                     styleSheet:StyleSheet)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>(model:Model,
+                                                                                                                             address:Address<Action>,
+                                                                                                                             contextStyle
+                                                                                                                             /*?:ContextStyle*/):DOM =>html.figure(
+    {
+      style: Style.mix(baseStyleSheet.base, styleSheet.base, {
+        backgroundImage: `url(${model.uri})`
+      }, contextStyle)
+    })

--- a/src/common/keyboard.js
+++ b/src/common/keyboard.js
@@ -158,7 +158,7 @@ const writeChord = event => {
 
 
 export const bindings = /*::<Action>*/
-  (bindingTable/*:BindingTable<Action>*/)/*:(event:KeyboardEvent) => Action | Abort*/ => {
+  (bindingTable: BindingTable<Action>)/*:(event:KeyboardEvent) => Action | Abort*/ => {
   const bindings = Object.create(null);
   Object.keys(bindingTable).forEach(key => {
     bindings[readChord(key)] = bindingTable[key];

--- a/src/common/keyboard.js
+++ b/src/common/keyboard.js
@@ -5,99 +5,90 @@
  * file, you can obtain one at http://mozilla.org/mpl/2.0/. */
 
 /*::
-import type {BindingTable, Abort, kind} from "./keyboard"
-*/
+ import type {BindingTable, Abort, kind} from "./keyboard"
+ */
 
-import {Effects} from "reflex";
-import * as OS from './os';
+import * as OS from './os'
 
 const platform = OS.platform();
 
-const getCharCode =
-  ({charCode, keyCode}) =>
-  ( keyCode === 13
-  ? 13
-  : charCode == null
-  ? keyCode
-  : charCode == 0
-  ? keyCode
-  : keyCode >= 32
-  ? keyCode
-  : 0
-  );
+const getCharCode = ({ charCode, keyCode }) =>( keyCode === 13
+        ? 13
+        : charCode == null
+        ? keyCode
+        : charCode == 0
+        ? keyCode
+        : keyCode >= 32
+        ? keyCode
+        : 0
+);
 
 
 if (!('key' in window.KeyboardEvent.prototype)) {
-  const keyTable =
-    { "3": "Enter"
-    , "8": "Backspace"
-    , "9": "Tab"
-    , "12": "Clear"
-    , "13": "Enter"
-    , "16": "Shift"
-    , "17": "Control"
-    , "18": "Alt"
-    , "19": "Pause"
-    , "20": "CapsLock"
-    , "27": "Escape"
-    , "32": "Space"
-    , "33": "PageUp"
-    , "34": "PageDown"
-    , "35": "End"
-    , "36": "Home"
-    , "37": "ArrowLeft"
-    , "38": "ArrowUp"
-    , "39": "ArrowRight"
-    , "40": "ArrowDown"
-    , "44": "PrintScreen"
-    , "45": "Insert"
-    , "46": "Delete"
-    , "112": "F1"
-    , "113": "F2"
-    , "114": "F3"
-    , "115": "F4"
-    , "116": "F5"
-    , "117": "F6"
-    , "118": "F7"
-    , "119": "F8"
-    , "120": "F9"
-    , "121": "F10"
-    , "122": "F11"
-    , "123": "F12"
-    , "144": "NumLock"
-    , "145": "ScrollLock"
-    , "224": "Meta"
-    , "91": "Meta"
-    , "92": "Meta"
-    , "93": "Meta"
-    , "63273": "Home"
-    , "63275": "End"
-    , "63276": "PageUp"
-    , "63277": "PageDown"
-    , "63302": "Insert"
-    };
+  const keyTable = {
+    "3": "Enter",
+    "8": "Backspace",
+    "9": "Tab",
+    "12": "Clear",
+    "13": "Enter",
+    "16": "Shift",
+    "17": "Control",
+    "18": "Alt",
+    "19": "Pause",
+    "20": "CapsLock",
+    "27": "Escape",
+    "32": "Space",
+    "33": "PageUp",
+    "34": "PageDown",
+    "35": "End",
+    "36": "Home",
+    "37": "ArrowLeft",
+    "38": "ArrowUp",
+    "39": "ArrowRight",
+    "40": "ArrowDown",
+    "44": "PrintScreen",
+    "45": "Insert",
+    "46": "Delete",
+    "112": "F1",
+    "113": "F2",
+    "114": "F3",
+    "115": "F4",
+    "116": "F5",
+    "117": "F6",
+    "118": "F7",
+    "119": "F8",
+    "120": "F9",
+    "121": "F10",
+    "122": "F11",
+    "123": "F12",
+    "144": "NumLock",
+    "145": "ScrollLock",
+    "224": "Meta",
+    "91": "Meta",
+    "92": "Meta",
+    "93": "Meta",
+    "63273": "Home",
+    "63275": "End",
+    "63276": "PageUp",
+    "63277": "PageDown",
+    "63302": "Insert"
+  };
 
-  const getKey = function() {
+  const getKey = function () {
     const charCode = getCharCode(this)
-    const key =
-    ( charCode in keyTable
-    ? keyTable[charCode]
-    : String.fromCharCode(charCode)
+    const key = ( charCode in keyTable ? keyTable[charCode] : String.fromCharCode(charCode)
     );
 
     return key
   };
 
-  Object.defineProperty
-  ( window.KeyboardEvent.prototype
-  , 'key'
-  , { get: getKey
+  Object.defineProperty(window.KeyboardEvent.prototype, 'key', {
+    get: getKey
     /*::, value: void(0)*/
-    }
-  );
+  });
 }
 
-const readModifiers = ({type, metaKey, shiftKey, altKey, ctrlKey}) => {
+const readModifiers = ({ type, metaKey, shiftKey, altKey, ctrlKey }) => {
   const modifiers = [];
   // Modifier fields indicate if relevant modifier is pressed, in case
   // of 'keyup' event including those does not make sense.
@@ -131,8 +122,7 @@ readKey.table = Object.assign(Object.create(null), {
   'esc': 'Escape'
 });
 
-const readChord = input =>
-  input
+const readChord = input =>input
     .split(/\s+/)
     .map(readKey)
     .sort()
@@ -143,54 +133,45 @@ const readChord = input =>
 const writeChord = event => {
   const key = event.key
   const modifiers = readModifiers(event)
-  const keys = modifiers.indexOf(key) < 0 ?
-                [...modifiers, key] :
-                modifiers;
+  const keys = modifiers.indexOf(key) < 0 ? [...modifiers, key] : modifiers;
 
   return keys
-          .map(readKey)
-          .join(' ')
-          .toLowerCase()
-          .split(' ')
-          .sort()
-          .join(' ');
+      .map(readKey)
+      .join(' ')
+      .toLowerCase()
+      .split(' ')
+      .sort()
+      .join(' ');
 };
 
 
 export const bindings = /*::<Action>*/
-  (bindingTable: BindingTable<Action>)/*:(event:KeyboardEvent) => Action | Abort*/ => {
-  const bindings = Object.create(null);
-  Object.keys(bindingTable).forEach(key => {
-    bindings[readChord(key)] = bindingTable[key];
-  });
+    (bindingTable:BindingTable<Action>)/*:(event:KeyboardEvent) => Action | Abort*/ => {
+      const bindings = Object.create(null);
+      Object.keys(bindingTable).forEach(key => {
+        bindings[readChord(key)] = bindingTable[key];
+      });
 
-  return (event) => {
-    const combination = writeChord(event);
-    const binding = bindings[combination]
+      return (event) => {
+        const combination = writeChord(event);
+        const binding = bindings[combination]
 
-    if (binding != null) {
-      event.stopPropagation();
-      event.preventDefault();
-      return binding(event);
-    }
-    else {
-      return {
-        type: "AbortEvent"
-      , action:
-        { type
-            : event.type === "keyup"
-            ? "KeyUp"
-            : event.type === "keydown"
-            ? "KeyDown"
-            : "KeyPress"
-        , combination: combination
-        , key: event.key
-        , metaKey: event.metaKey
-        , shiftKey: event.shiftKey
-        , altKey: event.altKey
-        , ctrlKey: event.ctrlKey
+        if (binding != null) {
+          event.stopPropagation();
+          event.preventDefault();
+          return binding(event);
+        } else {
+          return {
+            type: "AbortEvent", action: {
+              type: event.type === "keyup" ? "KeyUp" : event.type === "keydown" ? "KeyDown" : "KeyPress",
+              combination: combination,
+              key: event.key,
+              metaKey: event.metaKey,
+              shiftKey: event.shiftKey,
+              altKey: event.altKey,
+              ctrlKey: event.ctrlKey
+            }
+          };
         }
       };
-    }
-  };
-};
+    };

--- a/src/common/os.js
+++ b/src/common/os.js
@@ -7,13 +7,15 @@
 
 // Subset of `os` module from node.js and io.js:
 // https://iojs.org/api/os.html
-const PLATFORM = navigator.platform.startsWith('Win') ? 'win32' :
-                 navigator.platform.startsWith('Mac') ? 'darwin' :
-                 navigator.platform.startsWith('Linux') ? 'linux' :
-                 navigator.platform.startsWith('FreeBSD') ? 'freebsd' :
-                 navigator.platform;
+const PLATFORM = navigator.platform.startsWith('Win')
+    ? 'win32'
+    : navigator.platform.startsWith('Mac')
+    ? 'darwin'
+    : navigator.platform.startsWith('Linux')
+    ? 'linux'
+    : navigator.platform.startsWith('FreeBSD')
+    ? 'freebsd'
+    : navigator.platform;
 
 // https://iojs.org/api/os.html#os_os_platform
-export const platform =
-  (): string =>
-  PLATFORM;
+export const platform = ():string =>PLATFORM;

--- a/src/common/os.js
+++ b/src/common/os.js
@@ -15,5 +15,5 @@ const PLATFORM = navigator.platform.startsWith('Win') ? 'win32' :
 
 // https://iojs.org/api/os.html#os_os_platform
 export const platform =
-  ()/*:string*/ =>
+  (): string =>
   PLATFORM;

--- a/src/common/prelude.js
+++ b/src/common/prelude.js
@@ -5,87 +5,78 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {Effects} from "reflex"
+import { Effects } from 'reflex'
 
 /*::
-import type {Tagged} from "./prelude"
-*/
+ import type {Tagged} from "./prelude"
+ */
 
 export const merge = /*::<model:{}>*/
-  ( model: model
-  , changes/*:{[key:string]: any}*/
-  ): model => {
-  let result = model
-  for (let key in changes) {
-    if (changes.hasOwnProperty(key)) {
-      const value = changes[key]
+    (model:model, changes/*:{[key:string]: any}*/):model => {
+      let result = model
+      for (let key in changes) {
+        if (changes.hasOwnProperty(key)) {
+          const value = changes[key]
 
-      if (model[key] !== value) {
-        if (result === model) {
-          result = {}
-          for (let key in model) {
-            if (model.hasOwnProperty(key)) {
-              result[key] = model[key]
+          if (model[key] !== value) {
+            if (result === model) {
+              result = {}
+              for (let key in model) {
+                if (model.hasOwnProperty(key)) {
+                  result[key] = model[key]
+                }
+              }
+            }
+
+            if (value === void(0)) {
+              delete result[key]
+            } else {
+              result[key] = value
             }
           }
         }
-
-        if (value === void(0)) {
-          delete result[key]
-        } else {
-          result[key] = value
-        }
       }
-    }
-  }
 
-  // @FlowIssue: Ok just trust me on this!
-  return result
-}
+      // @FlowIssue: Ok just trust me on this!
+      return result
+    }
 
 
 export const take = /*::<item>*/
-  (items: Array<item>, n: number): Array<item> =>
-  ( items.length <= n
-  ? items
-  : items.slice(0, n)
-  )
+    (items:Array<item>, n:number):Array<item> =>( items.length <= n ? items : items.slice(0, n)
+    )
 
 export const move = /*::<item>*/
-  ( items: Array<item>
-  , from: number
-  , to: number
-  ): Array<item> => {
-  const count = items.length
-  if (from === to) {
-    return items
-  } else if (from >= count) {
-    return items
-  } else if (to >= count) {
-    return items
-  } else {
-    const result = items.slice(0)
-    const target = result.splice(from, 1)[0]
-    result.splice(to, 0, target)
-    return result
-  }
-}
+    (items:Array<item>, from:number, to:number):Array<item> => {
+      const count = items.length
+      if (from === to) {
+        return items
+      } else if (from >= count) {
+        return items
+      } else if (to >= count) {
+        return items
+      } else {
+        const result = items.slice(0)
+        const target = result.splice(from, 1)[0]
+        result.splice(to, 0, target)
+        return result
+      }
+    }
 
 export const remove = /*::<item>*/
-  (items: Array<item>, index: number): Array<item> =>
-  ( index < 0
-  ? items
-  : index >= items.length
-  ? items
-  : index === 0
-  ? items.slice(1)
-  : index === items.length - 1
-  ? items.slice(0, index)
-  : items.slice(0, index).concat(items.slice(index + 1))
-  );
+    (items:Array<item>, index:number):Array<item> =>( index < 0
+            ? items
+            : index >= items.length
+            ? items
+            : index === 0
+            ? items.slice(1)
+            : index === items.length - 1
+            ? items.slice(0, index)
+            : items.slice(0, index).concat(items.slice(index + 1))
+    );
 
 
-export const setIn = /*::<item>*/(items: Array<item>, index: number, item: item): Array<item> => {
+export const setIn = /*::<item>*/(items:Array<item>, index:number, item:item):Array<item> => {
   if (items[index] === item) {
     return items
   } else {
@@ -101,23 +92,19 @@ const Always = {
   }
 }
 
-const alwaysSymbol =
-  ( typeof(Symbol.for) === "function"
-  ? Symbol.for('always')
-  : Symbol('always')
-  )
+const alwaysSymbol = ( typeof(Symbol.for) === "function" ? Symbol.for('always') : Symbol('always')
+)
 
 // @FlowIssue: Frow is unable to infer
 const Null = () => null;
 // @FlowIssue: Frow is unable to infer
 const Void = () => void(0);
 
-export const always = /*::<a>*/(a: a)/*:(...args:Array<any>)=>a*/ => {
+export const always = /*::<a>*/(a:a)/*:(...args:Array<any>)=>a*/ => {
   const value = a
   if (value === null) {
     return Null
-  }
-  else if (value === void(0)) {
+  } else if (value === void(0)) {
     return Void
   }
   // @FlowIssue: Frow does not know we can access property on all other types.
@@ -143,30 +130,24 @@ export const always = /*::<a>*/(a: a)/*:(...args:Array<any>)=>a*/ => {
 // in place if `modlel` is "mutable". `batch` here wolud be able to take
 // advantage of these to update same model in place.
 export const batch = /*:: <model, action>*/
-  ( update/*:(m:model, a:action) => [model, Effects<action>]*/
-  , model: model
-  , actions: Array<action>
-  ): [model, Effects<action>] =>
-{
-  let effects = [];
-  let index = 0;
-  const count = actions.length;
-  while (index < count) {
-    const action = actions[index];
-    let [state, fx] = update(model, action);
-    model = state;
-    effects.push(fx);
-    index = index + 1
-  }
+    (update/*:(m:model, a:action) => [model, Effects<action>]*/, model:model,
+     actions:Array<action>):[model, Effects<action>] => {
+      let effects = [];
+      let index = 0;
+      const count = actions.length;
+      while (index < count) {
+        const action = actions[index];
+        let [state, fx] = update(model, action);
+        model = state;
+        effects.push(fx);
+        index = index + 1
+      }
 
-  return [model, Effects.batch(effects)];
-}
+      return [model, Effects.batch(effects)];
+    }
 
 export const tag = /*::<tag:string, kind>*/
-  (tag: tag)/*:(value:kind) => Tagged<tag, kind>*/ =>
-  value =>
-  ({ type: tag, source: value });
+    (tag:tag)/*:(value:kind) => Tagged<tag, kind>*/ =>value =>({ type: tag, source: value });
 
 export const tagged = /*::<tag:string, kind>*/
-  (tag: tag, value: kind): Tagged<tag, kind> =>
-  ({ type: tag, source: value });
+    (tag:tag, value:kind):Tagged<tag, kind> =>({ type: tag, source: value });

--- a/src/common/prelude.js
+++ b/src/common/prelude.js
@@ -12,9 +12,9 @@ import type {Tagged} from "./prelude"
 */
 
 export const merge = /*::<model:{}>*/
-  ( model/*:model*/
+  ( model: model
   , changes/*:{[key:string]: any}*/
-  )/*:model*/ => {
+  ): model => {
   let result = model
   for (let key in changes) {
     if (changes.hasOwnProperty(key)) {
@@ -45,17 +45,17 @@ export const merge = /*::<model:{}>*/
 
 
 export const take = /*::<item>*/
-  (items/*:Array<item>*/, n/*:number*/)/*:Array<item>*/ =>
+  (items: Array<item>, n: number): Array<item> =>
   ( items.length <= n
   ? items
   : items.slice(0, n)
   )
 
 export const move = /*::<item>*/
-  ( items/*:Array<item>*/
-  , from/*:number*/
-  , to/*:number*/
-  )/*:Array<item>*/ => {
+  ( items: Array<item>
+  , from: number
+  , to: number
+  ): Array<item> => {
   const count = items.length
   if (from === to) {
     return items
@@ -72,7 +72,7 @@ export const move = /*::<item>*/
 }
 
 export const remove = /*::<item>*/
-  (items/*:Array<item>*/, index/*:number*/)/*:Array<item>*/ =>
+  (items: Array<item>, index: number): Array<item> =>
   ( index < 0
   ? items
   : index >= items.length
@@ -85,7 +85,7 @@ export const remove = /*::<item>*/
   );
 
 
-export const setIn = /*::<item>*/(items/*:Array<item>*/, index/*:number*/, item/*:item*/)/*:Array<item>*/ => {
+export const setIn = /*::<item>*/(items: Array<item>, index: number, item: item): Array<item> => {
   if (items[index] === item) {
     return items
   } else {
@@ -112,7 +112,7 @@ const Null = () => null;
 // @FlowIssue: Frow is unable to infer
 const Void = () => void(0);
 
-export const always = /*::<a>*/(a/*:a*/)/*:(...args:Array<any>)=>a*/ => {
+export const always = /*::<a>*/(a: a)/*:(...args:Array<any>)=>a*/ => {
   const value = a
   if (value === null) {
     return Null
@@ -144,9 +144,9 @@ export const always = /*::<a>*/(a/*:a*/)/*:(...args:Array<any>)=>a*/ => {
 // advantage of these to update same model in place.
 export const batch = /*:: <model, action>*/
   ( update/*:(m:model, a:action) => [model, Effects<action>]*/
-  , model/*:model*/
-  , actions/*:Array<action>*/
-  )/*:[model, Effects<action>]*/ =>
+  , model: model
+  , actions: Array<action>
+  ): [model, Effects<action>] =>
 {
   let effects = [];
   let index = 0;
@@ -163,10 +163,10 @@ export const batch = /*:: <model, action>*/
 }
 
 export const tag = /*::<tag:string, kind>*/
-  (tag/*:tag*/)/*:(value:kind) => Tagged<tag, kind>*/ =>
+  (tag: tag)/*:(value:kind) => Tagged<tag, kind>*/ =>
   value =>
   ({ type: tag, source: value });
 
 export const tagged = /*::<tag:string, kind>*/
-  (tag/*:tag*/, value/*:kind*/)/*:Tagged<tag, kind>*/ =>
+  (tag: tag, value: kind): Tagged<tag, kind> =>
   ({ type: tag, source: value });

--- a/src/common/ref.js
+++ b/src/common/ref.js
@@ -19,14 +19,14 @@ const state =
   };
 
 export const create =
-  ()/*:Model*/ =>
+  (): Model =>
   ( { name: 'data-ref'
     , value: `ref-${++state.nextRef}`
     }
   );
 
 export const deref =
-  (ref/*:Model*/)/*:Task<Error, HTMLElement>*/ =>
+  (ref: Model): Task<Error, HTMLElement> =>
   new Task
   ( (succeed, fail) => {
       const element = document.querySelector(`[${ref.name}='${ref.value}']`);

--- a/src/common/ref.js
+++ b/src/common/ref.js
@@ -1,39 +1,34 @@
 /* @flow */
 
-import {Effects, Task} from "reflex"
+import { Task } from 'reflex'
 
 /*::
-import type {Never} from "reflex"
+ import type {Never} from "reflex"
 
-export type Model =
-  { name: string
-  , value: string
-  }
+ export type Model =
+ { name: string
+ , value: string
+ }
 
-export type Action =
-  | Action
-*/
+ export type Action =
+ | Action
+ */
 
-const state =
-  { nextRef: 0
-  };
+const state = {
+  nextRef: 0
+};
 
-export const create =
-  (): Model =>
-  ( { name: 'data-ref'
-    , value: `ref-${++state.nextRef}`
-    }
-  );
+export const create = ():Model =>( {
+  name: 'data-ref', value: `ref-${++state.nextRef}`
+}
+);
 
-export const deref =
-  (ref: Model): Task<Error, HTMLElement> =>
-  new Task
-  ( (succeed, fail) => {
-      const element = document.querySelector(`[${ref.name}='${ref.value}']`);
-      void
+export const deref = (ref:Model):Task<Error, HTMLElement> =>new Task((succeed, fail) => {
+  const element = document.querySelector(`[${ref.name}='${ref.value}']`);
+  void
       ( element == null
-      ? fail(Error(`Could not find element by [${ref.name}='${ref.value}'], make sure to include {[ref.name]: ref.value} in a virtual node`))
-      : succeed(element)
+              ? fail(Error(
+              `Could not find element by [${ref.name}='${ref.value}'], make sure to include {[ref.name]: ref.value} in a virtual node`))
+              : succeed(element)
       );
-    }
-  );
+});

--- a/src/common/request-animation-frame.js
+++ b/src/common/request-animation-frame.js
@@ -16,7 +16,7 @@ const state =
 const frameTime = 1000 / 60
 
 export const requestAnimationFrame =
-  (request/*:(time:number) => any*/)/*:number*/ => {
+  (request/*:(time:number) => any*/): number => {
     const id = ++state.nextID;
     state.ids.push(id);
     state.requests.push(request);
@@ -32,7 +32,7 @@ export const requestAnimationFrame =
   }
 
 export const cancelAnimationFrame =
-  (id/*:number*/) => {
+  (id: number) => {
     const index = state.ids.indexOf(id);
     if (index >= 0) {
       state.ids.splice(index, 1);

--- a/src/common/request-animation-frame.js
+++ b/src/common/request-animation-frame.js
@@ -1,65 +1,57 @@
 /* @flow */
 
-import * as Runtime from "./runtime"
+import * as Runtime from './runtime'
 /*::
-import {performance} from "./performance"
-*/
+ import {performance} from "./performance"
+ */
 
-const state =
-  { requests: []
-  , ids: []
-  , nextID: 0
-  , isScheduled: false
-  , time: 0
-  }
+const state = {
+  requests: [], ids: [], nextID: 0, isScheduled: false, time: 0
+}
 
 const frameTime = 1000 / 60
 
-export const requestAnimationFrame =
-  (request/*:(time:number) => any*/): number => {
-    const id = ++state.nextID;
-    state.ids.push(id);
-    state.requests.push(request);
+export const requestAnimationFrame = (request/*:(time:number) => any*/):number => {
+  const id = ++state.nextID;
+  state.ids.push(id);
+  state.requests.push(request);
 
-    if (!state.isScheduled) {
-      const now = performance.now()
-      const delta = Math.max(0, frameTime - (now - state.time));
-      setTimeout(onAnimationFrame, delta);
-      state.isScheduled = true;
-    }
-
-    return id;
+  if (!state.isScheduled) {
+    const now = performance.now()
+    const delta = Math.max(0, frameTime - (now - state.time));
+    setTimeout(onAnimationFrame, delta);
+    state.isScheduled = true;
   }
 
-export const cancelAnimationFrame =
-  (id: number) => {
-    const index = state.ids.indexOf(id);
-    if (index >= 0) {
-      state.ids.splice(index, 1);
-      state.requests.splice(index, 1);
-    }
-  }
+  return id;
+}
 
-const onAnimationFrame =
-  () => {
-    const now = performance.now();
-    state.time = now;
-    state.isScheduled = false;
-    state.ids.splice(0);
-    const requests = state.requests.splice(0);
-
-    const count = requests.length;
-    let index  = 0;
-    while (index < count) {
-      requests[index++](now);
-    }
+export const cancelAnimationFrame = (id:number) => {
+  const index = state.ids.indexOf(id);
+  if (index >= 0) {
+    state.ids.splice(index, 1);
+    state.requests.splice(index, 1);
   }
+}
 
-export const doOverride =
-  () => {
-    window.requestAnimationFrame = requestAnimationFrame
-    console.warn("non-native requestAnimationFrame will be used");
+const onAnimationFrame = () => {
+  const now = performance.now();
+  state.time = now;
+  state.isScheduled = false;
+  state.ids.splice(0);
+  const requests = state.requests.splice(0);
+
+  const count = requests.length;
+  let index = 0;
+  while (index < count) {
+    requests[index++](now);
   }
+}
+
+export const doOverride = () => {
+  window.requestAnimationFrame = requestAnimationFrame
+  console.warn("non-native requestAnimationFrame will be used");
+}
 
 
 if (Runtime.env.raf === "timer") {

--- a/src/common/result.js
+++ b/src/common/result.js
@@ -6,22 +6,18 @@
 
 
 /*::
-import type {Result, Ok, Error} from "./result"
-export type {Result, Ok, Error}
-*/
+ import type {Result, Ok, Error} from "./result"
+ export type {Result, Ok, Error}
+ */
 
 export const ok = /*::<value>*/
-  (value: value): Ok<value> =>
-  ( { isOk: true
-    , isError: false
-    , value
+    (value:value):Ok<value> =>( {
+      isOk: true, isError: false, value
     }
-  );
+    );
 
 export const error = /*::<error>*/
-  (error: error): Error<error> =>
-  ( { isOk: false
-    , isError: true
-    , error
+    (error:error):Error<error> =>( {
+      isOk: false, isError: true, error
     }
-  );
+    );

--- a/src/common/result.js
+++ b/src/common/result.js
@@ -11,7 +11,7 @@ export type {Result, Ok, Error}
 */
 
 export const ok = /*::<value>*/
-  (value/*:value*/)/*:Ok<value>*/ =>
+  (value: value): Ok<value> =>
   ( { isOk: true
     , isError: false
     , value
@@ -19,7 +19,7 @@ export const ok = /*::<value>*/
   );
 
 export const error = /*::<error>*/
-  (error/*:error*/)/*:Error<error>*/ =>
+  (error: error): Error<error> =>
   ( { isOk: false
     , isError: true
     , error

--- a/src/common/runtime.js
+++ b/src/common/runtime.js
@@ -52,38 +52,38 @@ export const FullscreenToggled
 
 
 export const RemoteDebugResponse =
-  (value/*:boolean*/)/*:RemoteDebugResponseType*/ =>
+  (value: boolean): RemoteDebugResponseType =>
   ( { type: "RemoteDebugResponse"
     , value
     }
   );
 
 export const DownloadUpdate =
-  (result/*:string*/)/*:DownloadUpdateType*/ =>
+  (result: string): DownloadUpdateType =>
   ( { type: "DownloadUpdate"
     , result
     }
   );
 
-export const isServo/*:boolean*/ =
+export const isServo: boolean =
   window
   .navigator
   .userAgent
   .toLowerCase()
   .indexOf(' servo') != -1
 
-export const isElectron/*:boolean*/ =
+export const isElectron: boolean =
   window
   .navigator
   .userAgent
   .toLowerCase()
   .indexOf(' electron') != -1
 
-export const never/*:Task<Never, any>*/ =
+export const never: Task<Never, any> =
   new Task(succeed => void(0));
 
 export const respond = /*::<message>*/
-  (message/*:message*/)/*:Task<Never, message>*/ =>
+  (message: message): Task<Never, message> =>
   new Task
   ( (succeed, fail) =>
     void ( Promise
@@ -93,7 +93,7 @@ export const respond = /*::<message>*/
   );
 
 export const send = /*::<message>*/
-  (message/*:message*/)/*:Task<Never, void>*/ =>
+  (message: message): Task<Never, void> =>
   new Task(succeed => {
     window.dispatchEvent(new window.CustomEvent("mozContentEvent", {
       bubbles: true,
@@ -105,7 +105,7 @@ export const send = /*::<message>*/
   });
 
 export const receive = /*::<message>*/
-  (type/*:string*/)/*:Task<Never, message>*/ =>
+  (type: string): Task<Never, message> =>
   new Task(succeed => {
     const onMessage = ({detail: message}) => {
       if (message.type === type) {
@@ -118,12 +118,12 @@ export const receive = /*::<message>*/
 
 
 export const request = /*::<request, response>*/
-  (type/*:string*/, message/*:request*/)/*:Task<Never, response>*/ =>
+  (type: string, message: request): Task<Never, response> =>
   send(message)
   .chain(always(receive(type)));
 
 
-export const quit/*:Task<Never, Result<Error, void>>*/ =
+export const quit: Task<Never, Result<Error, void>> =
   ( isServo
   ? new Task((succeed, fail) => {
       try {
@@ -139,19 +139,19 @@ export const quit/*:Task<Never, Result<Error, void>>*/ =
     .chain(always(never))
   );
 
-export const minimize/*:Task<Never, Result<Error, void>>*/ =
+export const minimize: Task<Never, Result<Error, void>> =
   send({type: "minimize-native-window"})
   // We do not get event back when window is minimized so we just pretend
   // that we got it after a tick.
   .chain(always(respond(ok())))
 
-export const toggleFullscreen/*:Task<Never, Result<Error, void>>*/ =
+export const toggleFullscreen: Task<Never, Result<Error, void>> =
   send({type: "toggle-fullscreen-native-window"})
   // We do not get event back when window is maximized so we just pretend
   // that we got it after a tick.
   .chain(always(respond(ok())));
 
-export const reload/*:Task<Never, Result<Error, void>>*/ =
+export const reload: Task<Never, Result<Error, void>> =
   new Task(succeed => {
     try {
       window.location.reload();
@@ -162,15 +162,15 @@ export const reload/*:Task<Never, Result<Error, void>>*/ =
   });
 
 
-export const restart/*:Task<Never, Result<Error, void>>*/ =
+export const restart: Task<Never, Result<Error, void>> =
   send({type: "restart"})
   .chain(always(respond(error(Error(`Unsupported runtime task "restart" was triggered`)))));
 
-export const cleanRestart/*:Task<Never, Result<Error, void>>*/ =
+export const cleanRestart: Task<Never, Result<Error, void>> =
   send({type: "clear-cache-and-restart"})
   .chain(always(never));
 
-export const cleanReload/*:Task<Never, Result<Error, void>>*/ =
+export const cleanReload: Task<Never, Result<Error, void>> =
   ( isServo
   ? new Task(succeed => {
       try {
@@ -188,7 +188,7 @@ export const cleanReload/*:Task<Never, Result<Error, void>>*/ =
 // titlebar configuration.
 const platform = OS.platform()
 export const useNativeTitlebar =
-  ()/*:boolean*/ =>
+  (): boolean =>
   platform != "darwin";
 
 const Env =

--- a/src/common/runtime.js
+++ b/src/common/runtime.js
@@ -6,213 +6,169 @@
 
 
 /*::
-import type {Never} from "reflex"
-import type {Result} from "../common/result"
-import type {RemoteDebugResponseType, DownloadUpdateType} from "./runtime"
+ import type {Never} from "reflex"
+ import type {Result} from "../common/result"
+ import type {RemoteDebugResponseType, DownloadUpdateType} from "./runtime"
 
-*/
-import {always} from "../common/prelude";
-import {Task} from "reflex";
-import {ok, error} from "../common/result";
-import * as OS from '../common/os';
-import * as URL from '../common/url-helper';
-import * as QueryString from 'querystring';
+ */
+import { always } from '../common/prelude'
+import { Task } from 'reflex'
+import { ok, error } from '../common/result'
+import * as OS from '../common/os'
+import * as URL from '../common/url-helper'
+import * as QueryString from 'querystring'
 
 // Actions
-export const RemoteDebugRequest
-  = {type: "RemoteDebugRequest"};
+export const RemoteDebugRequest = { type: "RemoteDebugRequest" };
 
-export const UpdateAvailable
-  = {type: "UpdateAvailable"};
+export const UpdateAvailable = { type: "UpdateAvailable" };
 
-export const UpdateDownloaded
-  = {type: "UpdateDownloaded"};
+export const UpdateDownloaded = { type: "UpdateDownloaded" };
 
-export const Restart
-  = {type: "Restart"};
+export const Restart = { type: "Restart" };
 
-export const CleanRestart
-  = {type: "CleanRestart"};
+export const CleanRestart = { type: "CleanRestart" };
 
-export const CleanReload
-  = {type: "CleanReload"};
+export const CleanReload = { type: "CleanReload" };
 
-export const Reload
-  = {type: "Reload"};
+export const Reload = { type: "Reload" };
 
-export const Quit
-  = {type: "Quit"};
+export const Quit = { type: "Quit" };
 
-export const Minimized
-  = {type: "Minimized"};
+export const Minimized = { type: "Minimized" };
 
-export const FullscreenToggled
-  = {type: "FullscreenToggled"};
+export const FullscreenToggled = { type: "FullscreenToggled" };
 
 
+export const RemoteDebugResponse = (value:boolean):RemoteDebugResponseType =>( {
+  type: "RemoteDebugResponse", value
+}
+);
 
-export const RemoteDebugResponse =
-  (value: boolean): RemoteDebugResponseType =>
-  ( { type: "RemoteDebugResponse"
-    , value
-    }
-  );
+export const DownloadUpdate = (result:string):DownloadUpdateType =>( {
+  type: "DownloadUpdate", result
+}
+);
 
-export const DownloadUpdate =
-  (result: string): DownloadUpdateType =>
-  ( { type: "DownloadUpdate"
-    , result
-    }
-  );
+export const isServo:boolean = window
+        .navigator
+        .userAgent
+        .toLowerCase()
+        .indexOf(' servo') != -1
 
-export const isServo: boolean =
-  window
-  .navigator
-  .userAgent
-  .toLowerCase()
-  .indexOf(' servo') != -1
+export const isElectron:boolean = window
+        .navigator
+        .userAgent
+        .toLowerCase()
+        .indexOf(' electron') != -1
 
-export const isElectron: boolean =
-  window
-  .navigator
-  .userAgent
-  .toLowerCase()
-  .indexOf(' electron') != -1
-
-export const never: Task<Never, any> =
-  new Task(succeed => void(0));
+export const never:Task<Never, any> = new Task(succeed => void(0));
 
 export const respond = /*::<message>*/
-  (message: message): Task<Never, message> =>
-  new Task
-  ( (succeed, fail) =>
-    void ( Promise
-      .resolve(message)
-      .then(succeed, fail)
-    )
-  );
+    (message:message):Task<Never, message> =>new Task((succeed, fail) =>void ( Promise
+            .resolve(message)
+            .then(succeed, fail)
+    ));
 
 export const send = /*::<message>*/
-  (message: message): Task<Never, void> =>
-  new Task(succeed => {
-    window.dispatchEvent(new window.CustomEvent("mozContentEvent", {
-      bubbles: true,
-      cancelable: false,
-      detail: message
-    }));
+    (message:message):Task<Never, void> =>new Task(succeed => {
+      window.dispatchEvent(new window.CustomEvent("mozContentEvent", {
+        bubbles: true, cancelable: false, detail: message
+      }));
 
-    succeed(void(0));
-  });
+      succeed(void(0));
+    });
 
 export const receive = /*::<message>*/
-  (type: string): Task<Never, message> =>
-  new Task(succeed => {
-    const onMessage = ({detail: message}) => {
-      if (message.type === type) {
-        window.removeEventListener('mozChromeEvent', onMessage);
-        succeed(message);
-      }
-    };
-    window.addEventListener('mozChromeEvent', onMessage);
-  });
+    (type:string):Task<Never, message> =>new Task(succeed => {
+      const onMessage = ({ detail: message }) => {
+        if (message.type === type) {
+          window.removeEventListener('mozChromeEvent', onMessage);
+          succeed(message);
+        }
+      };
+      window.addEventListener('mozChromeEvent', onMessage);
+    });
 
 
 export const request = /*::<request, response>*/
-  (type: string, message: request): Task<Never, response> =>
-  send(message)
-  .chain(always(receive(type)));
+    (type:string, message:request):Task<Never, response> =>send(message)
+        .chain(always(receive(type)));
 
 
-export const quit: Task<Never, Result<Error, void>> =
-  ( isServo
-  ? new Task((succeed, fail) => {
+export const quit:Task<Never, Result<Error, void>> = ( isServo ? new Task((succeed, fail) => {
       try {
         window.close();
         succeed(ok(void(0)));
       } catch (reason) {
         succeed(error(reason));
       }
-    })
-  : send({type: "shutdown-application"})
+    }) : send({ type: "shutdown-application" })
     // We do not actually close a window but rather we shut down an app, there
     // will be nothing handling a response so we don"t even bother with it.
-    .chain(always(never))
-  );
+        .chain(always(never))
+);
 
-export const minimize: Task<Never, Result<Error, void>> =
-  send({type: "minimize-native-window"})
-  // We do not get event back when window is minimized so we just pretend
-  // that we got it after a tick.
-  .chain(always(respond(ok())))
+export const minimize:Task<Never, Result<Error, void>> = send({ type: "minimize-native-window" })
+// We do not get event back when window is minimized so we just pretend
+// that we got it after a tick.
+    .chain(always(respond(ok())))
 
-export const toggleFullscreen: Task<Never, Result<Error, void>> =
-  send({type: "toggle-fullscreen-native-window"})
-  // We do not get event back when window is maximized so we just pretend
-  // that we got it after a tick.
-  .chain(always(respond(ok())));
+export const toggleFullscreen:Task<Never, Result<Error, void>> = send({ type: "toggle-fullscreen-native-window" })
+// We do not get event back when window is maximized so we just pretend
+// that we got it after a tick.
+    .chain(always(respond(ok())));
 
-export const reload: Task<Never, Result<Error, void>> =
-  new Task(succeed => {
-    try {
-      window.location.reload();
-      succeed(ok());
-    } catch (e) {
-      succeed(error(e));
-    }
-  });
+export const reload:Task<Never, Result<Error, void>> = new Task(succeed => {
+  try {
+    window.location.reload();
+    succeed(ok());
+  } catch (e) {
+    succeed(error(e));
+  }
+});
 
 
-export const restart: Task<Never, Result<Error, void>> =
-  send({type: "restart"})
-  .chain(always(respond(error(Error(`Unsupported runtime task "restart" was triggered`)))));
+export const restart:Task<Never, Result<Error, void>> = send({ type: "restart" })
+    .chain(always(respond(error(Error(`Unsupported runtime task "restart" was triggered`)))));
 
-export const cleanRestart: Task<Never, Result<Error, void>> =
-  send({type: "clear-cache-and-restart"})
-  .chain(always(never));
+export const cleanRestart:Task<Never, Result<Error, void>> = send({ type: "clear-cache-and-restart" })
+    .chain(always(never));
 
-export const cleanReload: Task<Never, Result<Error, void>> =
-  ( isServo
-  ? new Task(succeed => {
+export const cleanReload:Task<Never, Result<Error, void>> = ( isServo ? new Task(succeed => {
       try {
         window.location.reload(true);
         succeed(ok(void(0)));
       } catch (reason) {
         succeed(error(reason));
       }
-    })
-  : send({type: "clear-cache-and-reload"})
-    .chain(always(never))
-  );
+    }) : send({ type: "clear-cache-and-reload" })
+        .chain(always(never))
+);
 
 // This is a temporary measure. Eventually, we want Servo to expose the
 // titlebar configuration.
 const platform = OS.platform()
-export const useNativeTitlebar =
-  (): boolean =>
-  platform != "darwin";
+export const useNativeTitlebar = ():boolean =>platform != "darwin";
 
-const Env =
-  () => {
-    const url = URL.parse(window.location.href);
-    const params = url.searchParams;
-    if (params != null && Symbol.iterator in params) {
-      const env = Object.create(null);
-      for (let [key, value] of params) {
-        if (env[key] == null) {
-          env[key] = value;
-        }
-        else if (Array.isArray(env[key])) {
-          env[key].push(value)
-        }
-        else {
-          env[key] = [env[key], value]
-        }
+const Env = () => {
+  const url = URL.parse(window.location.href);
+  const params = url.searchParams;
+  if (params != null && Symbol.iterator in params) {
+    const env = Object.create(null);
+    for (let [key, value] of params) {
+      if (env[key] == null) {
+        env[key] = value;
+      } else if (Array.isArray(env[key])) {
+        env[key].push(value)
+      } else {
+        env[key] = [env[key], value]
       }
-      return env
     }
-    else {
-      return QueryString.parse(url.search.substr(1));
-    }
+    return env
+  } else {
+    return QueryString.parse(url.search.substr(1));
   }
+}
 
 export const env/*:{[key:string]: ?string|?Array<?string>}*/ = Env();

--- a/src/common/selector.js
+++ b/src/common/selector.js
@@ -5,25 +5,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /*::
-import type {Integer} from "../common/prelude"
-*/
+ import type {Integer} from "../common/prelude"
+ */
 
 // Returns position that is `offset` by given number from the given `index` if
 // total number of items is equal to given `size`. If `loop` is true and offset
 // is out of bounds position is calculated by looping. Otherwise last / first
 // index is retuned.
-export const indexOfOffset =
-  ( index: Integer
-  , offset: Integer
-  , size: Integer
-  , loop: boolean
-  ): Integer => {
+export const indexOfOffset = (index:Integer, offset:Integer, size:Integer, loop:boolean):Integer => {
   const position = index + offset;
   if (size === 0) {
     return index
   } else if (loop) {
     const index = position - Math.trunc(position / size) * size
-    return index < 0 ? index + size :  index
+    return index < 0 ? index + size : index
   } else {
     return Math.min(size - 1, Math.max(0, position))
   }

--- a/src/common/selector.js
+++ b/src/common/selector.js
@@ -13,11 +13,11 @@ import type {Integer} from "../common/prelude"
 // is out of bounds position is calculated by looping. Otherwise last / first
 // index is retuned.
 export const indexOfOffset =
-  ( index/*:Integer*/
-  , offset/*:Integer*/
-  , size/*:Integer*/
-  , loop/*:boolean*/
-  )/*:Integer*/ => {
+  ( index: Integer
+  , offset: Integer
+  , size: Integer
+  , loop: boolean
+  ): Integer => {
   const position = index + offset;
   if (size === 0) {
     return index

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -4,142 +4,114 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {error, ok} from '../common/result';
-import * as Unknown from '../common/unknown';
-import {merge, always} from '../common/prelude';
-import {Effects, Task} from 'reflex';
+import { error, ok } from '../common/result'
+import * as Unknown from '../common/unknown'
+import { merge, always } from '../common/prelude'
+import { Effects, Task } from 'reflex'
 
 /*::
-import type {Model, Action, Name, Value, Settings} from "./settings"
-import type {Address, Never} from "reflex"
-import type {Result} from "./result"
-*/
+ import type {Model, Action, Name, Value, Settings} from "./settings"
+ import type {Address, Never} from "reflex"
+ import type {Result} from "./result"
+ */
 
 
-const NotSupported =
-  ReferenceError('navigator.mozSettings API is not available');
+const NotSupported = ReferenceError('navigator.mozSettings API is not available');
 
-export const Fetched =
-  (result: Result<Error, Settings>): Action =>
-  ( { type: "Fetched"
-    , result
-    }
-  );
+export const Fetched = (result:Result<Error, Settings>):Action =>( {
+  type: "Fetched", result
+}
+);
 
-export const Updated =
-  (result: Result<Error, Settings>): Action =>
-  ( { type: "Updated"
-    , result
-    }
-  );
+export const Updated = (result:Result<Error, Settings>):Action =>( {
+  type: "Updated", result
+}
+);
 
-export const Changed =
-  (result: Result<Error, Settings>): Action =>
-  ( { type: "Changed"
-    , result
-    }
-  );
+export const Changed = (result:Result<Error, Settings>):Action =>( {
+  type: "Changed", result
+}
+);
 
-const merges =
-  records =>
-  ( records.length === 1
-  ? records[0]
-  : records.reduce
-    ( (result, record) => {
-        for (let name in record) {
-          if (record.hasOwnProperty(name)) {
-            result[name] = record[name]
-          }
+const merges = records =>( records.length === 1 ? records[0] : records.reduce((result, record) => {
+      for (let name in record) {
+        if (record.hasOwnProperty(name)) {
+          result[name] = record[name]
         }
-        return result
       }
-    )
-  );
+      return result
+    })
+);
 
-export const fetch =
-  (names: Array<Name>): Task<Never, Result<Error, Settings>> =>
-  new Task((succeed, fail) => {
-    if (navigator.mozSettings != null) {
-      const lock = navigator.mozSettings.createLock();
-      const settings = names.map(name => lock.get(name));
-      Promise
+export const fetch = (names:Array<Name>):Task<Never, Result<Error, Settings>> =>new Task((succeed, fail) => {
+  if (navigator.mozSettings != null) {
+    const lock = navigator.mozSettings.createLock();
+    const settings = names.map(name => lock.get(name));
+    Promise
         .all(settings)
         .then(merges)
         .then(ok, error)
         .then(succeed, fail);
-    } else {
-      Promise
+  } else {
+    Promise
         .resolve(error(NotSupported))
         .then(succeed, fail);
-    }
-  });
+  }
+});
 
 
-export const change =
-  (settings: Settings): Task<Never, Result<Error, Settings>> =>
-  new Task((succeed, fail) => {
-    if (navigator.mozSettings != null) {
-      const lock = navigator.mozSettings.createLock();
-      lock
+export const change = (settings:Settings):Task<Never, Result<Error, Settings>> =>new Task((succeed, fail) => {
+  if (navigator.mozSettings != null) {
+    const lock = navigator.mozSettings.createLock();
+    lock
         .set(settings)
         .then(always(ok(settings)), error)
         .then(succeed, fail);
-    } else {
-      Promise
+  } else {
+    Promise
         .resolve(error(NotSupported))
         .then(succeed, fail);
-    }
-  });
+  }
+});
 
-export const observe =
-  (namePattern: string): Task<Never, Result<Error, Settings>>=>
-  new Task((succeed, fail) => {
-    const onChange = change => {
-      if (navigator.mozSettings) {
-        if (namePattern === "*") {
-          navigator.mozSettings.removeEventListener("settingchange", onChange);
-        }
-        else {
-          navigator.mozSettings.removeObserver(namePattern, onChange);
-        }
-      }
-
-      succeed(ok({[change.settingName]: change.settingValue}));
-    }
-
+export const observe = (namePattern:string):Task < Never, Result < Error, Settings >> =>new Task((succeed, fail) => {
+  const onChange = change => {
     if (navigator.mozSettings) {
       if (namePattern === "*") {
-        navigator.mozSettings.addEventListener("settingchange", onChange);
+        navigator.mozSettings.removeEventListener("settingchange", onChange);
+      } else {
+        navigator.mozSettings.removeObserver(namePattern, onChange);
       }
-      else {
-        navigator.mozSettings.addObserver(namePattern, onChange);
-      }
-    } else {
-      fail(error(NotSupported));
     }
-  });
+
+    succeed(ok({ [change.settingName]: change.settingValue }));
+  }
+
+  if (navigator.mozSettings) {
+    if (namePattern === "*") {
+      navigator.mozSettings.addEventListener("settingchange", onChange);
+    } else {
+      navigator.mozSettings.addObserver(namePattern, onChange);
+    }
+  } else {
+    fail(error(NotSupported));
+  }
+});
 
 
-export const init =
-  (names: Array<Name>): [Model, Effects<Action>] =>
-  [ null
-  , Effects
-    .perform(fetch(names))
-    .map(Fetched)
-  ];
+export const init = (names:Array<Name>):[Model, Effects<Action>] =>[
+  null, Effects
+      .perform(fetch(names))
+      .map(Fetched)
+];
 
-const updateSettings = (model, settings) =>
-  // @TODO: Ignore unknown settings
-  [ ( model == null
-    ? settings
-    : merge(model, settings)
-    )
-  , Effects.batch
-    ( Object
-      .keys(settings)
-      .map(name => Effects.perform(observe(name)).map(Updated))
-    )
-  ];
+const updateSettings = (model, settings) =>// @TODO: Ignore unknown settings
+    [
+      ( model == null ? settings : merge(model, settings)
+      ), Effects.batch(Object
+                           .keys(settings)
+                           .map(name => Effects.perform(observe(name)).map(Updated)))
+    ];
 
 const report = (model, error) => {
   console.error(`Unhandled error occured `, error);
@@ -147,22 +119,14 @@ const report = (model, error) => {
 }
 
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] =>
-  ( action.type === 'Fetched'
-  ? ( action.result.isOk
-    ? updateSettings(model, action.result.value)
-    : report(model, action.result.error)
+export const update = (model:Model, action:Action):[Model, Effects<Action>] =>( action.type === 'Fetched'
+        ? ( action.result.isOk ? updateSettings(model, action.result.value) : report(model, action.result.error)
     )
-  : action.type === 'Updated'
-  ? ( action.result.isOk
-    ? updateSettings(model, action.result.value)
-    : report(model, action.result.error)
+        : action.type === 'Updated'
+        ? ( action.result.isOk ? updateSettings(model, action.result.value) : report(model, action.result.error)
     )
-  : action.type === 'Changed'
-  ? ( action.result.isOk
-    ? updateSettings(model, action.result.value)
-    : report(model, action.result.error)
+        : action.type === 'Changed'
+        ? ( action.result.isOk ? updateSettings(model, action.result.value) : report(model, action.result.error)
     )
-  : Unknown.update(model, action)
-  );
+        : Unknown.update(model, action)
+);

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -20,21 +20,21 @@ const NotSupported =
   ReferenceError('navigator.mozSettings API is not available');
 
 export const Fetched =
-  (result/*:Result<Error, Settings>*/)/*:Action*/ =>
+  (result: Result<Error, Settings>): Action =>
   ( { type: "Fetched"
     , result
     }
   );
 
 export const Updated =
-  (result/*:Result<Error, Settings>*/)/*:Action*/ =>
+  (result: Result<Error, Settings>): Action =>
   ( { type: "Updated"
     , result
     }
   );
 
 export const Changed =
-  (result/*:Result<Error, Settings>*/)/*:Action*/ =>
+  (result: Result<Error, Settings>): Action =>
   ( { type: "Changed"
     , result
     }
@@ -57,7 +57,7 @@ const merges =
   );
 
 export const fetch =
-  (names/*:Array<Name>*/)/*:Task<Never, Result<Error, Settings>>*/ =>
+  (names: Array<Name>): Task<Never, Result<Error, Settings>> =>
   new Task((succeed, fail) => {
     if (navigator.mozSettings != null) {
       const lock = navigator.mozSettings.createLock();
@@ -76,7 +76,7 @@ export const fetch =
 
 
 export const change =
-  (settings/*:Settings*/)/*:Task<Never, Result<Error, Settings>>*/ =>
+  (settings: Settings): Task<Never, Result<Error, Settings>> =>
   new Task((succeed, fail) => {
     if (navigator.mozSettings != null) {
       const lock = navigator.mozSettings.createLock();
@@ -92,7 +92,7 @@ export const change =
   });
 
 export const observe =
-  (namePattern/*:string*/)/*:Task<Never, Result<Error, Settings>>*/=>
+  (namePattern: string): Task<Never, Result<Error, Settings>>=>
   new Task((succeed, fail) => {
     const onChange = change => {
       if (navigator.mozSettings) {
@@ -121,7 +121,7 @@ export const observe =
 
 
 export const init =
-  (names/*:Array<Name>*/)/*:[Model, Effects<Action>]*/ =>
+  (names: Array<Name>): [Model, Effects<Action>] =>
   [ null
   , Effects
     .perform(fetch(names))
@@ -148,7 +148,7 @@ const report = (model, error) => {
 
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model: Model, action: Action): [Model, Effects<Action>] =>
   ( action.type === 'Fetched'
   ? ( action.result.isOk
     ? updateSettings(model, action.result.value)

--- a/src/common/stopwatch.js
+++ b/src/common/stopwatch.js
@@ -12,10 +12,10 @@ import * as Unknown from "../common/unknown";
 import type {Action, Model, Time} from "./stopwatch"
 */
 
-export const Start/*:Action*/ = {type: "Start"};
-export const End/*:Action*/ = {type: "End"};
+export const Start: Action = {type: "Start"};
+export const End: Action = {type: "End"};
 export const Tick =
-  (time/*:Time*/)/*:Action*/ =>
+  (time: Time): Action =>
   ( { type: "Tick"
     , time
     }
@@ -23,11 +23,11 @@ export const Tick =
 
 
 export const init =
-  ()/*:[Model, Effects<Action>]*/ =>
+  (): [Model, Effects<Action>] =>
   [null, Effects.none];
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model: Model, action: Action): [Model, Effects<Action>] =>
   ( action.type === "End"
   ? [ null, Effects.none ]
   : action.type === "Start"

--- a/src/common/stopwatch.js
+++ b/src/common/stopwatch.js
@@ -4,48 +4,44 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Effects, Task} from 'reflex';
-import {merge, always} from "../common/prelude";
-import * as Unknown from "../common/unknown";
+import { Effects, Task } from 'reflex'
+import { merge } from '../common/prelude'
+import * as Unknown from '../common/unknown'
 
 /*::
-import type {Action, Model, Time} from "./stopwatch"
-*/
+ import type {Action, Model, Time} from "./stopwatch"
+ */
 
-export const Start: Action = {type: "Start"};
-export const End: Action = {type: "End"};
-export const Tick =
-  (time: Time): Action =>
-  ( { type: "Tick"
-    , time
-    }
-  );
+export const Start:Action = { type: "Start" };
+export const End:Action = { type: "End" };
+export const Tick = (time:Time):Action =>( {
+  type: "Tick", time
+}
+);
 
 
-export const init =
-  (): [Model, Effects<Action>] =>
-  [null, Effects.none];
+export const init = ():[Model, Effects<Action>] =>[null, Effects.none];
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] =>
-  ( action.type === "End"
-  ? [ null, Effects.none ]
-  : action.type === "Start"
-  ? [ null, Effects.perform(Task.requestAnimationFrame().map(Tick)) ]
-  : action.type === "Tick"
-  ? ( model == null
-    ? [ {
-          time: action.time,
-          elapsed: 0
-        }
-      , Effects.perform(Task.requestAnimationFrame().map(Tick))
-      ]
-    : [ merge(model, {
-          time: action.time,
-          elapsed: model.elapsed + (action.time - model.time)
-        })
-      , Effects.perform(Task.requestAnimationFrame().map(Tick))
-      ]
+export const update = (model:Model, action:Action):[Model, Effects<Action>] =>( action.type === "End"
+        ? [
+      null,
+      Effects.none
+    ]
+        : action.type === "Start"
+        ? [
+      null,
+      Effects.perform(Task.requestAnimationFrame().map(Tick))
+    ]
+        : action.type === "Tick"
+        ? ( model == null ? [
+          {
+            time: action.time, elapsed: 0
+          }, Effects.perform(Task.requestAnimationFrame().map(Tick))
+        ] : [
+          merge(model, {
+            time: action.time, elapsed: model.elapsed + (action.time - model.time)
+          }), Effects.perform(Task.requestAnimationFrame().map(Tick))
+        ]
     )
-  : Unknown.update(model, action)
-  );
+        : Unknown.update(model, action)
+);

--- a/src/common/style.js
+++ b/src/common/style.js
@@ -5,8 +5,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /*::
-import type {Rules, Sheet} from "./style"
-*/
+ import type {Rules, Sheet} from "./style"
+ */
 
 const composedStyles = Object.create(null);
 
@@ -14,7 +14,7 @@ const ID = Symbol('style-sheet/id');
 var id = 0;
 
 export const StyleSheet = {
-  create: /*::<sheet:Sheet>*/(sheet: sheet): sheet => {
+  create: /*::<sheet:Sheet>*/(sheet:sheet):sheet => {
     const result = {}
     for (var name in sheet) {
       if (sheet.hasOwnProperty(name)) {
@@ -23,8 +23,7 @@ export const StyleSheet = {
           // @FlowIssue: Flow does not work with symbols
           style[ID] = ++id;
           result[name] = style;
-        }
-        else {
+        } else {
           result[name] = style;
         }
       }
@@ -38,7 +37,7 @@ export const StyleSheet = {
 // Mix multiple style objects together. Will memoize the combination of styles
 // to minimize object creation. Returns style object that is the result of
 // mixing styles together.
-export function mix (...styles: Array<?Rules>): Rules {
+export function mix(...styles:Array<?Rules>):Rules {
   var length = styles.length;
   var index = 0;
   var id = null;
@@ -60,21 +59,17 @@ export function mix (...styles: Array<?Rules>): Rules {
     }
   }
 
-  const composedStyle = id !== null ?
-    composedStyles[id/*::.toString()*/] :
-    null;
+  const composedStyle = id !== null ? composedStyles[id/*::.toString()*/] : null;
 
   if (composedStyle != null) {
     return composedStyle
-  }
-  else if (id != null) {
+  } else if (id != null) {
     const composedStyle = Object.assign({}, ...styles);
     // @FlowIssue: Flow does not get spread here.
     composedStyle[ID] = id;
     composedStyles[id/*::.toString()*/] = composedStyle;
     return composedStyle;
-  }
-  else {
+  } else {
     const composedStyle = Object.assign({}, ...styles);
     // @FlowIssue: Flow does not get spread here.
     composedStyle[ID] = null;

--- a/src/common/style.js
+++ b/src/common/style.js
@@ -14,7 +14,7 @@ const ID = Symbol('style-sheet/id');
 var id = 0;
 
 export const StyleSheet = {
-  create: /*::<sheet:Sheet>*/(sheet/*:sheet*/)/*:sheet*/ => {
+  create: /*::<sheet:Sheet>*/(sheet: sheet): sheet => {
     const result = {}
     for (var name in sheet) {
       if (sheet.hasOwnProperty(name)) {
@@ -38,7 +38,7 @@ export const StyleSheet = {
 // Mix multiple style objects together. Will memoize the combination of styles
 // to minimize object creation. Returns style object that is the result of
 // mixing styles together.
-export const mix = (...styles/*:Array<?Rules>*/)/*:Rules*/ => {
+export function mix (...styles: Array<?Rules>): Rules {
   var length = styles.length;
   var index = 0;
   var id = null;

--- a/src/common/target.js
+++ b/src/common/target.js
@@ -5,22 +5,27 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {Effects} from "reflex";
-import {merge} from "../common/prelude";
-import * as Unknown from "../common/unknown";
+import { Effects } from 'reflex'
+import { merge } from '../common/prelude'
+import * as Unknown from '../common/unknown'
 
 /*::
-import type {Action, Model} from "./target"
-*/
+ import type {Action, Model} from "./target"
+ */
 
-export const Over: Action = {type: "Over"};
-export const Out: Action = {type: "Out"};
+export const Over:Action = { type: "Over" };
+export const Out:Action = { type: "Out" };
 
 export const update = /*::<model:Model>*/
-  (model: model, action: Action): [model, Effects<Action>] =>
-  ( action.type == "Over"
-  ? [merge(model, {isPointerOver: true}), Effects.none]
-  : action.type == "Out"
-  ? [merge(model, {isPointerOver: false}), Effects.none]
-  : Unknown.update(model, action)
-  );
+    (model:model, action:Action):[model, Effects<Action>] =>( action.type == "Over"
+            ? [
+          merge(model, { isPointerOver: true }),
+          Effects.none
+        ]
+            : action.type == "Out"
+            ? [
+          merge(model, { isPointerOver: false }),
+          Effects.none
+        ]
+            : Unknown.update(model, action)
+    );

--- a/src/common/target.js
+++ b/src/common/target.js
@@ -13,11 +13,11 @@ import * as Unknown from "../common/unknown";
 import type {Action, Model} from "./target"
 */
 
-export const Over/*:Action*/ = {type: "Over"};
-export const Out/*:Action*/ = {type: "Out"};
+export const Over: Action = {type: "Over"};
+export const Out: Action = {type: "Out"};
 
 export const update = /*::<model:Model>*/
-  (model/*:model*/, action/*:Action*/)/*:[model, Effects<Action>]*/ =>
+  (model: model, action: Action): [model, Effects<Action>] =>
   ( action.type == "Over"
   ? [merge(model, {isPointerOver: true}), Effects.none]
   : action.type == "Out"

--- a/src/common/text-input.js
+++ b/src/common/text-input.js
@@ -25,7 +25,7 @@ import type {Action, Model, StyleSheet, ContextStyle} from './text-input'
 
 const EditableAction = tag("Editable");
 const FocusableAction =
-  (action/*:Focusable.Action*/)/*:Action*/ =>
+  (action: Focusable.Action): Action =>
   ( action.type === "Focus"
   ? Focus
   : action.type === "Blur"
@@ -35,18 +35,18 @@ const FocusableAction =
 const ControlAction = tag("Control");
 
 export const Change = Editable.Change;
-export const Focus/*:Action*/ = { type: "Focus" };
-export const Blur/*:Action*/ = { type: "Blur" };
-export const Enable/*:Action*/ = ControlAction(Control.Enable);
-export const Disable/*:Action*/ = ControlAction(Control.Disable);
+export const Focus: Action = { type: "Focus" };
+export const Blur: Action = { type: "Blur" };
+export const Enable: Action = ControlAction(Control.Enable);
+export const Disable: Action = ControlAction(Control.Disable);
 
 
 export const init =
-  ( value/*:string*/=''
-  , selection/*:?Editable.Selection*/=null
-  , placeholder/*:string*/=''
-  , isDisabled/*:boolean*/=false
-  )/*:[Model, Effects<Action>]*/ =>
+  ( value: string=''
+  , selection: ?Editable.Selection=null
+  , placeholder: string=''
+  , isDisabled: boolean=false
+  ): [Model, Effects<Action>] =>
   [ { value
     , placeholder
     , selection
@@ -87,7 +87,7 @@ const updateControl = cursor
   );
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model: Model, action: Action): [Model, Effects<Action>] =>
   ( action.type === 'Change'
   ? updateEditable(model, action)
   : action.type === 'Editable'
@@ -122,11 +122,11 @@ const decodeChange = compose
 
 
 export const view =
-  (key/*:string*/, styleSheet/*:StyleSheet*/)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>
-  ( model/*:Model*/
-  , address/*:Address<Action>*/
+  (key: string, styleSheet: StyleSheet)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>
+  ( model: Model
+  , address: Address<Action>
   , contextStyle/*?:ContextStyle*/
-  )/*:DOM*/ =>
+  ): DOM =>
   html.input
   ( { key
     , type: 'input'

--- a/src/common/text-input.js
+++ b/src/common/text-input.js
@@ -4,153 +4,110 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, forward, Effects} from 'reflex';
-import {Style} from '../common/style';
-import {compose} from '../lang/functional';
-import {tag, tagged, merge, always} from '../common/prelude';
-import {cursor} from "../common/cursor"
-import * as Unknown from '../common/unknown';
-import * as Focusable from '../common/focusable';
-import * as Editable from '../common/editable';
-import * as Control from '../common/control';
-
-import {on, focus, selection} from '@driver';
+import { html, forward, Effects } from 'reflex'
+import { Style } from '../common/style'
+import { compose } from '../lang/functional'
+import { tag, tagged, merge, always } from '../common/prelude'
+import { cursor } from '../common/cursor'
+import * as Unknown from '../common/unknown'
+import * as Focusable from '../common/focusable'
+import * as Editable from '../common/editable'
+import * as Control from '../common/control'
+import { on, focus, selection } from '@driver'
 
 /*::
-import type {Address, DOM} from "reflex"
-import type {Action, Model, StyleSheet, ContextStyle} from './text-input'
-*/
-
+ import type {Address, DOM} from "reflex"
+ import type {Action, Model, StyleSheet, ContextStyle} from './text-input'
+ */
 
 
 const EditableAction = tag("Editable");
-const FocusableAction =
-  (action: Focusable.Action): Action =>
-  ( action.type === "Focus"
-  ? Focus
-  : action.type === "Blur"
-  ? Blur
-  : tagged("Focusable", action)
-  );
+const FocusableAction = (action:Focusable.Action):Action =>( action.type === "Focus"
+        ? Focus
+        : action.type === "Blur"
+        ? Blur
+        : tagged("Focusable", action)
+);
 const ControlAction = tag("Control");
 
 export const Change = Editable.Change;
-export const Focus: Action = { type: "Focus" };
-export const Blur: Action = { type: "Blur" };
-export const Enable: Action = ControlAction(Control.Enable);
-export const Disable: Action = ControlAction(Control.Disable);
+export const Focus:Action = { type: "Focus" };
+export const Blur:Action = { type: "Blur" };
+export const Enable:Action = ControlAction(Control.Enable);
+export const Disable:Action = ControlAction(Control.Disable);
 
 
-export const init =
-  ( value: string=''
-  , selection: ?Editable.Selection=null
-  , placeholder: string=''
-  , isDisabled: boolean=false
-  ): [Model, Effects<Action>] =>
-  [ { value
-    , placeholder
-    , selection
-    , isDisabled
-    , isFocused: false
-    }
-  , Effects.none
-  ];
+export const init = (value:string = '', selection:?Editable.Selection = null, placeholder:string = '',
+                     isDisabled:boolean = false):[Model, Effects<Action>] =>[
+  {
+    value, placeholder, selection, isDisabled, isFocused: false
+  }, Effects.none
+];
 
-const enable =
-  model =>
-  [ merge(model, {isDisabled: false})
-  , Effects.none
-  ];
+const enable = model =>[
+  merge(model, { isDisabled: false }), Effects.none
+];
 
-const disable =
-  model =>
-  [ merge(model, {isDisabled: true})
-  , Effects.none
-  ];
+const disable = model =>[
+  merge(model, { isDisabled: true }), Effects.none
+];
 
-const updateEditable = cursor
-  ( { tag: EditableAction
-    , update: Editable.update
-    }
-  );
+const updateEditable = cursor({
+                                tag: EditableAction, update: Editable.update
+                              });
 
-const updateFocusable = cursor
-  ( { tag: FocusableAction
-    , update: Focusable.update
-    }
-  );
+const updateFocusable = cursor({
+                                 tag: FocusableAction, update: Focusable.update
+                               });
 
-const updateControl = cursor
-  ( { tag: ControlAction
-    , update: Control.update
-    }
-  );
+const updateControl = cursor({
+                               tag: ControlAction, update: Control.update
+                             });
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] =>
-  ( action.type === 'Change'
-  ? updateEditable(model, action)
-  : action.type === 'Editable'
-  ? updateEditable(model, action.source)
-  : action.type === 'Focusable'
-  ? updateFocusable(model, action.source)
-  : action.type === 'Focus'
-  ? updateFocusable(model, action)
-  : action.type === 'Blur'
-  ? updateFocusable(model, action)
-  : action.type === 'Control'
-  ? updateControl(model, action.source)
-  : Unknown.update(model, action)
-  );
+export const update = (model:Model, action:Action):[Model, Effects<Action>] =>( action.type === 'Change'
+        ? updateEditable(model, action)
+        : action.type === 'Editable'
+        ? updateEditable(model, action.source)
+        : action.type === 'Focusable'
+        ? updateFocusable(model, action.source)
+        : action.type === 'Focus'
+        ? updateFocusable(model, action)
+        : action.type === 'Blur'
+        ? updateFocusable(model, action)
+        : action.type === 'Control'
+        ? updateControl(model, action.source)
+        : Unknown.update(model, action)
+);
 
-const decodeSelection =
-  ({target}) =>
-  ( { start: target.selectionStart
-    , end: target.selectionEnd
-    , direction: target.selectionDirection
-    }
-  );
+const decodeSelection = ({ target }) =>( {
+  start: target.selectionStart, end: target.selectionEnd, direction: target.selectionDirection
+}
+);
 
-const decodeSelect =
-  compose(EditableAction, Editable.Select, decodeSelection);
+const decodeSelect = compose(EditableAction, Editable.Select, decodeSelection);
 
-const decodeChange = compose
-  ( EditableAction
-  , event =>
-    Change(event.target.value, decodeSelection(event))
-  );
+const decodeChange = compose(EditableAction, event =>Change(event.target.value, decodeSelection(event)));
 
 
-export const view =
-  (key: string, styleSheet: StyleSheet)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>
-  ( model: Model
-  , address: Address<Action>
-  , contextStyle/*?:ContextStyle*/
-  ): DOM =>
-  html.input
-  ( { key
-    , type: 'input'
-    , placeholder: model.placeholder
-    , value: model.value
-    , disabled:
-      ( model.isDisabled
-      ? true
-      : void(0)
-      )
-    , isFocused: focus(model.isFocused)
-    , selection: selection(model.selection)
-    , onInput: on(address, decodeChange)
-    , onKeyUp: on(address, decodeSelect)
-    , onSelect: on(address, decodeSelect)
-    , onFocus: forward(address, always(Focus))
-    , onBlur: forward(address, always(Blur))
-    , style: Style
-      ( styleSheet.base
-      , ( model.isDisabled
-        ? styleSheet.disabled
-        : styleSheet.enabled
-        )
-      , contextStyle
-      )
-    }
-  )
+export const view = (key:string,
+                     styleSheet:StyleSheet)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>(model:Model,
+                                                                                                                             address:Address<Action>,
+                                                                                                                             contextStyle
+                                                                                                                             /*?:ContextStyle*/):DOM =>html.input(
+    {
+      key,
+      type: 'input',
+      placeholder: model.placeholder,
+      value: model.value,
+      disabled: ( model.isDisabled ? true : void(0)
+      ),
+      isFocused: focus(model.isFocused),
+      selection: selection(model.selection),
+      onInput: on(address, decodeChange),
+      onKeyUp: on(address, decodeSelect),
+      onSelect: on(address, decodeSelect),
+      onFocus: forward(address, always(Focus)),
+      onBlur: forward(address, always(Blur)),
+      style: Style(styleSheet.base, ( model.isDisabled ? styleSheet.disabled : styleSheet.enabled
+      ), contextStyle)
+    })

--- a/src/common/toggle.js
+++ b/src/common/toggle.js
@@ -21,13 +21,13 @@ import type {Action, Model, StyleSheet, ContextStyle} from "./toggle"
 
 
 export const init =
-  ( isDisabled/*:boolean*/=false
-  , isFocused/*:boolean*/=false
-  , isActive/*:boolean*/=false
-  , isPointerOver/*:boolean*/=false
-  , isChecked/*:boolean*/=false
-  , text/*:string*/=""
-  )/*:[Model, Effects<Action>]*/ =>
+  ( isDisabled: boolean=false
+  , isFocused: boolean=false
+  , isActive: boolean=false
+  , isPointerOver: boolean=false
+  , isChecked: boolean=false
+  , text: string=""
+  ): [Model, Effects<Action>] =>
   [
     { isDisabled,
       isFocused,
@@ -39,22 +39,22 @@ export const init =
   , Effects.none
   ];
 
-export const Press/*:Action*/ = {type: "Press"};
-export const Check/*:Action*/ = {type: "Check"};
-export const Uncheck/*:Action*/ = {type: "Uncheck"};
+export const Press: Action = {type: "Press"};
+export const Check: Action = {type: "Check"};
+export const Uncheck: Action = {type: "Uncheck"};
 
 const TargetAction =action => ({type: "Target", action});
 const FocusableAction = action => ({type: "Focusable", action});
 const ButtonAction = action => ({type: "Button", action});
 
-export const Focus/*:Action*/ = FocusableAction(Focusable.Focus);
-export const Blur/*:Action*/ = FocusableAction(Focusable.Blur);
+export const Focus: Action = FocusableAction(Focusable.Focus);
+export const Blur: Action = FocusableAction(Focusable.Blur);
 
-export const Over/*:Action*/ = TargetAction(Target.Over);
-export const Out/*:Action*/ = TargetAction(Target.Out);
+export const Over: Action = TargetAction(Target.Over);
+export const Out: Action = TargetAction(Target.Out);
 
-export const Down/*:Action*/ = ButtonAction(Button.Down);
-export const Up/*:Action*/ = ButtonAction(Button.Up);
+export const Down: Action = ButtonAction(Button.Down);
+export const Up: Action = ButtonAction(Button.Up);
 
 
 const updateTarget = cursor({
@@ -74,7 +74,7 @@ const updateButton = cursor({
 
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model: Model, action: Action): [Model, Effects<Action>] =>
   ( action.type === "Press"
   ? [ merge(model, {isChecked: !model.isChecked})
     , ( model.isChecked
@@ -102,11 +102,11 @@ export const update =
 
 
 export const view =
-  (key/*:string*/, styleSheet/*:StyleSheet*/)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>
-  ( model/*:Model*/
-  , address/*:Address<Action>*/
+  (key: string, styleSheet: StyleSheet)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>
+  ( model: Model
+  , address: Address<Action>
   , contextStyle/*?:ContextStyle*/
-  )/*:DOM*/ =>
+  ): DOM =>
   html.button({
     key: key,
     className: key,

--- a/src/common/toggle.js
+++ b/src/common/toggle.js
@@ -5,146 +5,113 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {merge, always} from "../common/prelude"
-import {cursor} from "../common/cursor"
-import * as Unknown from "../common/unknown"
-import * as Target from "../common/target"
-import * as Focusable from "../common/focusable"
-import * as Button from "../common/button"
-import {Style} from "../common/style"
-import {html, Effects, forward, Task} from "reflex"
+import { merge, always } from '../common/prelude'
+import { cursor } from '../common/cursor'
+import * as Unknown from '../common/unknown'
+import * as Target from '../common/target'
+import * as Focusable from '../common/focusable'
+import * as Button from '../common/button'
+import { Style } from '../common/style'
+import { html, Effects, forward, Task } from 'reflex'
 
 /*::
-import type {Address, DOM} from "reflex"
-import type {Action, Model, StyleSheet, ContextStyle} from "./toggle"
-*/
+ import type {Address, DOM} from "reflex"
+ import type {Action, Model, StyleSheet, ContextStyle} from "./toggle"
+ */
 
 
-export const init =
-  ( isDisabled: boolean=false
-  , isFocused: boolean=false
-  , isActive: boolean=false
-  , isPointerOver: boolean=false
-  , isChecked: boolean=false
-  , text: string=""
-  ): [Model, Effects<Action>] =>
-  [
-    { isDisabled,
-      isFocused,
-      isActive,
-      isPointerOver,
-      isChecked,
-      text
-    }
-  , Effects.none
-  ];
+export const init = (isDisabled:boolean = false, isFocused:boolean = false, isActive:boolean = false,
+                     isPointerOver:boolean = false, isChecked:boolean = false,
+                     text:string = ""):[Model, Effects<Action>] =>[
+  {
+    isDisabled, isFocused, isActive, isPointerOver, isChecked, text
+  }, Effects.none
+];
 
-export const Press: Action = {type: "Press"};
-export const Check: Action = {type: "Check"};
-export const Uncheck: Action = {type: "Uncheck"};
+export const Press:Action = { type: "Press" };
+export const Check:Action = { type: "Check" };
+export const Uncheck:Action = { type: "Uncheck" };
 
-const TargetAction =action => ({type: "Target", action});
-const FocusableAction = action => ({type: "Focusable", action});
-const ButtonAction = action => ({type: "Button", action});
+const TargetAction = action => ({ type: "Target", action });
+const FocusableAction = action => ({ type: "Focusable", action });
+const ButtonAction = action => ({ type: "Button", action });
 
-export const Focus: Action = FocusableAction(Focusable.Focus);
-export const Blur: Action = FocusableAction(Focusable.Blur);
+export const Focus:Action = FocusableAction(Focusable.Focus);
+export const Blur:Action = FocusableAction(Focusable.Blur);
 
-export const Over: Action = TargetAction(Target.Over);
-export const Out: Action = TargetAction(Target.Out);
+export const Over:Action = TargetAction(Target.Over);
+export const Out:Action = TargetAction(Target.Out);
 
-export const Down: Action = ButtonAction(Button.Down);
-export const Up: Action = ButtonAction(Button.Up);
+export const Down:Action = ButtonAction(Button.Down);
+export const Up:Action = ButtonAction(Button.Up);
 
 
 const updateTarget = cursor({
-  update: Target.update,
-  tag: TargetAction
-});
+                              update: Target.update, tag: TargetAction
+                            });
 
 const updateFocusable = cursor({
-  update: Focusable.update,
-  tag: FocusableAction
-});
+                                 update: Focusable.update, tag: FocusableAction
+                               });
 
 const updateButton = cursor({
-  update: Button.update,
-  tag: ButtonAction
-});
+                              update: Button.update, tag: ButtonAction
+                            });
 
 
-export const update =
-  (model: Model, action: Action): [Model, Effects<Action>] =>
-  ( action.type === "Press"
-  ? [ merge(model, {isChecked: !model.isChecked})
-    , ( model.isChecked
-      ? Effects.perform(Task.succeed(Uncheck))
-      : Effects.perform(Task.succeed(Check))
+export const update = (model:Model, action:Action):[Model, Effects<Action>] =>( action.type === "Press"
+        ? [
+      merge(model, { isChecked: !model.isChecked }),
+      ( model.isChecked ? Effects.perform(Task.succeed(Uncheck)) : Effects.perform(Task.succeed(Check))
       )
     ]
 
-  : action.type === "Check"
-  ? [ merge(model, {isChecked: true })
-    , Effects.none
+        : action.type === "Check"
+        ? [
+      merge(model, { isChecked: true }),
+      Effects.none
     ]
-  : action.type === "Uncheck"
-  ? [ merge(model, {isChecked: false })
-    , Effects.none
+        : action.type === "Uncheck"
+        ? [
+      merge(model, { isChecked: false }),
+      Effects.none
     ]
-  : action.type === "Button"
-  ? updateButton(model, action.action)
-  : action.type === "Target"
-  ? updateTarget(model, action.action)
-  : action.type === "Focusable"
-  ? updateFocusable(model, action.action)
-  : Unknown.update(model, action)
-  );
+        : action.type === "Button"
+        ? updateButton(model, action.action)
+        : action.type === "Target"
+        ? updateTarget(model, action.action)
+        : action.type === "Focusable"
+        ? updateFocusable(model, action.action)
+        : Unknown.update(model, action)
+);
 
 
-export const view =
-  (key: string, styleSheet: StyleSheet)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>
-  ( model: Model
-  , address: Address<Action>
-  , contextStyle/*?:ContextStyle*/
-  ): DOM =>
-  html.button({
-    key: key,
-    className: key,
-    style: Style
-      ( styleSheet.base
+export const view = (key:string,
+                     styleSheet:StyleSheet)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>(model:Model,
+                                                                                                                             address:Address<Action>,
+                                                                                                                             contextStyle
+                                                                                                                             /*?:ContextStyle*/):DOM =>html.button(
+    {
+      key: key, className: key, style: Style(styleSheet.base
 
-      ,   model.isFocused
-        ? styleSheet.focused
-        : styleSheet.blured
+        , model.isFocused ? styleSheet.focused : styleSheet.blured
 
-      ,   model.isDisabled
-        ? styleSheet.disabled
-        : styleSheet.enabled
+        , model.isDisabled ? styleSheet.disabled : styleSheet.enabled
 
 
-      ,  model.isPointerOver
-        ? styleSheet.over
-        : styleSheet.out
+        , model.isPointerOver ? styleSheet.over : styleSheet.out
 
-      ,  model.isActive
-        ? styleSheet.active
-        : styleSheet.inactive
+        , model.isActive ? styleSheet.active : styleSheet.inactive
 
-      ,   model.isChecked
-        ? styleSheet.checked
-        : styleSheet.unchecked
+        , model.isChecked ? styleSheet.checked : styleSheet.unchecked
 
-      , contextStyle
-    ),
+        , contextStyle),
 
-    onFocus: forward(address, always(Focus)),
-    onBlur: forward(address, always(Blur)),
+      onFocus: forward(address, always(Focus)), onBlur: forward(address, always(Blur)),
 
-    onMouseOver: forward(address, always(Over)),
-    onMouseOut: forward(address, always(Out)),
+      onMouseOver: forward(address, always(Over)), onMouseOut: forward(address, always(Out)),
 
-    onMouseDown: forward(address, always(Down)),
-    onMouseUp: forward(address, always(Up)),
+      onMouseDown: forward(address, always(Down)), onMouseUp: forward(address, always(Up)),
 
-    onClick: forward(address, always(Press))
-  });
+      onClick: forward(address, always(Press))
+    });

--- a/src/common/unknown.js
+++ b/src/common/unknown.js
@@ -4,32 +4,32 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Effects, Task} from "reflex";
+import { Effects, Task } from 'reflex'
 /*::
-import type {Action} from "./unknown";
-import type {Never} from "reflex";
-*/
+ import type {Action} from "./unknown";
+ import type {Never} from "reflex";
+ */
 
-export function warn(...params: Array<any>): Task<Never, Action> {
+export function warn(...params:Array<any>):Task<Never, Action> {
   return new Task((succeed, fail) => {
     console.warn(...params);
   });
 }
 
-export function log(...params: Array<any>): Task<Never, Action> {
+export function log(...params:Array<any>):Task<Never, Action> {
   return new Task((succeed, fail) => {
     console.log(...params);
   });
 }
 
-export function error(...params: Array<any>): Task<Never, Action> {
+export function error(...params:Array<any>):Task<Never, Action> {
   return new Task((succeed, fail) => {
     console.error(...params);
   });
 }
 
 
-export function update<M, A>(model: M, action: A): [M, Effects<A>] {
+export function update<M, A>(model:M, action:A):[M, Effects<A>] {
   console.warn('Unknown action was passed & ignored: ', action, Error().stack);
   return [model, Effects.none];
 };

--- a/src/common/unknown.js
+++ b/src/common/unknown.js
@@ -10,27 +10,26 @@ import type {Action} from "./unknown";
 import type {Never} from "reflex";
 */
 
-export const warn =
-  (...params/*:Array<any>*/)/*:Task<Never, Action>*/ =>
-  new Task((succeed, fail) => {
+export function warn(...params: Array<any>): Task<Never, Action> {
+  return new Task((succeed, fail) => {
     console.warn(...params);
   });
+}
 
-export const log =
-  (...params/*:Array<any>*/)/*:Task<Never, Action>*/ =>
-  new Task((succeed, fail) => {
+export function log(...params: Array<any>): Task<Never, Action> {
+  return new Task((succeed, fail) => {
     console.log(...params);
   });
+}
 
-export const error =
-  (...params/*:Array<any>*/)/*:Task<Never, Action>*/ =>
-  new Task((succeed, fail) => {
+export function error(...params: Array<any>): Task<Never, Action> {
+  return new Task((succeed, fail) => {
     console.error(...params);
   });
+}
 
 
-export const update = /*::<model, action>*/
-  (model/*:model*/, action/*:action*/)/*:[model, Effects<action>]*/ => {
-    console.warn('Unknown action was passed & ignored: ', action, Error().stack);
-    return [model, Effects.none];
-  };
+export function update<M, A>(model: M, action: A): [M, Effects<A>] {
+  console.warn('Unknown action was passed & ignored: ', action, Error().stack);
+  return [model, Effects.none];
+};

--- a/src/common/url-helper.js
+++ b/src/common/url-helper.js
@@ -9,7 +9,7 @@ import {URL, nullURL} from "./url"
 import type {URI} from "../common/prelude"
 */
 
-export const parse = (input/*:string*/)/*:URL*/ => {
+export const parse = (input: string): URL => {
   try {
     return new URL(input);
   } catch(_) {
@@ -18,35 +18,35 @@ export const parse = (input/*:string*/)/*:URL*/ => {
 }
 
 export const hasScheme =
-  (input/*:URI*/)/*:boolean*/ =>
+  (input: URI): boolean =>
   !!(rscheme.exec(input) || [])[0];
 
 export const getOrigin =
-  (url/*:URI*/)/*:string*/ =>
+  (url: URI): string =>
   parse(url).origin;
 
 export const getBaseURI =
-  ()/*:URL*/ =>
+  (): URL =>
   new URL('./', location.href);
 
 export const getHostname =
-  (url/*:URI*/)/*:string*/ =>
+  (url: URI): string =>
   parse(url).hostname;
 
 export const getDomainName =
-  (url/*:URI*/)/*:string*/ =>
+  (url: URI): string =>
   getHostname(url).replace(/^www\./, '');
 
 export const getProtocol =
-  (url/*:URI*/)/*:string*/ =>
+  (url: URI): string =>
   parse(url).protocol;
 
 export const getManifestURL =
-  ()/*:URL*/ =>
+  (): URL =>
   new URL('./manifest.webapp', getBaseURI().href);
 
 export const getPathname =
-  (input/*:URI*/)/*:string*/ =>
+  (input: URI): string =>
   parse(input).pathname;
 
 
@@ -56,17 +56,17 @@ const isHttpOrHttps = (url) => {
 }
 
 export const isAboutURL =
-  (url/*:URI*/)/*:boolean*/ =>
+  (url: URI): boolean =>
   parse(url).protocol === 'about:';
 
-export const isPrivileged = (uri/*:URI*/)/*:boolean*/ => {
+export const isPrivileged = (uri: URI): boolean => {
   // FIXME: not safe. White list?
   return uri.startsWith(new URL('./components/about/', getBaseURI().href).href);
 };
 
 const rscheme = /^(?:[a-z\u00a1-\uffff0-9-+]+)(?::|:\/\/)/i;
 
-export const isNotURL = (input/*:string*/)/*:boolean*/ => {
+export const isNotURL = (input: string): boolean => {
   var str = input.trim();
 
   // for cases, ?abc and 'a? b' which should searching query
@@ -99,17 +99,17 @@ const readAboutURL = input =>
   input === 'about:blank' ? input :
   `${getBaseURI()}components/about/${input.replace('about:', '')}/index.html`;
 
-export const read = (input/*:string*/)/*:URI*/ =>
+export const read = (input: string): URI =>
   isNotURL(input) ? readSearchURL(input) :
   !hasScheme(input) ? `http://${input}` :
   isAboutURL(input) ? readAboutURL(input) :
   input;
 
-export const normalize = (uri/*:URI*/)/*:URI*/ =>
+export const normalize = (uri: URI): URI =>
   isAboutURL(uri) ? readAboutURL(uri) :
   uri;
 
-export const resolve = (from/*:URI*/, to/*:URI*/)/*:URI*/ =>
+export const resolve = (from: URI, to: URI): URI =>
   new URL(to, from).href;
 
 const aboutPattern = /\/about\/([^\/]+)\/index.html$/;
@@ -119,7 +119,7 @@ const readAboutTerm = input => {
   return match != null ? match[1] : null;
 }
 
-export const asAboutURI = (uri/*:URI*/)/*:?URI*/ => {
+export const asAboutURI = (uri: URI): ?URI => {
   const base = getBaseURI();
   const {origin, pathname} = new window.URI(uri);
   const about = base.origin === origin ? readAboutTerm(pathname) : null;
@@ -127,7 +127,7 @@ export const asAboutURI = (uri/*:URI*/)/*:?URI*/ => {
 }
 
 // Prettify a URL for display purposes. Will minimize the amount of URL cruft.
-export const prettify = (input/*:URI*/)/*:string*/ =>
+export const prettify = (input: URI): string =>
   // Don't mess with non-urls.
   ( isNotURL(input)
   ? input

--- a/src/common/url-helper.js
+++ b/src/common/url-helper.js
@@ -4,69 +4,51 @@
  * license, v. 2.0. if a copy of the mpl was not distributed with this
  * file, you can obtain one at http://mozilla.org/mpl/2.0/. */
 
-import {URL, nullURL} from "./url"
+import { URL, nullURL } from './url'
 /*::
-import type {URI} from "../common/prelude"
-*/
+ import type {URI} from "../common/prelude"
+ */
 
-export const parse = (input: string): URL => {
+export const parse = (input:string):URL => {
   try {
     return new URL(input);
-  } catch(_) {
+  } catch (_) {
     return nullURL;
   }
 }
 
-export const hasScheme =
-  (input: URI): boolean =>
-  !!(rscheme.exec(input) || [])[0];
+export const hasScheme = (input:URI):boolean =>!!(rscheme.exec(input) || [])[0];
 
-export const getOrigin =
-  (url: URI): string =>
-  parse(url).origin;
+export const getOrigin = (url:URI):string =>parse(url).origin;
 
-export const getBaseURI =
-  (): URL =>
-  new URL('./', location.href);
+export const getBaseURI = ():URL =>new URL('./', location.href);
 
-export const getHostname =
-  (url: URI): string =>
-  parse(url).hostname;
+export const getHostname = (url:URI):string =>parse(url).hostname;
 
-export const getDomainName =
-  (url: URI): string =>
-  getHostname(url).replace(/^www\./, '');
+export const getDomainName = (url:URI):string =>getHostname(url).replace(/^www\./, '');
 
-export const getProtocol =
-  (url: URI): string =>
-  parse(url).protocol;
+export const getProtocol = (url:URI):string =>parse(url).protocol;
 
-export const getManifestURL =
-  (): URL =>
-  new URL('./manifest.webapp', getBaseURI().href);
+export const getManifestURL = ():URL =>new URL('./manifest.webapp', getBaseURI().href);
 
-export const getPathname =
-  (input: URI): string =>
-  parse(input).pathname;
+export const getPathname = (input:URI):string =>parse(input).pathname;
 
 
 const isHttpOrHttps = (url) => {
-  const {protocol} = parse(url);
+  const { protocol } = parse(url);
   return (protocol === 'http:' || protocol === 'https:');
 }
 
-export const isAboutURL =
-  (url: URI): boolean =>
-  parse(url).protocol === 'about:';
+export const isAboutURL = (url:URI):boolean =>parse(url).protocol === 'about:';
 
-export const isPrivileged = (uri: URI): boolean => {
+export const isPrivileged = (uri:URI):boolean => {
   // FIXME: not safe. White list?
   return uri.startsWith(new URL('./components/about/', getBaseURI().href).href);
 };
 
 const rscheme = /^(?:[a-z\u00a1-\uffff0-9-+]+)(?::|:\/\/)/i;
 
-export const isNotURL = (input: string): boolean => {
+export const isNotURL = (input:string):boolean => {
   var str = input.trim();
 
   // for cases, ?abc and 'a? b' which should searching query
@@ -92,25 +74,22 @@ export const isNotURL = (input: string): boolean => {
   }
 }
 
-const readSearchURL = input =>
-  `https://duckduckgo.com/?q=${encodeURIComponent(input)}`;
+const readSearchURL = input =>`https://duckduckgo.com/?q=${encodeURIComponent(input)}`;
 
-const readAboutURL = input =>
-  input === 'about:blank' ? input :
-  `${getBaseURI()}components/about/${input.replace('about:', '')}/index.html`;
+const readAboutURL = input =>input === 'about:blank' ? input : `${getBaseURI()}components/about/${input.replace(
+    'about:', '')}/index.html`;
 
-export const read = (input: string): URI =>
-  isNotURL(input) ? readSearchURL(input) :
-  !hasScheme(input) ? `http://${input}` :
-  isAboutURL(input) ? readAboutURL(input) :
-  input;
+export const read = (input:string):URI =>isNotURL(input)
+    ? readSearchURL(input)
+    : !hasScheme(input)
+    ? `http://${input}`
+    : isAboutURL(input)
+    ? readAboutURL(input)
+    : input;
 
-export const normalize = (uri: URI): URI =>
-  isAboutURL(uri) ? readAboutURL(uri) :
-  uri;
+export const normalize = (uri:URI):URI =>isAboutURL(uri) ? readAboutURL(uri) : uri;
 
-export const resolve = (from: URI, to: URI): URI =>
-  new URL(to, from).href;
+export const resolve = (from:URI, to:URI):URI =>new URL(to, from).href;
 
 const aboutPattern = /\/about\/([^\/]+)\/index.html$/;
 
@@ -119,24 +98,20 @@ const readAboutTerm = input => {
   return match != null ? match[1] : null;
 }
 
-export const asAboutURI = (uri: URI): ?URI => {
+export const asAboutURI = (uri:URI):?URI => {
   const base = getBaseURI();
-  const {origin, pathname} = new window.URI(uri);
+  const { origin, pathname } = new window.URI(uri);
   const about = base.origin === origin ? readAboutTerm(pathname) : null;
   return about != null ? `about:${about}` : null;
 }
 
 // Prettify a URL for display purposes. Will minimize the amount of URL cruft.
-export const prettify = (input: URI): string =>
-  // Don't mess with non-urls.
-  ( isNotURL(input)
-  ? input
-  // Don't mess with `about:`, `data:`, etc.
-  : !isHttpOrHttps(input)
-  ? input
-  // If there's a meaningful pathname, keep it.
-  : getPathname(input) !== '/'
-  ? `${getHostname(input)}${getPathname(input)}`
-  // Otherwise, just show the hostname
-  : `${getHostname(input)}`
-  );
+export const prettify = (input:URI):string =>// Don't mess with non-urls.
+    ( isNotURL(input) ? input
+            // Don't mess with `about:`, `data:`, etc.
+            : !isHttpOrHttps(input) ? input
+            // If there's a meaningful pathname, keep it.
+            : getPathname(input) !== '/' ? `${getHostname(input)}${getPathname(input)}`
+            // Otherwise, just show the hostname
+            : `${getHostname(input)}`
+    );

--- a/src/common/url.js
+++ b/src/common/url.js
@@ -6,29 +6,29 @@
 
 export const URL = window.URL;
 export const URLSearchParams = window.URLSearchParams;
-export const nullURL =
-  { href: ''
-  , origin: ''
-  , protocol: ''
-  , username: ''
-  , password: ''
-  , host: ''
-  , hostname: ''
-  , port: ''
-  , pathname: ''
-  , search: ''
-  , hash: ''
-  , searchParams:
-    ( window.URLSearchParams != null
-    ? new window.URLSearchParams()
-    : { append() { throw Error('Not Implemented') }
-      , delete() { throw Error('Not Implemented') }
-      , get() { return void(0) }
-      , getAll() { return [] }
-      , has() { return false }
-      , set() { throw Error('Not Implemented') }
-      , ['@@iterator']() { return [].values() }
-      , [Symbol.iterator]() { return [].values() }
+export const nullURL = {
+  href: '',
+  origin: '',
+  protocol: '',
+  username: '',
+  password: '',
+  host: '',
+  hostname: '',
+  port: '',
+  pathname: '',
+  search: '',
+  hash: '',
+  searchParams: ( window.URLSearchParams != null
+          ? new window.URLSearchParams()
+          : {
+        append() { throw Error('Not Implemented') },
+        delete() { throw Error('Not Implemented') },
+        get() { return void(0) },
+        getAll() { return [] },
+        has() { return false },
+        set() { throw Error('Not Implemented') },
+        ['@@iterator']() { return [].values() },
+        [Symbol.iterator]() { return [].values() }
       }
-    )
+  )
 }

--- a/src/devtools.js
+++ b/src/devtools.js
@@ -49,21 +49,21 @@ type Flags <model, action, flags> =
 */
 
 const TagRecord = /*::<model, action>*/
-  (action/*:Record.Action<model, action>*/)/*:Action<model, action>*/ =>
+  (action: Record.Action<model, action>): Action<model, action> =>
   ( { type: "Record"
     , record: action
     }
   );
 
 const TagLog = /*::<model, action>*/
-  (action/*:Log.Action<model, action>*/)/*:Action<model, action>*/ =>
+  (action: Log.Action<model, action>): Action<model, action> =>
   ( { type: "Log"
     , log: action
     }
   );
 
 const TagReplay = /*::<model, action>*/
-  (action/*:Replay.Action<model, action>*/)/*:Action<model, action>*/ =>
+  (action: Replay.Action<model, action>): Action<model, action> =>
   ( action.type === "Replay"
   ? { type: "ReplayDebuggee"
     , model: action.replay
@@ -74,7 +74,7 @@ const TagReplay = /*::<model, action>*/
   );
 
 const TagDebuggee = /*::<model, action>*/
-  (action/*:action*/)/*:Action<model, action>*/ =>
+  (action: action): Action<model, action> =>
   ( action == null
   ? { type: "Debuggee"
     , debuggee: action
@@ -93,21 +93,21 @@ const TagDebuggee = /*::<model, action>*/
 export const Persist = { type: "Persist" }
 
 export const persist = /*::<model, action, flags>*/
-  ( model/*:Model<model, action>*/
-  )/*:Step<model, action>*/ =>
+  ( model: Model<model, action>
+  ): Step<model, action> =>
   [ model
   , Effects.none
   ];
 
 export const restore = /*::<model, action, flags>*/
-  ({Debuggee, flags}/*:Flags<model, action, flags>*/
-  )/*:Step<model, action>*/ =>
+  ({Debuggee, flags}: Flags<model, action, flags>
+  ): Step<model, action> =>
   [ merge(window.application.model.value, {Debuggee, flags})
   , Effects.none
   ];
 
 export const init = /*::<model, action, flags>*/
-  ({Debuggee, flags}/*:Flags<model, action, flags>*/)/*:Step<model, action>*/ => {
+  ({Debuggee, flags}: Flags<model, action, flags>): Step<model, action> => {
     const disable = [null, Effects.none]
 
     const [record, recordFX] =
@@ -151,9 +151,9 @@ export const init = /*::<model, action, flags>*/
   }
 
 export const update = /*::<model, action, flags>*/
-  ( model/*:Model<model, action>*/
-  , action/*:Action<model, action>*/
-  )/*:Step<model, action>*/ =>
+  ( model: Model<model, action>
+  , action: Action<model, action>
+  ): Step<model, action> =>
   ( action.type === "Record"
   ? ( model.record == null
     ? nofx(model)
@@ -184,15 +184,15 @@ export const update = /*::<model, action, flags>*/
   )
 
 const nofx = /*::<model, action>*/
-  (model/*:model*/)/*:[model, Effects<action>]*/ =>
+  (model: model): [model, Effects<action>] =>
   [ model
   , Effects.none
   ]
 
 const updateRecord = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , action/*:Record.Action<model, action>*/
-  )/*:Step<model, action>*/ => {
+  ( model: Model<model, action>
+  , action: Record.Action<model, action>
+  ): Step<model, action> => {
     const ignore = [null, Effects.none]
     const [record, fx] =
       ( model.record == null
@@ -204,9 +204,9 @@ const updateRecord = /*::<model, action>*/
 
 
 const updateReply = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , action/*:Replay.Action<model, action>*/
-  )/*:Step<model, action>*/ => {
+  ( model: Model<model, action>
+  , action: Replay.Action<model, action>
+  ): Step<model, action> => {
     const ignore = [null, Effects.none]
     const [replay, fx] =
       ( model.replay == null
@@ -217,9 +217,9 @@ const updateReply = /*::<model, action>*/
   }
 
 const updateLog = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , action/*:Log.Action<model, action>*/
-  )/*:Step<model, action>*/ => {
+  ( model: Model<model, action>
+  , action: Log.Action<model, action>
+  ): Step<model, action> => {
     const ignore = [null, Effects.none]
     const [log, fx] =
       ( model.log == null
@@ -231,9 +231,9 @@ const updateLog = /*::<model, action>*/
 
 
 const updateDebuggee = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , action/*:action*/
-  )/*:Step<model, action>*/ => {
+  ( model: Model<model, action>
+  , action: action
+  ): Step<model, action> => {
     const {Debuggee} = model
     const ignore = [null, Effects.none]
 
@@ -284,13 +284,13 @@ const updateDebuggee = /*::<model, action>*/
   }
 
 const replayDebuggee = /*::<model, action>*/
-  (model/*:Model<model, action>*/, debuggee/*:model*/)/*:Step<model, action>*/ =>
+  (model: Model<model, action>, debuggee: model): Step<model, action> =>
   nofx(merge(model, {debuggee}))
 
 export const render = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , address/*:Address<Action<model, action>>*/
-  )/*:DOM*/ =>
+  ( model: Model<model, action>
+  , address: Address<Action<model, action>>
+  ): DOM =>
   html.main
   ( { className: "devtools"
     }
@@ -314,9 +314,9 @@ export const render = /*::<model, action>*/
   )
 
 export const view = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , address/*:Address<Action<model, action>>*/
-  )/*:DOM*/ =>
+  ( model: Model<model, action>
+  , address: Address<Action<model, action>>
+  ): DOM =>
   thunk
   ( 'Devtools'
   , render

--- a/src/devtools.js
+++ b/src/devtools.js
@@ -1,325 +1,261 @@
 /* @flow */
 
-import {Effects, Task, thunk, html, forward} from "reflex"
-import {merge} from "./common/prelude"
-import {cursor} from "./common/cursor"
-import {ok, error} from "./common/result"
-import * as Runtime from "./common/runtime"
-import * as Unknown from "./common/unknown"
-import * as Replay from "./devtools/replay"
-import * as Record from "./devtools/record"
-import * as Log from "./devtools/log"
+import { Effects, thunk, html, forward } from 'reflex'
+import { merge } from './common/prelude'
+import * as Runtime from './common/runtime'
+import * as Unknown from './common/unknown'
+import * as Replay from './devtools/replay'
+import * as Record from './devtools/record'
+import * as Log from './devtools/log'
 
 /*::
-import type {Address, Never, DOM, Init, Update, View, AdvancedConfiguration} from "reflex"
-import type {Result} from "./common/result"
+ import type {Address, Never, DOM, Init, Update, View, AdvancedConfiguration} from "reflex"
+ import type {Result} from "./common/result"
 
-export type Model <model, action> =
-  { record: ?Record.Model<model, action>
-  , replay: ?Replay.Model<model, action>
-  , log: ?Log.Model<model, action>
+ export type Model <model, action> =
+ { record: ?Record.Model<model, action>
+ , replay: ?Replay.Model<model, action>
+ , log: ?Log.Model<model, action>
 
-  , Debuggee: Debuggee<model, action>
-  , debuggee: ?model
-  }
+ , Debuggee: Debuggee<model, action>
+ , debuggee: ?model
+ }
 
-export type Action <model, action> =
-  | { type: "Debuggee", debuggee: action }
-  | { type: "Record", record: Record.Action<model, action> }
-  | { type: "Replay", replay: Replay.Action<model, action> }
-  | { type: "Log", log: Log.Action<model, action> }
-  | { type: "ReplayDebuggee", model: model }
-  | { type: "Persist" }
+ export type Action <model, action> =
+ | { type: "Debuggee", debuggee: action }
+ | { type: "Record", record: Record.Action<model, action> }
+ | { type: "Replay", replay: Replay.Action<model, action> }
+ | { type: "Log", log: Log.Action<model, action> }
+ | { type: "ReplayDebuggee", model: model }
+ | { type: "Persist" }
 
 
 
-export type Debuggee <model, action> =
-  { init: Init<model, action, any>
-  , update: Update<model, action>
-  , view: View<model, action>
-  }
+ export type Debuggee <model, action> =
+ { init: Init<model, action, any>
+ , update: Update<model, action>
+ , view: View<model, action>
+ }
 
-export type Step <model, action> =
-  [Model<model, action>, Effects<Action<model, action>>]
+ export type Step <model, action> =
+ [Model<model, action>, Effects<Action<model, action>>]
 
-type Flags <model, action, flags> =
-  { Debuggee: Debuggee<model, action>
-  , flags: flags
-  }
-*/
+ type Flags <model, action, flags> =
+ { Debuggee: Debuggee<model, action>
+ , flags: flags
+ }
+ */
 
 const TagRecord = /*::<model, action>*/
-  (action: Record.Action<model, action>): Action<model, action> =>
-  ( { type: "Record"
-    , record: action
+    (action:Record.Action<model, action>):Action<model, action> =>( {
+      type: "Record", record: action
     }
-  );
+    );
 
 const TagLog = /*::<model, action>*/
-  (action: Log.Action<model, action>): Action<model, action> =>
-  ( { type: "Log"
-    , log: action
+    (action:Log.Action<model, action>):Action<model, action> =>( {
+      type: "Log", log: action
     }
-  );
+    );
 
 const TagReplay = /*::<model, action>*/
-  (action: Replay.Action<model, action>): Action<model, action> =>
-  ( action.type === "Replay"
-  ? { type: "ReplayDebuggee"
-    , model: action.replay
-    }
-  : { type: "Replay"
-    , replay: action
-    }
-  );
+    (action:Replay.Action<model, action>):Action<model, action> =>( action.type === "Replay" ? {
+          type: "ReplayDebuggee", model: action.replay
+        } : {
+          type: "Replay", replay: action
+        }
+    );
 
 const TagDebuggee = /*::<model, action>*/
-  (action: action): Action<model, action> =>
-  ( action == null
-  ? { type: "Debuggee"
-    , debuggee: action
-    }
-  : /*::typeof(action) === "object" && action != null && */
-    action.type === "PrintSnapshot"
-  ? TagRecord(action)
-  : /*::typeof(action) === "object" && action != null && */
-    action.type === "PublishSnapshot"
-  ? TagRecord(action)
-  : { type: "Debuggee"
-    , debuggee: action
-    }
-  )
+    (action:action):Action<model, action> =>( action == null
+            ? {
+          type: "Debuggee",
+          debuggee: action
+        }
+            : /*::typeof(action) === "object" && action != null && */
+            action.type === "PrintSnapshot"
+                ? TagRecord(action)
+                : /*::typeof(action) === "object" && action != null && */
+                action.type === "PublishSnapshot"
+                    ? TagRecord(action)
+                    : {
+                  type: "Debuggee",
+                  debuggee: action
+                }
+    )
 
 export const Persist = { type: "Persist" }
 
 export const persist = /*::<model, action, flags>*/
-  ( model: Model<model, action>
-  ): Step<model, action> =>
-  [ model
-  , Effects.none
-  ];
+    (model:Model<model, action>):Step<model, action> =>[
+      model, Effects.none
+    ];
 
 export const restore = /*::<model, action, flags>*/
-  ({Debuggee, flags}: Flags<model, action, flags>
-  ): Step<model, action> =>
-  [ merge(window.application.model.value, {Debuggee, flags})
-  , Effects.none
-  ];
+    ({ Debuggee, flags }: Flags<model, action, flags>):Step<model, action> =>[
+      merge(window.application.model.value, { Debuggee, flags }), Effects.none
+    ];
 
 export const init = /*::<model, action, flags>*/
-  ({Debuggee, flags}: Flags<model, action, flags>): Step<model, action> => {
-    const disable = [null, Effects.none]
+    ({ Debuggee, flags }: Flags<model, action, flags>):Step<model, action> => {
+      const disable = [null, Effects.none]
 
-    const [record, recordFX] =
-      ( Runtime.env.record == null
-      ? disable
-      : Record.init(flags)
-      );
+      const [record, recordFX] =
+          ( Runtime.env.record == null ? disable : Record.init(flags)
+          );
 
-    const [replay, replayFX] =
-      ( Runtime.env.replay == null
-      ? disable
-      : Replay.init(flags)
-      );
+      const [replay, replayFX] =
+          ( Runtime.env.replay == null ? disable : Replay.init(flags)
+          );
 
-    const [log, logFX] =
-      ( Runtime.env.log == null
-      ? disable
-      : Log.init(flags)
-      );
+      const [log, logFX] =
+          ( Runtime.env.log == null ? disable : Log.init(flags)
+          );
 
-    const [debuggee, debuggeeFX] = Debuggee.init(flags);
+      const [debuggee, debuggeeFX] = Debuggee.init(flags);
 
-    const model =
-      { record
-      , replay
-      , log
-      , debuggee
-      , Debuggee
-      , flags
+      const model = {
+        record, replay, log, debuggee, Debuggee, flags
       }
 
-    const fx = Effects.batch
-      ( [ recordFX.map(TagRecord)
-        , replayFX.map(TagReplay)
-        , logFX.map(TagLog)
-        , debuggeeFX.map(TagDebuggee)
-        ]
-      )
+      const fx = Effects.batch([
+                                 recordFX.map(TagRecord),
+                                 replayFX.map(TagReplay),
+                                 logFX.map(TagLog),
+                                 debuggeeFX.map(TagDebuggee)
+                               ])
 
-    return [model, fx]
-  }
+      return [model, fx]
+    }
 
 export const update = /*::<model, action, flags>*/
-  ( model: Model<model, action>
-  , action: Action<model, action>
-  ): Step<model, action> =>
-  ( action.type === "Record"
-  ? ( model.record == null
-    ? nofx(model)
-    : updateRecord(model, action.record)
-    )
-  : action.type === "Replay"
-  ? ( model.replay == null
-    ? nofx(model)
-    : updateReply(model, action.replay)
-    )
-  : action.type === "Log"
-  ? ( model.log == null
-    ? nofx(model)
-    : updateLog(model, action.log)
-    )
-  : action.type === "Debuggee"
-  ? ( model.debuggee == null
-    ? nofx(model)
-    : updateDebuggee(model, action.debuggee)
-    )
-  : action.type === "ReplayDebuggee"
-  ? replayDebuggee(model, action.model)
+    (model:Model<model, action>, action:Action<model, action>):Step<model, action> =>( action.type === "Record"
+            ? ( model.record == null ? nofx(model) : updateRecord(model, action.record)
+        )
+            : action.type === "Replay"
+            ? ( model.replay == null ? nofx(model) : updateReply(model, action.replay)
+        )
+            : action.type === "Log"
+            ? ( model.log == null ? nofx(model) : updateLog(model, action.log)
+        )
+            : action.type === "Debuggee"
+            ? ( model.debuggee == null ? nofx(model) : updateDebuggee(model, action.debuggee)
+        )
+            : action.type === "ReplayDebuggee"
+            ? replayDebuggee(model, action.model)
 
-  : action.type === "Persist"
-  ? persist(model)
-  
-  : Unknown.update(model, action)
-  )
+            : action.type === "Persist"
+            ? persist(model)
+
+            : Unknown.update(model, action)
+    )
 
 const nofx = /*::<model, action>*/
-  (model: model): [model, Effects<action>] =>
-  [ model
-  , Effects.none
-  ]
+    (model:model):[model, Effects<action>] =>[
+      model, Effects.none
+    ]
 
 const updateRecord = /*::<model, action>*/
-  ( model: Model<model, action>
-  , action: Record.Action<model, action>
-  ): Step<model, action> => {
-    const ignore = [null, Effects.none]
-    const [record, fx] =
-      ( model.record == null
-      ? ignore
-      : Record.update(model.record, action)
-      )
-    return [merge(model, {record}), fx.map(TagRecord)]
-  }
+    (model:Model<model, action>, action:Record.Action<model, action>):Step<model, action> => {
+      const ignore = [null, Effects.none]
+      const [record, fx] =
+          ( model.record == null ? ignore : Record.update(model.record, action)
+          )
+      return [merge(model, { record }), fx.map(TagRecord)]
+    }
 
 
 const updateReply = /*::<model, action>*/
-  ( model: Model<model, action>
-  , action: Replay.Action<model, action>
-  ): Step<model, action> => {
-    const ignore = [null, Effects.none]
-    const [replay, fx] =
-      ( model.replay == null
-      ? ignore
-      : Replay.update(model.replay, action)
-      )
-    return [merge(model, {replay}), fx.map(TagReplay)]
-  }
+    (model:Model<model, action>, action:Replay.Action<model, action>):Step<model, action> => {
+      const ignore = [null, Effects.none]
+      const [replay, fx] =
+          ( model.replay == null ? ignore : Replay.update(model.replay, action)
+          )
+      return [merge(model, { replay }), fx.map(TagReplay)]
+    }
 
 const updateLog = /*::<model, action>*/
-  ( model: Model<model, action>
-  , action: Log.Action<model, action>
-  ): Step<model, action> => {
-    const ignore = [null, Effects.none]
-    const [log, fx] =
-      ( model.log == null
-      ? ignore
-      : Log.update(model.log, action)
-      )
-    return [merge(model, {log}), fx.map(TagLog)]
-  }
+    (model:Model<model, action>, action:Log.Action<model, action>):Step<model, action> => {
+      const ignore = [null, Effects.none]
+      const [log, fx] =
+          ( model.log == null ? ignore : Log.update(model.log, action)
+          )
+      return [merge(model, { log }), fx.map(TagLog)]
+    }
 
 
 const updateDebuggee = /*::<model, action>*/
-  ( model: Model<model, action>
-  , action: action
-  ): Step<model, action> => {
-    const {Debuggee} = model
-    const ignore = [null, Effects.none]
+    (model:Model<model, action>, action:action):Step<model, action> => {
+      const { Debuggee } = model
+      const ignore = [null, Effects.none]
 
-    const [record, recordFX] =
-      ( model.record == null
-      ? ignore
-      : Record.update(model.record, {type: "Debuggee", debuggee: action})
-      );
+      const [record, recordFX] =
+          ( model.record == null ? ignore : Record.update(model.record, { type: "Debuggee", debuggee: action })
+          );
 
-    const [replay, replayFX] =
-      ( model.replay == null
-      ? ignore
-      : Replay.update(model.replay, {type: "Debuggee", debuggee: action})
-      );
+      const [replay, replayFX] =
+          ( model.replay == null ? ignore : Replay.update(model.replay, { type: "Debuggee", debuggee: action })
+          );
 
-    const [log, logFX] =
-      ( model.log == null
-      ? ignore
-      : Log.update(model.log, {type: "Debuggee", debuggee: action})
-      );
+      const [log, logFX] =
+          ( model.log == null ? ignore : Log.update(model.log, { type: "Debuggee", debuggee: action })
+          );
 
 
+      const [debuggee, debuggeeFX] =
+          ( model.debuggee == null ? ignore : Debuggee.update(model.debuggee, action)
+          )
 
-    const [debuggee, debuggeeFX] =
-      ( model.debuggee == null
-      ? ignore
-      : Debuggee.update(model.debuggee, action)
-      )
+      const fx = Effects.batch([
+                                 recordFX.map(TagRecord),
+                                 replayFX.map(TagReplay),
+                                 logFX.map(TagLog),
+                                 debuggeeFX.map(TagDebuggee)
+                               ])
 
-    const fx = Effects.batch
-      ( [ recordFX.map(TagRecord)
-        , replayFX.map(TagReplay)
-        , logFX.map(TagLog)
-        , debuggeeFX.map(TagDebuggee)
-        ]
-      )
+      const next = merge(model, {
+        record, replay, log, debuggee
+      })
 
-    const next = merge
-      ( model
-      , { record
-        , replay
-        , log
-        , debuggee
-        }
-      )
-
-    return [next, fx]
-  }
+      return [next, fx]
+    }
 
 const replayDebuggee = /*::<model, action>*/
-  (model: Model<model, action>, debuggee: model): Step<model, action> =>
-  nofx(merge(model, {debuggee}))
+    (model:Model<model, action>, debuggee:model):Step<model, action> =>nofx(merge(model, { debuggee }))
 
 export const render = /*::<model, action>*/
-  ( model: Model<model, action>
-  , address: Address<Action<model, action>>
-  ): DOM =>
-  html.main
-  ( { className: "devtools"
-    }
-  , [ ( model.debuggee == null
-      ? ""
-      : model.Debuggee.view(model.debuggee, forward(address, TagDebuggee))
-      )
-    , ( model.record == null
-      ? ""
-      : Record.view(model.record, forward(address, TagRecord))
-      )
-    , ( model.replay == null
-      ? ""
-      : Replay.view(model.replay, forward(address, TagReplay))
-      )
-    , ( model.log == null
-      ? ""
-      : Log.view(model.log, forward(address, TagLog))
-      )
-    ]
-  )
+    (model:Model<model, action>, address:Address<Action<model, action>>):DOM =>html.main({
+                                                                                           className: "devtools"
+                                                                                         }, [
+                                                                                           ( model.debuggee == null
+                                                                                                   ? ""
+                                                                                                   : model.Debuggee.view(
+                                                                                                   model.debuggee,
+                                                                                                   forward(address,
+                                                                                                           TagDebuggee))
+                                                                                           ),
+                                                                                           ( model.record == null
+                                                                                                   ? ""
+                                                                                                   : Record.view(
+                                                                                                   model.record,
+                                                                                                   forward(address,
+                                                                                                           TagRecord))
+                                                                                           ),
+                                                                                           ( model.replay == null
+                                                                                                   ? ""
+                                                                                                   : Replay.view(
+                                                                                                   model.replay,
+                                                                                                   forward(address,
+                                                                                                           TagReplay))
+                                                                                           ),
+                                                                                           ( model.log == null
+                                                                                                   ? ""
+                                                                                                   : Log.view(model.log,
+                                                                                                              forward(
+                                                                                                                  address,
+                                                                                                                  TagLog))
+                                                                                           )
+                                                                                         ])
 
 export const view = /*::<model, action>*/
-  ( model: Model<model, action>
-  , address: Address<Action<model, action>>
-  ): DOM =>
-  thunk
-  ( 'Devtools'
-  , render
-  , model
-  , address
-  )
+    (model:Model<model, action>, address:Address<Action<model, action>>):DOM =>thunk('Devtools', render, model, address)

--- a/src/devtools/log.js
+++ b/src/devtools/log.js
@@ -1,82 +1,59 @@
 /* @flow */
 
-import {Effects, Task, html, forward} from "reflex"
-import {merge, always} from "../common/prelude"
-import {ok, error} from "../common/result"
-import * as Runtime from "../common/runtime"
-import * as Unknown from "../common/unknown"
+import { Effects, html } from 'reflex'
+import { always } from '../common/prelude'
+import * as Runtime from '../common/runtime'
+import * as Unknown from '../common/unknown'
 
 /*::
-import type {Address, Never, DOM, Init, Update, View, AdvancedConfiguration} from "reflex"
-import type {Result} from "../common/result"
-import type {URI, ID} from "../common/prelude"
+ import type {Address, Never, DOM, Init, Update, View, AdvancedConfiguration} from "reflex"
+ import type {Result} from "../common/result"
+ import type {URI, ID} from "../common/prelude"
 
 
-export type Model <model, action> =
-  { mode: 'raw' | 'json' | 'none'
-  }
+ export type Model <model, action> =
+ { mode: 'raw' | 'json' | 'none'
+ }
 
-export type Action <model, action> =
-  | { type: "NoOp" }
-  | { type: "Debuggee", debuggee: action }
+ export type Action <model, action> =
+ | { type: "NoOp" }
+ | { type: "Debuggee", debuggee: action }
 
-type Step <model, action> =
-  [ Model<model, action>
-  , Effects<Action<model, action>>
-  ]
-*/
-
+ type Step <model, action> =
+ [ Model<model, action>
+ , Effects<Action<model, action>>
+ ]
+ */
 
 
 const NoOp = always({ type: "NoOp" });
 
 export const init = /*::<model, action, flags>*/
-  (): Step<model, action> =>
-  ( [ { mode:
-        ( Runtime.env.log === 'json'
-        ? 'json'
-        : Runtime.env.log != null
-        ? 'raw'
-        : 'none'
-        )
-      }
-    , Effects.none
-    ]
-  )
+    ():Step<model, action> =>( [
+          {
+            mode: ( Runtime.env.log === 'json' ? 'json' : Runtime.env.log != null ? 'raw' : 'none'
+            )
+          }, Effects.none
+        ]
+    )
 
 export const update = /*::<model, action>*/
-  ( model: Model<model, action>
-  , action: Action<model, action>
-  ): Step<model, action> =>
-  ( action.type === "NoOp"
-  ? nofx(model)
-  : action.type === 'Debuggee'
-  ? log(model, action.debuggee)
-  : Unknown.update(model, action)
-  )
+    (model:Model<model, action>, action:Action<model, action>):Step<model, action> =>( action.type === "NoOp" ? nofx(
+            model) : action.type === 'Debuggee' ? log(model, action.debuggee) : Unknown.update(model, action)
+    )
 
-const nofx =
-  model =>
-  [ model
-  , Effects.none
-  ]
+const nofx = model =>[
+  model, Effects.none
+]
 
 const log = /*::<model, action>*/
-  ( model: Model<model, action>
-  , action: action
-  ): Step<model, action> => {
-    ( model.mode === 'raw'
-    ? console.log('Action >>', action)
-    : model.mode === 'json'
-    ? console.log(`Action >> ${JSON.stringify(action)}`)
-    : null
-    );
+    (model:Model<model, action>, action:action):Step<model, action> => {
+      ( model.mode === 'raw' ? console.log('Action >>', action) : model.mode === 'json' ? console.log(
+              `Action >> ${JSON.stringify(action)}`) : null
+      );
 
-    return nofx(model)
-  }
+      return nofx(model)
+    }
 
 export const view = /*::<model, action>*/
-  ( model: Model<model, action>
-  , address: Address<Action<model, action>>
-  ): DOM =>
-  html.noscript()
+    (model:Model<model, action>, address:Address<Action<model, action>>):DOM =>html.noscript()

--- a/src/devtools/log.js
+++ b/src/devtools/log.js
@@ -31,7 +31,7 @@ type Step <model, action> =
 const NoOp = always({ type: "NoOp" });
 
 export const init = /*::<model, action, flags>*/
-  ()/*:Step<model, action>*/ =>
+  (): Step<model, action> =>
   ( [ { mode:
         ( Runtime.env.log === 'json'
         ? 'json'
@@ -45,9 +45,9 @@ export const init = /*::<model, action, flags>*/
   )
 
 export const update = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , action/*:Action<model, action>*/
-  )/*:Step<model, action>*/ =>
+  ( model: Model<model, action>
+  , action: Action<model, action>
+  ): Step<model, action> =>
   ( action.type === "NoOp"
   ? nofx(model)
   : action.type === 'Debuggee'
@@ -62,9 +62,9 @@ const nofx =
   ]
 
 const log = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , action/*:action*/
-  )/*:Step<model, action>*/ => {
+  ( model: Model<model, action>
+  , action: action
+  ): Step<model, action> => {
     ( model.mode === 'raw'
     ? console.log('Action >>', action)
     : model.mode === 'json'
@@ -76,7 +76,7 @@ const log = /*::<model, action>*/
   }
 
 export const view = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , address/*:Address<Action<model, action>>*/
-  )/*:DOM*/ =>
+  ( model: Model<model, action>
+  , address: Address<Action<model, action>>
+  ): DOM =>
   html.noscript()

--- a/src/devtools/record.js
+++ b/src/devtools/record.js
@@ -1,57 +1,55 @@
 /* @flow */
 
-import {Effects, Task, html, thunk, forward} from "reflex"
-import {merge, always} from "../common/prelude"
-import {ok, error} from "../common/result"
-import * as Runtime from "../common/runtime"
-import * as Unknown from "../common/unknown"
-import * as Style from "../common/style"
+import { Effects, Task, html, thunk } from 'reflex'
+import { merge, always } from '../common/prelude'
+import { ok, error } from '../common/result'
+import * as Unknown from '../common/unknown'
+import * as Style from '../common/style'
 
 /*::
-import type {Address, Never, DOM, Init, Update, View, AdvancedConfiguration} from "reflex"
-import type {Result} from "../common/result"
-import type {URI, ID} from "../common/prelude"
+ import type {Address, Never, DOM, Init, Update, View, AdvancedConfiguration} from "reflex"
+ import type {Result} from "../common/result"
+ import type {URI, ID} from "../common/prelude"
 
 
-export type Gist =
-  { id: ID
-  , url: URI
-  , description: String
-  , public: boolean
-  , files:
-    { "snapshot.json":
-      { size: number
-      , raw_url: URI
-      , type: "application/json"
-      , language: "JSON"
-      , truncated: boolean
-      , "content": JSON
-      }
-    }
-  , html_url: URI
-  , created_at: String
-  , updated_at: String
-  }
+ export type Gist =
+ { id: ID
+ , url: URI
+ , description: String
+ , public: boolean
+ , files:
+ { "snapshot.json":
+ { size: number
+ , raw_url: URI
+ , type: "application/json"
+ , language: "JSON"
+ , truncated: boolean
+ , "content": JSON
+ }
+ }
+ , html_url: URI
+ , created_at: String
+ , updated_at: String
+ }
 
-export type Model <model, action> =
-  { status: 'Idle' | 'Pending'
-  , description: string
-  }
+ export type Model <model, action> =
+ { status: 'Idle' | 'Pending'
+ , description: string
+ }
 
-export type Action <model, action> =
-  | { type: "NoOp" }
-  | { type: "Debuggee", debuggee: action }
-  | { type: "PrintSnapshot" }
-  | { type: "PrintedSnapshot" }
-  | { type: "PublishSnapshot" }
-  | { type: "PublishedSnapshot", result: Result<Error, Gist> }
+ export type Action <model, action> =
+ | { type: "NoOp" }
+ | { type: "Debuggee", debuggee: action }
+ | { type: "PrintSnapshot" }
+ | { type: "PrintedSnapshot" }
+ | { type: "PublishSnapshot" }
+ | { type: "PublishedSnapshot", result: Result<Error, Gist> }
 
-type Step <model, action> =
-  [ Model<model, action>
-  , Effects<Action<model, action>>
-  ]
-*/
-
+ type Step <model, action> =
+ [ Model<model, action>
+ , Effects<Action<model, action>>
+ ]
+ */
 
 
 const NoOp = always({ type: "NoOp" });
@@ -59,181 +57,141 @@ const PrintSnapshot = { type: "PrintSnapshot" };
 const PublishSnapshot = { type: "PublishSnapshot" };
 const PrintedSnapshot = always({ type: "PrintedSnapshot" });
 const PublishedSnapshot = /*::<model, action>*/
-  (result: Result<Error, Gist>): Action<model, action> =>
-  ( { type: "PublishedSnapshot"
-    , result
+    (result:Result<Error, Gist>):Action<model, action> =>( {
+      type: "PublishedSnapshot", result
     }
-  );
+    );
 
 export const init = /*::<model, action, flags>*/
-  (): Step<model, action> =>
-  ( [ { status: "Idle"
-      , description: ""
-      }
-    , Effects.none
-    ]
-  )
+    ():Step<model, action> =>( [
+          {
+            status: "Idle", description: ""
+          }, Effects.none
+        ]
+    )
 
 export const update = /*::<model, action>*/
-  ( model: Model<model, action>
-  , action: Action<model, action>
-  ): Step<model, action> =>
-  ( action.type === "NoOp"
-  ? nofx(model)
-  : action.type === "PrintSnapshot"
-  ? printSnapshot(model)
-  : action.type === "PrintedSnapshot"
-  ? printedSnapshot(model)
-  : action.type === "PublishSnapshot"
-  ? publishSnapshot(model)
-  : action.type === "PublishedSnapshot"
-  ? publishedSnapshot(model, action.result)
-  : action.type === "Debuggee"
-  ? nofx(model)
-  : Unknown.update(model, action)
-  )
+    (model:Model<model, action>, action:Action<model, action>):Step<model, action> =>( action.type === "NoOp"
+            ? nofx(model)
+            : action.type === "PrintSnapshot"
+            ? printSnapshot(model)
+            : action.type === "PrintedSnapshot"
+            ? printedSnapshot(model)
+            : action.type === "PublishSnapshot"
+            ? publishSnapshot(model)
+            : action.type === "PublishedSnapshot"
+            ? publishedSnapshot(model, action.result)
+            : action.type === "Debuggee"
+            ? nofx(model)
+            : Unknown.update(model, action)
+    )
 
-const nofx =
-  model =>
-  [ model
-  , Effects.none
-  ]
+const nofx = model =>[
+  model, Effects.none
+]
 
 const createSnapshot = /*::<model, action>*/
-  (model: Model<model, action>): Task<Error, string> =>
-  new Task((succeed, fail) => {
-    try {
-      succeed(JSON.stringify(window.application.model.value.debuggee))
-    }
-    catch (error) {
-      fail(error)
-    }
-  })
+    (model:Model<model, action>):Task<Error, string> =>new Task((succeed, fail) => {
+      try {
+        succeed(JSON.stringify(window.application.model.value.debuggee))
+      } catch (error) {
+        fail(error)
+      }
+    })
 
 
 const printSnapshot = /*::<model, action>*/
-  (model: Model<model, action>): Step<model, action> =>
-  [ merge(model, { status: 'Pending', description: 'Printing...' })
-  , Effects.batch
-    ( [ Effects.perform
-        ( createSnapshot(model)
-          .chain(snapshot => Unknown.log(`\n\n${snapshot}\n\n`))
-          .map(ok)
-          .capture(reason => Task.succeed(error(reason)))
-        )
-        .map(NoOp)
-      , Effects.perform
-        ( Task.sleep(200) )
-        .map(PrintedSnapshot)
-      ]
-    )
-  ];
+    (model:Model<model, action>):Step<model, action> =>[
+      merge(model, { status: 'Pending', description: 'Printing...' }), Effects.batch([
+                                                                                       Effects.perform(
+                                                                                           createSnapshot(model)
+                                                                                               .chain(
+                                                                                                   snapshot => Unknown.log(
+                                                                                                       `\n\n${snapshot}\n\n`))
+                                                                                               .map(ok)
+                                                                                               .capture(
+                                                                                                   reason => Task.succeed(
+                                                                                                       error(reason))))
+                                                                                              .map(NoOp),
+                                                                                       Effects.perform(Task.sleep(200))
+                                                                                              .map(PrintedSnapshot)
+                                                                                     ])
+    ];
 
 const printedSnapshot = /*::<model, action>*/
-  (model: Model<model, action>): Step<model, action> =>
-  [ merge(model, { status: 'Idle', description: '' })
-  , Effects.none
-  ];
+    (model:Model<model, action>):Step<model, action> =>[
+      merge(model, { status: 'Idle', description: '' }), Effects.none
+    ];
 
 const publishSnapshot = /*::<model, action>*/
-  (model: Model<model, action>): Step<model, action> =>
-  [ merge(model, {status: "Pending", description: "Publishing..." })
-  , Effects.perform
-    ( createSnapshot(model)
-      .chain(uploadSnapshot)
-      .map(ok)
-      .capture(reason => Task.succeed(error(reason)))
-    )
-    .map(PublishedSnapshot)
-  ]
+    (model:Model<model, action>):Step<model, action> =>[
+      merge(model, { status: "Pending", description: "Publishing..." }), Effects.perform(createSnapshot(model)
+                                                                                             .chain(uploadSnapshot)
+                                                                                             .map(ok)
+                                                                                             .capture(
+                                                                                                 reason => Task.succeed(
+                                                                                                     error(reason))))
+                                                                                .map(PublishedSnapshot)
+    ]
 
 const publishedSnapshot = /*::<model, action>*/
-  ( model: Model<model, action>
-  , result: Result<Error, Gist>
-  ): Step<model, action> =>
-  [ merge(model, {status: "Idle", description: "" })
-  , Effects.perform
-    ( result.isError
-    ? Unknown.error(result.error)
-    : Unknown.log(`Snapshot published as gist #${result.value.id}: ${result.value.html_url}`)
-    )
-    .map(NoOp)
-  ]
+    (model:Model<model, action>, result:Result<Error, Gist>):Step<model, action> =>[
+      merge(model, { status: "Idle", description: "" }),
+      Effects.perform(result.isError ? Unknown.error(result.error) : Unknown.log(
+          `Snapshot published as gist #${result.value.id}: ${result.value.html_url}`))
+             .map(NoOp)
+    ]
 
-const uploadSnapshot =
-  (snapshot: string): Task<Error, Gist> =>
-  new Task((succeed, fail) => {
-    const request = new XMLHttpRequest({mozSystem: true});
-    request.open('POST', 'https://api.github.com/gists', true);
-    request.responseType = 'json';
-    request.send
-    ( JSON.stringify
-      ( { "description": "Browser.html generated state snapshot"
-        , "public": true
-        , "files":
-          { "snapshot.json":
-            { "content": snapshot }
-          }
-        }
-      )
-    );
+const uploadSnapshot = (snapshot:string):Task<Error, Gist> =>new Task((succeed, fail) => {
+  const request = new XMLHttpRequest({ mozSystem: true });
+  request.open('POST', 'https://api.github.com/gists', true);
+  request.responseType = 'json';
+  request.send(JSON.stringify({
+                                "description": "Browser.html generated state snapshot", "public": true, "files": {
+      "snapshot.json": { "content": snapshot }
+    }
+                              }));
 
-    request.onload = () =>
-    ( request.status === 201
-    ? succeed(request.response)
-    : fail(Error(`Failed to upload snapshot : ${request.statusText}`))
-    )
-  });
+  request.onload = () =>( request.status === 201 ? succeed(request.response) : fail(
+          Error(`Failed to upload snapshot : ${request.statusText}`))
+  )
+});
 
 export const render = /*::<model, action>*/
-  ( model: Model<model, action>
-  , address: Address<Action<model, action>>
-  ): DOM =>
-  html.dialog
-  ( { id: "record"
-    , style: Style.mix
-      ( styleSheet.base
-      , ( model.status === 'Pending'
-        ? styleSheet.flash
-        : styleSheet.noflash
-        )
-      )
-    , open: true
-    }
-  , [ html.h1(null, [model.description])
-    ]
-  );
+    (model:Model<model, action>, address:Address<Action<model, action>>):DOM =>html.dialog({
+                                                                                             id: "record",
+                                                                                             style: Style.mix(
+                                                                                                 styleSheet.base,
+                                                                                                 ( model.status === 'Pending'
+                                                                                                         ? styleSheet.flash
+                                                                                                         : styleSheet.noflash
+                                                                                                 )),
+                                                                                             open: true
+                                                                                           }, [
+                                                                                             html.h1(null,
+                                                                                                     [model.description])
+                                                                                           ]);
 
 export const view = /*::<model, action>*/
-  ( model: Model<model, action>
-  , address: Address<Action<model, action>>
-  ): DOM =>
-  thunk
-  ( "record"
-  , render
-  , model
-  , address
-  );
+    (model:Model<model, action>, address:Address<Action<model, action>>):DOM =>thunk("record", render, model, address);
 
 
-const styleSheet = Style.createSheet
-  ( { base:
-      { position: "absolute"
-      , pointerEvents: "none"
-      , background: "#fff"
-      , opacity: 0
-      , height: "100%"
-      , width: "100%"
-      , transitionDuration: "50ms"
-      // @TODO: Enable once this works properly on servo.
-      // , transitionProperty: "opacity"
-      , transitionTimingFunction: "ease"
-      , textAlign: "center"
-      , lineHeight: "100vh"
-      }
-    , flash:
-      { opacity: 0.9
-      }
-    , noflash: null
-    }
-  );
+const styleSheet = Style.createSheet({
+                                       base: {
+                                         position: "absolute",
+                                         pointerEvents: "none",
+                                         background: "#fff",
+                                         opacity: 0,
+                                         height: "100%",
+                                         width: "100%",
+                                         transitionDuration: "50ms"
+                                         // @TODO: Enable once this works properly on servo.
+                                         // , transitionProperty: "opacity"
+                                         ,
+                                         transitionTimingFunction: "ease",
+                                         textAlign: "center",
+                                         lineHeight: "100vh"
+                                       }, flash: {
+    opacity: 0.9
+  }, noflash: null
+                                     });

--- a/src/devtools/record.js
+++ b/src/devtools/record.js
@@ -59,14 +59,14 @@ const PrintSnapshot = { type: "PrintSnapshot" };
 const PublishSnapshot = { type: "PublishSnapshot" };
 const PrintedSnapshot = always({ type: "PrintedSnapshot" });
 const PublishedSnapshot = /*::<model, action>*/
-  (result/*:Result<Error, Gist>*/)/*:Action<model, action>*/ =>
+  (result: Result<Error, Gist>): Action<model, action> =>
   ( { type: "PublishedSnapshot"
     , result
     }
   );
 
 export const init = /*::<model, action, flags>*/
-  ()/*:Step<model, action>*/ =>
+  (): Step<model, action> =>
   ( [ { status: "Idle"
       , description: ""
       }
@@ -75,9 +75,9 @@ export const init = /*::<model, action, flags>*/
   )
 
 export const update = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , action/*:Action<model, action>*/
-  )/*:Step<model, action>*/ =>
+  ( model: Model<model, action>
+  , action: Action<model, action>
+  ): Step<model, action> =>
   ( action.type === "NoOp"
   ? nofx(model)
   : action.type === "PrintSnapshot"
@@ -100,7 +100,7 @@ const nofx =
   ]
 
 const createSnapshot = /*::<model, action>*/
-  (model/*:Model<model, action>*/)/*:Task<Error, string>*/ =>
+  (model: Model<model, action>): Task<Error, string> =>
   new Task((succeed, fail) => {
     try {
       succeed(JSON.stringify(window.application.model.value.debuggee))
@@ -112,7 +112,7 @@ const createSnapshot = /*::<model, action>*/
 
 
 const printSnapshot = /*::<model, action>*/
-  (model/*:Model<model, action>*/)/*:Step<model, action>*/ =>
+  (model: Model<model, action>): Step<model, action> =>
   [ merge(model, { status: 'Pending', description: 'Printing...' })
   , Effects.batch
     ( [ Effects.perform
@@ -130,13 +130,13 @@ const printSnapshot = /*::<model, action>*/
   ];
 
 const printedSnapshot = /*::<model, action>*/
-  (model/*:Model<model, action>*/)/*:Step<model, action>*/ =>
+  (model: Model<model, action>): Step<model, action> =>
   [ merge(model, { status: 'Idle', description: '' })
   , Effects.none
   ];
 
 const publishSnapshot = /*::<model, action>*/
-  (model/*:Model<model, action>*/)/*:Step<model, action>*/ =>
+  (model: Model<model, action>): Step<model, action> =>
   [ merge(model, {status: "Pending", description: "Publishing..." })
   , Effects.perform
     ( createSnapshot(model)
@@ -148,9 +148,9 @@ const publishSnapshot = /*::<model, action>*/
   ]
 
 const publishedSnapshot = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , result/*:Result<Error, Gist>*/
-  )/*:Step<model, action>*/ =>
+  ( model: Model<model, action>
+  , result: Result<Error, Gist>
+  ): Step<model, action> =>
   [ merge(model, {status: "Idle", description: "" })
   , Effects.perform
     ( result.isError
@@ -161,7 +161,7 @@ const publishedSnapshot = /*::<model, action>*/
   ]
 
 const uploadSnapshot =
-  (snapshot/*:string*/)/*:Task<Error, Gist>*/ =>
+  (snapshot: string): Task<Error, Gist> =>
   new Task((succeed, fail) => {
     const request = new XMLHttpRequest({mozSystem: true});
     request.open('POST', 'https://api.github.com/gists', true);
@@ -186,9 +186,9 @@ const uploadSnapshot =
   });
 
 export const render = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , address/*:Address<Action<model, action>>*/
-  )/*:DOM*/ =>
+  ( model: Model<model, action>
+  , address: Address<Action<model, action>>
+  ): DOM =>
   html.dialog
   ( { id: "record"
     , style: Style.mix
@@ -205,9 +205,9 @@ export const render = /*::<model, action>*/
   );
 
 export const view = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , address/*:Address<Action<model, action>>*/
-  )/*:DOM*/ =>
+  ( model: Model<model, action>
+  , address: Address<Action<model, action>>
+  ): DOM =>
   thunk
   ( "record"
   , render

--- a/src/devtools/replay.js
+++ b/src/devtools/replay.js
@@ -1,185 +1,141 @@
 /* @flow */
 
-import {Effects, Task, html, thunk, forward} from "reflex"
-import {merge} from "../common/prelude"
-import {ok, error} from "../common/result"
-import * as Runtime from "../common/runtime"
-import * as Unknown from "../common/unknown"
-import * as Style from "../common/style"
+import { Effects, Task, html, thunk } from 'reflex'
+import { merge } from '../common/prelude'
+import { ok, error } from '../common/result'
+import * as Runtime from '../common/runtime'
+import * as Unknown from '../common/unknown'
+import * as Style from '../common/style'
 
 /*::
-import type {Address, Never, DOM, Init, Update, View, AdvancedConfiguration} from "reflex"
-import type {Result} from "../common/result"
+ import type {Address, Never, DOM, Init, Update, View, AdvancedConfiguration} from "reflex"
+ import type {Result} from "../common/result"
 
-export type Model <model, action> =
-  { snapshotURI: string
-  , error: ?Error
-  , replayed: boolean
-  }
+ export type Model <model, action> =
+ { snapshotURI: string
+ , error: ?Error
+ , replayed: boolean
+ }
 
-export type Action <model, action> =
-  | { type: "Load" }
-  | { type: "Snapshot", result: Result<Error, model> }
-  | { type: "Replay", replay: model }
-  | { type: "Debuggee", debuggee: action }
+ export type Action <model, action> =
+ | { type: "Load" }
+ | { type: "Snapshot", result: Result<Error, model> }
+ | { type: "Replay", replay: model }
+ | { type: "Debuggee", debuggee: action }
 
-type Step <model, action> =
-  [ Model
-  , Effects<Action<model, action>>
-  ]
-*/
-
+ type Step <model, action> =
+ [ Model
+ , Effects<Action<model, action>>
+ ]
+ */
 
 
 const Load = { type: "Load" }
 
 const Snapshot = /*::<model, action>*/
-  (result: Result<Error, model>): Action<model, action> =>
-  ( { type: "Snapshot"
-    , result
+    (result:Result<Error, model>):Action<model, action> =>( {
+      type: "Snapshot", result
     }
-  )
+    )
 
 const Replay = /*::<model, action>*/
-  (model: model): Action<model, action> =>
-  ( { type: "Replay"
-    , replay: model
+    (model:model):Action<model, action> =>( {
+      type: "Replay", replay: model
     }
-  )
+    )
 
 
 export const init = /*::<model, action, flags>*/
-  (flags: flags): Step<model, action> =>
-  ( [ { flags
-      , snapshotURI: String(Runtime.env.replay)
-      , error: null
-      , replayed: false
-      }
-    , Effects.receive(Load)
-    ]
-  )
+    (flags:flags):Step<model, action> =>( [
+          {
+            flags, snapshotURI: String(Runtime.env.replay), error: null, replayed: false
+          }, Effects.receive(Load)
+        ]
+    )
 
 export const update = /*::<model, action>*/
-  ( model: Model<model, action>
-  , action: Action<model, action>
-  ): Step<model, action> =>
-  ( action.type === "Load"
-  ? loadSnapshot(model)
-  : action.type === "Snapshot"
-  ? receiveSnapshot(model, action.result)
-  : action.type === "Debuggee"
-  ? nofx(model)
-  : Unknown.update(model, action)
-  )
+    (model:Model<model, action>, action:Action<model, action>):Step<model, action> =>( action.type === "Load"
+            ? loadSnapshot(model)
+            : action.type === "Snapshot"
+            ? receiveSnapshot(model, action.result)
+            : action.type === "Debuggee"
+            ? nofx(model)
+            : Unknown.update(model, action)
+    )
 
-const nofx =
-  model =>
-  [ model
-  , Effects.none
-  ]
+const nofx = model =>[
+  model, Effects.none
+]
 
 const receiveSnapshot = /*::<model, action>*/
-  ( model: Model<model, action>
-  , result: Result<Error, model>
-  ): Step<model, action> =>
-  ( result.isOk
-  ? [ merge(model, {replayed: true})
-    , Effects.receive(Replay(result.value))
-    ]
-  : nofx(merge(model, {error: result.error}))
-  )
+    (model:Model<model, action>, result:Result<Error, model>):Step<model, action> =>( result.isOk ? [
+          merge(model, { replayed: true }), Effects.receive(Replay(result.value))
+        ] : nofx(merge(model, { error: result.error }))
+    )
 
 const loadSnapshot = /*::<model, action>*/
-  (model: Model<model, action>): Step<model, action> =>
-  [ model
-  , Effects.perform(fetchSnapshot(model.snapshotURI))
-    .map(Snapshot)
-  ]
+    (model:Model<model, action>):Step<model, action> =>[
+      model, Effects.perform(fetchSnapshot(model.snapshotURI))
+                    .map(Snapshot)
+    ]
 
 const fetchSnapshot = /*::<model>*/
-  (uri: string): Task<Never, Result<Error, model>> => new Task(succeed => {
-    const request = new XMLHttpRequest({mozSystem: true});
-    request.open
-    ( 'GET'
-    , uri
-    , true
-    );
+    (uri:string):Task<Never, Result<Error, model>> => new Task(succeed => {
+      const request = new XMLHttpRequest({ mozSystem: true });
+      request.open('GET', uri, true);
 
 
-    request.overrideMimeType('application/json');
-    request.responseType = 'json';
-    request.send();
+      request.overrideMimeType('application/json');
+      request.responseType = 'json';
+      request.send();
 
 
-    request.onload =
-      () =>
-      succeed
-      ( request.status === 200
-      ? ok(request.response)
-      : request.status === 0
-      ? ok(request.response)
-      : error(Error(`Failed to fetch ${uri} : ${request.statusText}`))
-      )
-  });
+      request.onload = () =>succeed(
+          request.status === 200 ? ok(request.response) : request.status === 0 ? ok(request.response) : error(
+              Error(`Failed to fetch ${uri} : ${request.statusText}`)))
+    });
 
 
 export const render = /*::<model, action>*/
-  ( model: Model<model, action>
-  , address: Address<Action<model, action>>
-  ): DOM =>
-  html.dialog
-  ( { id: "replay"
-    , style: Style.mix
-      ( styleSheet.base
-      , ( model.replayed === true
-        ? styleSheet.loaded
-        : styleSheet.loading
-        )
-      )
-    , open: true
-    }
-  , [ html.h1
-      ( null
-      , [ ( model.error != null
-          ? String(model.error)
-          : model.replayed
-          ? ""
-          : `Loading snapshot from ${model.snapshotURI}`
-          )
-        ]
-      )
-    ]
-  );
+    (model:Model<model, action>, address:Address<Action<model, action>>):DOM =>html.dialog({
+                                                                                             id: "replay",
+                                                                                             style: Style.mix(
+                                                                                                 styleSheet.base,
+                                                                                                 ( model.replayed === true
+                                                                                                         ? styleSheet.loaded
+                                                                                                         : styleSheet.loading
+                                                                                                 )),
+                                                                                             open: true
+                                                                                           }, [
+                                                                                             html.h1(null, [
+                                                                                               ( model.error != null
+                                                                                                       ? String(
+                                                                                                       model.error)
+                                                                                                       : model.replayed
+                                                                                                       ? ""
+                                                                                                       : `Loading snapshot from ${model.snapshotURI}`
+                                                                                               )
+                                                                                             ])
+                                                                                           ]);
 
 export const view = /*::<model, action>*/
-  ( model: Model<model, action>
-  , address: Address<Action<model, action>>
-  ): DOM =>
-  thunk
-  ( 'replay'
-  , render
-  , model
-  , address
-  );
+    (model:Model<model, action>, address:Address<Action<model, action>>):DOM =>thunk('replay', render, model, address);
 
 
-const styleSheet = Style.createSheet
-  ( { base:
-      { position: "absolute"
-      , pointerEvents: "none"
-      , background: "#fff"
-      , height: "100%"
-      , width: "100%"
-      , textAlign: "center"
-      , lineHeight: "100vh"
-      , textOverflow: "ellipsis"
-      , whiteSpace: "nowrap"
-      }
-    , loaded:
-      { opacity: 0
-      }
-    , loading:
-      { opaticy: 1
-      }
-    }
-  );
+const styleSheet = Style.createSheet({
+                                       base: {
+                                         position: "absolute",
+                                         pointerEvents: "none",
+                                         background: "#fff",
+                                         height: "100%",
+                                         width: "100%",
+                                         textAlign: "center",
+                                         lineHeight: "100vh",
+                                         textOverflow: "ellipsis",
+                                         whiteSpace: "nowrap"
+                                       }, loaded: {
+    opacity: 0
+  }, loading: {
+    opaticy: 1
+  }
+                                     });

--- a/src/devtools/replay.js
+++ b/src/devtools/replay.js
@@ -34,14 +34,14 @@ type Step <model, action> =
 const Load = { type: "Load" }
 
 const Snapshot = /*::<model, action>*/
-  (result/*:Result<Error, model>*/)/*:Action<model, action>*/ =>
+  (result: Result<Error, model>): Action<model, action> =>
   ( { type: "Snapshot"
     , result
     }
   )
 
 const Replay = /*::<model, action>*/
-  (model/*:model*/)/*:Action<model, action>*/ =>
+  (model: model): Action<model, action> =>
   ( { type: "Replay"
     , replay: model
     }
@@ -49,7 +49,7 @@ const Replay = /*::<model, action>*/
 
 
 export const init = /*::<model, action, flags>*/
-  (flags/*:flags*/)/*:Step<model, action>*/ =>
+  (flags: flags): Step<model, action> =>
   ( [ { flags
       , snapshotURI: String(Runtime.env.replay)
       , error: null
@@ -60,9 +60,9 @@ export const init = /*::<model, action, flags>*/
   )
 
 export const update = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , action/*:Action<model, action>*/
-  )/*:Step<model, action>*/ =>
+  ( model: Model<model, action>
+  , action: Action<model, action>
+  ): Step<model, action> =>
   ( action.type === "Load"
   ? loadSnapshot(model)
   : action.type === "Snapshot"
@@ -79,9 +79,9 @@ const nofx =
   ]
 
 const receiveSnapshot = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , result/*:Result<Error, model>*/
-  )/*:Step<model, action>*/ =>
+  ( model: Model<model, action>
+  , result: Result<Error, model>
+  ): Step<model, action> =>
   ( result.isOk
   ? [ merge(model, {replayed: true})
     , Effects.receive(Replay(result.value))
@@ -90,14 +90,14 @@ const receiveSnapshot = /*::<model, action>*/
   )
 
 const loadSnapshot = /*::<model, action>*/
-  (model/*:Model<model, action>*/)/*:Step<model, action>*/ =>
+  (model: Model<model, action>): Step<model, action> =>
   [ model
   , Effects.perform(fetchSnapshot(model.snapshotURI))
     .map(Snapshot)
   ]
 
 const fetchSnapshot = /*::<model>*/
-  (uri/*:string*/)/*:Task<Never, Result<Error, model>>*/ => new Task(succeed => {
+  (uri: string): Task<Never, Result<Error, model>> => new Task(succeed => {
     const request = new XMLHttpRequest({mozSystem: true});
     request.open
     ( 'GET'
@@ -124,9 +124,9 @@ const fetchSnapshot = /*::<model>*/
 
 
 export const render = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , address/*:Address<Action<model, action>>*/
-  )/*:DOM*/ =>
+  ( model: Model<model, action>
+  , address: Address<Action<model, action>>
+  ): DOM =>
   html.dialog
   ( { id: "replay"
     , style: Style.mix
@@ -152,9 +152,9 @@ export const render = /*::<model, action>*/
   );
 
 export const view = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , address/*:Address<Action<model, action>>*/
-  )/*:DOM*/ =>
+  ( model: Model<model, action>
+  , address: Address<Action<model, action>>
+  ): DOM =>
   thunk
   ( 'replay'
   , render

--- a/src/driver/virtual-dom/index.js
+++ b/src/driver/virtual-dom/index.js
@@ -4,21 +4,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {identity} from '../../lang/functional'
-import {forward, Effects, Task} from 'reflex'
-export {Renderer} from 'reflex-virtual-dom-driver'
+import { Task } from 'reflex'
+export { Renderer } from 'reflex-virtual-dom-driver'
 
 // @TODO documentation
 // I think this is some kind of memoization class? - GB 2015-11-12
 class On {
   static handleEvent(event) {
-    const {currentTarget, type} = event
+    const { currentTarget, type } = event
 
     const handler = currentTarget[`on:${type}`]
     if (handler) {
-      const data = handler.decode == null ?
-        void(0) :
-        handler.decode(event)
+      const data = handler.decode == null ? void(0) : handler.decode(event)
 
       if (data == null || data.type !== "AbortEvent") {
         if (handler.stopPropagation) {
@@ -37,6 +34,7 @@ class On {
       }
     }
   }
+
   constructor(address, decode, options, getTarget) {
     this.address = address
     this.decode = decode
@@ -55,14 +53,11 @@ class On {
       }
     }
   }
-  hook(node, name, previous) {
-    const type = name.indexOf('on') === 0 ?
-      name.substr(2).toLowerCase() :
-      name
 
-    const target = this.getTarget != null ?
-      this.getTarget(node) :
-      node
+  hook(node, name, previous) {
+    const type = name.indexOf('on') === 0 ? name.substr(2).toLowerCase() : name
+
+    const target = this.getTarget != null ? this.getTarget(node) : node
 
     if (previous == null || previous.type != this.type) {
       target.addEventListener(type, this.constructor.handleEvent)
@@ -70,14 +65,11 @@ class On {
 
     target[`on:${type}`] = this
   }
-  unhook(node, name, next) {
-    const type = name.indexOf('on') === 0 ?
-      name.substr(2).toLowerCase() :
-      name.toLowerCase()
 
-    const target = this.getTarget != null ?
-      this.getTarget(node) :
-      node
+  unhook(node, name, next) {
+    const type = name.indexOf('on') === 0 ? name.substr(2).toLowerCase() : name.toLowerCase()
+
+    const target = this.getTarget != null ? this.getTarget(node) : node
 
     if (next == null || next.type != this.type) {
       node.removeEventListener(type, this.constructor.handleEvent)
@@ -112,7 +104,7 @@ const hash = v => {
 
 const blank = Object.create(null)
 export const on = (address, decode, options, getTarget) => {
-  const {stopPropagation, preventDefault} = options || blank
+  const { stopPropagation, preventDefault } = options || blank
   const id = `on:${hash(decode)}@${hash(getTarget)}:${hash(stopPropagation)}:${hash(preventDefault)}}`
 
   if (!address[id]) {
@@ -123,8 +115,7 @@ export const on = (address, decode, options, getTarget) => {
 }
 
 const getRoot = target => target.ownerDocument.defaultView
-export const onWindow = (address, decode, options) =>
-  on(address, decode, options, getRoot)
+export const onWindow = (address, decode, options) =>on(address, decode, options, getRoot)
 
 class MetaProperty {
   constructor(value, update) {
@@ -132,21 +123,18 @@ class MetaProperty {
     this.update = update
     this.type = 'MetaProperty'
   }
+
   hook(node, name, previous) {
-    const before = previous == null ?
-        previous :
-      previous.type != this.type ?
-        previous :
-        previous.value
+    const before = previous == null ? previous : previous.type != this.type ? previous : previous.value
 
     this.update(node, this.value, before)
   }
+
   unhook(node, name, next) {
   }
 }
 
-export const metaProperty = update => value =>
-  new MetaProperty(value, update)
+export const metaProperty = update => value =>new MetaProperty(value, update)
 
 
 // Bunch of meta properties are booleans, meaning they can be toggled on
@@ -188,42 +176,36 @@ export const focus = metaBooleanProperty((node, next, previous) => {
 
 
 // Equality checking for selections.
-const isSameSelection = (a, b) =>
-  (a && b && a.start === b.start && a.end === b.end && a.direction === b.direction);
+const isSameSelection = (a, b) =>(a && b && a.start === b.start && a.end === b.end && a.direction === b.direction);
 
 export const selection = metaProperty((node, next, previous) => {
   if (next != null && !isSameSelection(next, previous)) {
-    const {start, end, direction} = next;
+    const { start, end, direction } = next;
     Promise.resolve().then(() => {
-      node.setSelectionRange(start === Infinity ? node.value.length : start,
-                             end === Infinity ? node.value.length : end,
+      node.setSelectionRange(start === Infinity ? node.value.length : start, end === Infinity ? node.value.length : end,
                              direction);
     })
   }
 });
 
 
-export const forceRender: Task<Error, void> =
-  new Task
-  ( (succeed, fail) => {
-      if (window.renderer) {
-        window.renderer.execute();
-        console.log('Rendered in the same tick');
-        succeed(void(0));
-      }
-      else {
-        fail(Error('window.renderer must be set to enable force rendering'))
-      }
-    }
-  )
+export const forceRender:Task<Error, void> = new Task((succeed, fail) => {
+  if (window.renderer) {
+    window.renderer.execute();
+    console.log('Rendered in the same tick');
+    succeed(void(0));
+  } else {
+    fail(Error('window.renderer must be set to enable force rendering'))
+  }
+})
 
 
 // @Hack: The following three functions have being copied from:
 // https://github.com/Gozala/reflex-virtual-dom-driver/blob/c0248855bcf76123e50ff55a4b41bf19a53ab793/src/hooks/event-handler.js#L103-L119
-// As it was impossible to import them.
-// This hack can go away once https://github.com/Gozala/reflex-virtual-dom-driver/issues/4 is fixed.
+// As it was impossible to import them. This hack can go away once
+// https://github.com/Gozala/reflex-virtual-dom-driver/issues/4 is fixed.
 const handleEvent = phase => event => {
-  const {currentTarget, type} = event
+  const { currentTarget, type } = event
   const handler = currentTarget[`on${type}${phase}`]
 
   if (typeof(handler) === 'function') {
@@ -234,64 +216,48 @@ const handleEvent = phase => event => {
     handler.handleEvent(event)
   }
 }
-const handleCapturing: EventListener = handleEvent('capture')
-const handleBubbling: EventListener = handleEvent('bubble')
+const handleCapturing:EventListener = handleEvent('capture')
+const handleBubbling:EventListener = handleEvent('bubble')
 
 
-export const replaceElement =
-  (query: string, element: HTMLElement): Task<Error, void> =>
-  new Task
-  ( ( succeed, fail ) => {
-      const target = document.querySelector(query)
-      if (target == null) {
-        fail(Error('could not find node ${query}'))
+export const replaceElement = (query:string, element:HTMLElement):Task<Error, void> =>new Task((succeed, fail) => {
+  const target = document.querySelector(query)
+  if (target == null) {
+    fail(Error('could not find node ${query}'))
+  } else {
+    if (target != element) {
+      const { attributes } = target
+      const count = attributes.length
+      let index = 0
+      while (index < count) {
+        const { name, value } = attributes[index]
+        index = index + 1
+        element.setAttribute(name, value)
       }
-      else {
-        if (target != element) {
-          const {attributes} = target
-          const count = attributes.length
-          let index = 0
-          while (index < count) {
-            const {name, value} = attributes[index]
-            index = index + 1
-            element.setAttribute(name, value)
+
+      for (let name in target) {
+        if (target.hasOwnProperty(name)) {
+          if (name.indexOf('on:') === 0) {
+            const type = name.substr(3);
+            const handler = target[name];
+            element.addEventListener(type, handler.constructor.handleEvent);
+          } else if (name.indexOf('on') === 0) {
+            ( name.endsWith('capture')
+                    ? element.addEventListener(name.substring(2, name.length - 'capture'.length), handleCapturing, true)
+                    : name.endsWith('bubble')
+                    ? element.addEventListener(name.substring(2, name.length - 'bubble'.length), handleBubbling, false)
+                    : void(0)
+            );
           }
 
-          for (let name in target) {
-            if (target.hasOwnProperty(name)) {
-              if (name.indexOf('on:') === 0) {
-                const type = name.substr(3);
-                const handler = target[name];
-                element.addEventListener(type, handler.constructor.handleEvent);
-              }
-              else if (name.indexOf('on') === 0) {
-                ( name.endsWith('capture')
-                ? element.addEventListener
-                  ( name.substring(2, name.length - 'capture'.length)
-                  , handleCapturing
-                  , true
-                  )
-                : name.endsWith('bubble')
-                ? element.addEventListener
-                  ( name.substring(2, name.length - 'bubble'.length)
-                  , handleBubbling
-                  , false
-                  )
-                : void(0)
-                );
-              }
-
-              element[name] = target[name]
-            }
-          }
+          element[name] = target[name]
         }
-        target.parentNode.replaceChild(element, target);
       }
-      succeed(void(0));
     }
-  );
+    target.parentNode.replaceChild(element, target);
+  }
+  succeed(void(0));
+});
 
-export const forceReplace =
-  (query: string, element: HTMLElement): Task<Error, void> =>
-  forceRender
-  .chain(_ => replaceElement(query, element));
+export const forceReplace = (query:string, element:HTMLElement):Task<Error, void> =>forceRender
+    .chain(_ => replaceElement(query, element));

--- a/src/driver/virtual-dom/index.js
+++ b/src/driver/virtual-dom/index.js
@@ -203,7 +203,7 @@ export const selection = metaProperty((node, next, previous) => {
 });
 
 
-export const forceRender/*:Task<Error, void>*/ =
+export const forceRender: Task<Error, void> =
   new Task
   ( (succeed, fail) => {
       if (window.renderer) {
@@ -234,12 +234,12 @@ const handleEvent = phase => event => {
     handler.handleEvent(event)
   }
 }
-const handleCapturing/*:EventListener*/ = handleEvent('capture')
-const handleBubbling/*:EventListener*/ = handleEvent('bubble')
+const handleCapturing: EventListener = handleEvent('capture')
+const handleBubbling: EventListener = handleEvent('bubble')
 
 
 export const replaceElement =
-  (query/*:string*/, element/*:HTMLElement*/)/*:Task<Error, void>*/ =>
+  (query: string, element: HTMLElement): Task<Error, void> =>
   new Task
   ( ( succeed, fail ) => {
       const target = document.querySelector(query)
@@ -292,6 +292,6 @@ export const replaceElement =
   );
 
 export const forceReplace =
-  (query/*:string*/, element/*:HTMLElement*/)/*:Task<Error, void>*/ =>
+  (query: string, element: HTMLElement): Task<Error, void> =>
   forceRender
   .chain(_ => replaceElement(query, element));

--- a/src/lang/functional.js
+++ b/src/lang/functional.js
@@ -8,21 +8,21 @@
 
 const compose = (...lambdas) => {
   /**
-  Returns the composition of a list of functions, where each function
-  consumes the return value of the function that follows. In math
-  terms, composing the functions `f()`, `g()`, and `h()` produces
-  `f(g(h()))`.
-  Usage:
+   Returns the composition of a list of functions, where each function
+   consumes the return value of the function that follows. In math
+   terms, composing the functions `f()`, `g()`, and `h()` produces
+   `f(g(h()))`.
+   Usage:
 
-  var square = function(x) { return x * x }
-  var increment = function(x) { return x + 1 }
+   var square = function(x) { return x * x }
+   var increment = function(x) { return x + 1 }
 
-  var f1 = compose(increment, square)
-  f1(5) // => 26
+   var f1 = compose(increment, square)
+   f1(5) // => 26
 
-  var f2 = compose(square, increment)
-  f2(5) // => 36
-  **/
+   var f2 = compose(square, increment)
+   f2(5) // => 36
+   **/
 
   const composed = (...args) => {
     var index = lambdas.length;
@@ -36,35 +36,34 @@ const compose = (...lambdas) => {
   composed.toString = compose$toString;
   return composed;
 };
-const compose$toString = function() {
+const compose$toString = function () {
   return `compose(${this.lambdas.join(', ')})`
 }
 
-const partial = (lambda, ...curried) =>
-  (...passed) => lambda(...curried, ...passed);
+const partial = (lambda, ...curried) =>(...passed) => lambda(...curried, ...passed);
 
-const curry = (lambda, arity=lambda.length, curried) => {
+const curry = (lambda, arity = lambda.length, curried) => {
   /**
-  Returns function with implicit currying, which will continue currying until
-  expected number of argument is collected. Expected number of arguments is
-  determined by `lambda.length` unless it's 0. In later case function will be
-  assumed to be variadic and will be curried until invoked with `0` arguments.
-  Optionally `arity` of curried arguments can be overridden via second `arity`
-  argument.
-  ## Examples
-     var sum = curry(function(a, b) {
+   Returns function with implicit currying, which will continue currying until
+   expected number of argument is collected. Expected number of arguments is
+   determined by `lambda.length` unless it's 0. In later case function will be
+   assumed to be variadic and will be curried until invoked with `0` arguments.
+   Optionally `arity` of curried arguments can be overridden via second `arity`
+   argument.
+   ## Examples
+   var sum = curry(function(a, b) {
        return a + b
      })
-     console.log(sum(2, 2)) // 4
-     console.log(sum(2)(4)) // 6
-     var sum = curry(function() {
+   console.log(sum(2, 2)) // 4
+   console.log(sum(2)(4)) // 6
+   var sum = curry(function() {
        return Array.prototype.reduce.call(arguments, function(sum, number) {
          return sum + number
        }, 0)
      })
-     console.log(sum(2, 2)()) // 4
-     console.log(sum(2, 4, 5)(-3)(1)()) // 9
-  **/
+   console.log(sum(2, 2)()) // 4
+   console.log(sum(2, 4, 5)(-3)(1)()) // 9
+   **/
   return (...passed) => {
     const args = curried ? [...curried, ...passed] : passed;
     return args.length >= arity ? lambda(...args) : curry(lambda, arity, args);
@@ -100,12 +99,12 @@ const scheduler = task => {
 }
 
 
-const throttle = (f, wait, options={}) => {
+const throttle = (f, wait, options = {}) => {
   var args = null;
   var result = null;
   var timeout = null;
   var previous = 0;
-  var {leading, trailing} = options;
+  var { leading, trailing } = options;
 
 
   const later = () => {
@@ -117,7 +116,9 @@ const throttle = (f, wait, options={}) => {
 
   return (...params) => {
     var now = Date.now();
-    if (!previous && leading === false) previous = now;
+    if (!previous && leading === false) {
+      previous = now;
+    }
     var remaining = wait - (now - previous);
     args = params;
     if (remaining <= 0) {
@@ -148,7 +149,9 @@ const debounce = (f, wait, immediate) => {
       timeout = null;
       if (!immediate) {
         result = f(...args);
-        if (!timeout) args = null;
+        if (!timeout) {
+          args = null;
+        }
       }
     }
   };
@@ -157,7 +160,9 @@ const debounce = (f, wait, immediate) => {
     args = params;
     timestamp = Date.now();
     var callNow = immediate && !timeout;
-    if (!timeout) timeout = setTimeout(later, wait);
+    if (!timeout) {
+      timeout = setTimeout(later, wait);
+    }
     if (callNow) {
       result = f(...args);
       args = null;

--- a/src/lang/promise.js
+++ b/src/lang/promise.js
@@ -11,7 +11,7 @@ exports.fromDOMRequest = request => new Promise((resolve, reject) => {
   request.onerror = event => reject(request.error.name);
 });
 
-exports.fromEvent = (target, type, capture=false) => new Promise((resolve, reject) => {
+exports.fromEvent = (target, type, capture = false) => new Promise((resolve, reject) => {
   target.addEventListener(type, {
     handleEvent(event) {
       target.removeEventListener(type, this, capture);

--- a/src/lang/task.js
+++ b/src/lang/task.js
@@ -10,11 +10,11 @@
 // in a given mode (`next` or `throw`). Result is a function
 // that takes a `value` and resumes `task` in a curried `mode`
 // with a given `value`.
-const resume = (task, mode="next") => value => {
+const resume = (task, mode = "next") => value => {
   try {
     return task[mode](value);
   } catch (error) {
-    return {error}
+    return { error }
   }
 }
 
@@ -29,7 +29,7 @@ const resume = (task, mode="next") => value => {
 // that will be rejection reason. If exception is thrown / not
 // handled in generator body then returned promise will be
 // rejected with a given exception.
-const spawn = function(task, ...params) {
+const spawn = function (task, ...params) {
   return new Promise((resolve, reject) => {
     // start a task by passing arguments to generator, note if generator
     // throws right away it will just reject outer promise.
@@ -46,7 +46,7 @@ const spawn = function(task, ...params) {
     // exception was captured or resolves with value if generator returned)
     // or suspends generator until yield value is resolved / rejected and
     // then resumes it with resolution value / rejecetion reason.
-    const step = ({done, error, value}) => {
+    const step = ({ done, error, value }) => {
       // If error was captured reject promise.
       if (error) {
         reject(error);
@@ -60,10 +60,7 @@ const spawn = function(task, ...params) {
       // reseming funciton and caputre results which then are cycled back
       // onto next step.
       else {
-        Promise.
-        resolve(value).
-        then(next, raise).
-        then(step);
+        Promise.resolve(value).then(next, raise).then(step);
       }
     };
 
@@ -83,7 +80,7 @@ exports.spawn = spawn;
 // promise or exception will be thrown into generator if promise is
 // rejected. If exception is throw / not caught in generator body
 // then returned promise will be rejected with that promise.
-const async = task => function(...params) {
+const async = task => function (...params) {
   return spawn.call(this, task, ...params);
 };
 exports.async = async;
@@ -98,9 +95,9 @@ const schedule = (id, task, ...params) => {
     try {
       yield pending;
     }
-    // spawn a task regardless if previous task completed with error
-    // or success. Note we do not catch error here to let it propagate
-    // and make devtools handle it more properly.
+        // spawn a task regardless if previous task completed with error
+        // or success. Note we do not catch error here to let it propagate
+        // and make devtools handle it more properly.
     finally {
       return spawn(task, ...params);
     }

--- a/src/main.js
+++ b/src/main.js
@@ -4,22 +4,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import "babel-polyfill";
-import "./common/request-animation-frame";
-import {start, Effects} from "reflex";
-import * as UI from "./browser";
-import {version} from "../package.json";
-import * as Config from "../browserhtml.json";
-import * as Runtime from "./common/runtime";
-import {Renderer} from "@driver";
-import * as Devtools from "./devtools"
+import 'babel-polyfill'
+import './common/request-animation-frame'
+import { start, Effects } from 'reflex'
+import * as UI from './browser'
+import { version } from '../package.json'
+import * as Runtime from './common/runtime'
+import { Renderer } from '@driver'
+import * as Devtools from './devtools'
 
 const isReload = window.application != null;
-console.timeStamp =
-  ( console.timeStamp == null
-  ? console.log
-  : console.timeStamp
-  );
+console.timeStamp = ( console.timeStamp == null ? console.log : console.timeStamp
+);
 
 // If hotswap change address so it points to a new mailbox &r
 // re-render.
@@ -27,29 +23,20 @@ if (isReload) {
   window.application.address(Devtools.Persist);
 }
 
-document.body.classList.toggle('use-native-titlebar',
-                               Runtime.useNativeTitlebar());
+document.body.classList.toggle('use-native-titlebar', Runtime.useNativeTitlebar());
 
-const application = start
-  ( { flags:
-      { Debuggee: UI
-      , flags: void(0)
-      }
-    , init:
-      ( isReload
-      ? Devtools.restore
-      : Devtools.init
-      )
+const application = start({
+                            flags: {
+                              Debuggee: UI, flags: void(0)
+                            }, init: ( isReload ? Devtools.restore : Devtools.init
+  )
 
 
-
-    , update: Devtools.update
-    , view: Devtools.view
-    }
-  );
+                            , update: Devtools.update, view: Devtools.view
+                          });
 
 
-const renderer = new Renderer({target: document.body});
+const renderer = new Renderer({ target: document.body });
 
 application.view.subscribe(renderer.address);
 application.task.subscribe(Effects.driver(application.address));


### PR DESCRIPTION
This was done using WebStorm, with the formatting settings slightly tweaked from the defaults. I'm not 100% happy with the results, but what's good about this formatter is that, in difference to the others I tried, it normalizes line breaks and blank lines. Some quick testing shows that other formatters work quite a bit better after this one, so perhaps it's a good intermediate step.

Note that I don't think we should land this as-is - I'll experiment more with applying further reformattings that we should then be able to run automatically and that our integration tests could verify.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1094)
<!-- Reviewable:end -->
