### PR TITLE
Use https when looking up search suggestions

### DIFF
--- a/src/browser/Navigators/Navigator/Assistant/search.js
+++ b/src/browser/Navigators/Navigator/Assistant/search.js
@@ -133,7 +133,7 @@ const search =
   new Task((succeed, fail) => {
     const request = new XMLHttpRequest({ mozSystem: true });
     pendingRequests[id] = request;
-    const uri = `http://ac.duckduckgo.com/ac/?q=${input}&type=list`
+    const uri = `https://ac.duckduckgo.com/ac/?q=${input}&type=list`
     request.open
     ( 'GET'
     , uri


### PR DESCRIPTION
I was getting many errors like:
```
Error: Network request to http://ac.duckduckgo.com/ac/?q=ip&type=list has failed:
Error: Network request to http://ac.duckduckgo.com/ac/?q=iph&type=list has failed:
Error: Network request to http://ac.duckduckgo.com/ac/?q=ipho&type=list has failed:
Error: Network request to http://ac.duckduckgo.com/ac/?q=iph&type=list has failed:
Error: Network request to http://ac.duckduckgo.com/ac/?q=ip&type=list has failed:
Error: Network request to http://ac.duckduckgo.com/ac/?q=i&type=list has failed:
```
and no search suggestions.

Using https seems to fix the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1096)
<!-- Reviewable:end -->
