### PR TITLE
Optimize imports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,6 +6,7 @@
   ],
   "plugins": [
     "syntax-flow",
-    "transform-flow-strip-types"
+    "transform-flow-strip-types",
+    "transform-class-properties"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "babel-cli": "6.6.5",
     "babel-plugin-syntax-flow": "6.3.13",
+    "babel-plugin-transform-class-properties": "6.10.2",
     "babel-plugin-transform-es2015-modules-umd": "6.4.3",
     "babel-plugin-transform-flow-strip-types": "6.4.0",
     "babel-polyfill": "6.7.4",

--- a/src/about/newtab/main.js
+++ b/src/about/newtab/main.js
@@ -4,10 +4,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import "babel-polyfill";
-import {start, Effects} from "reflex";
-import * as NewTab from "./newtab";
-import {Renderer} from "@driver";
+import 'babel-polyfill'
+import { start, Effects } from 'reflex'
+import * as NewTab from './newtab'
+import { Renderer } from '@driver'
 
 const application = start({
   flags: void(0),

--- a/src/about/newtab/newtab.js
+++ b/src/about/newtab/newtab.js
@@ -13,10 +13,10 @@ import * as Unknown from "../../common/unknown";
 import * as Tiles from './newtab/tiles';
 import * as Wallpapers from './newtab/wallpapers';
 
-/*::
+
 import type {Address, DOM} from "reflex"
 import type {Model, Action} from "./newtab"
-*/
+
 
 const WallpapersAction =
   action =>

--- a/src/about/newtab/newtab.js
+++ b/src/about/newtab/newtab.js
@@ -33,7 +33,7 @@ const TilesAction =
   );
 
 export const init =
-  ()/*:[Model, Effects<Action>]*/ =>
+  ():[Model, Effects<Action>] =>
   {
     const [tiles, tilesFx] = Tiles.init();
     const [wallpapers, wallpaperFx] = Wallpapers.init();
@@ -67,7 +67,7 @@ const updateTiles = cursor
   );
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model:Model, action:Action):[Model, Effects<Action>] =>
   ( action.type === 'Wallpapers'
   ? updateWallpapers(model, action.wallpapers)
   : action.type === 'Tiles'
@@ -107,7 +107,7 @@ const readWallpaper = ({src, color}) =>
   );
 
 export const view =
-  ({wallpapers, tiles, help}/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ => {
+  ({wallpapers, tiles, help}:Model, address:Address<Action>):DOM => {
   const activeWallpaper = Wallpapers.active(wallpapers);
   return (
     html.div

--- a/src/about/newtab/newtab.js
+++ b/src/about/newtab/newtab.js
@@ -4,18 +4,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {merge, tag, tagged} from "../../common/prelude"
-import {Effects, html, thunk, forward} from "reflex"
-import {Style, StyleSheet} from "../../common/style";
-import {cursor} from "../../common/cursor";
-import * as Unknown from "../../common/unknown";
-
-import * as Tiles from './newtab/tiles';
-import * as Wallpapers from './newtab/wallpapers';
-
-
-import type {Address, DOM} from "reflex"
-import type {Model, Action} from "./newtab"
+import { merge } from '../../common/prelude'
+import type { Address, DOM } from 'reflex'
+import { Effects, html, thunk, forward } from 'reflex'
+import { Style, StyleSheet } from '../../common/style'
+import { cursor } from '../../common/cursor'
+import * as Unknown from '../../common/unknown'
+import * as Tiles from './newtab/tiles'
+import * as Wallpapers from './newtab/wallpapers'
+import type { Model, Action } from './newtab'
 
 
 const WallpapersAction =

--- a/src/about/newtab/newtab/tile.js
+++ b/src/about/newtab/newtab/tile.js
@@ -8,10 +8,10 @@ import {html, Effects} from "reflex";
 import * as Style from "../../../common/style";
 import * as Unknown from "../../../common/unknown";
 
-/*::
+
 import type {Address, DOM} from "reflex";
 import type {URI, Action, Model} from "./tile";
-*/
+
 
 
 export const init =

--- a/src/about/newtab/newtab/tile.js
+++ b/src/about/newtab/newtab/tile.js
@@ -15,7 +15,7 @@ import type {URI, Action, Model} from "./tile";
 
 
 export const init =
-  (title/*:string*/, uri/*:URI*/, src/*:URI*/)/*:[Model, Effects<Action>]*/ =>
+  (title:string, uri:URI, src:URI):[Model, Effects<Action>] =>
   [ { title
     , uri
     , src
@@ -24,7 +24,7 @@ export const init =
   ]
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model:Model, action:Action):[Model, Effects<Action>] =>
   Unknown.update(model, action)
 
 const styleSheet = Style.createSheet
@@ -66,7 +66,7 @@ const styleSheet = Style.createSheet
   );
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/, isDark/*:boolean*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>, isDark:boolean):DOM =>
   html.a
   ( { className: 'tile'
     , style: styleSheet.tile

--- a/src/about/newtab/newtab/tile.js
+++ b/src/about/newtab/newtab/tile.js
@@ -4,14 +4,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, Effects} from "reflex";
-import * as Style from "../../../common/style";
-import * as Unknown from "../../../common/unknown";
-
-
-import type {Address, DOM} from "reflex";
-import type {URI, Action, Model} from "./tile";
-
+import type { Address, DOM } from 'reflex'
+import { html, Effects } from 'reflex'
+import * as Style from '../../../common/style'
+import * as Unknown from '../../../common/unknown'
+import type { URI, Action, Model } from './tile'
 
 
 export const init =

--- a/src/about/newtab/newtab/tiles.js
+++ b/src/about/newtab/newtab/tiles.js
@@ -13,11 +13,11 @@ import hardcodedTiles from '../tiles.json';
 import * as Unknown from "../../../common/unknown";
 import {cursor} from "../../../common/cursor";
 
-/*::
+
 import type {Address, DOM} from "reflex"
 import type {Tagged} from "../../../common/prelude"
 import type {Action, Model} from "./tiles"
-*/
+
 
 
 

--- a/src/about/newtab/newtab/tiles.js
+++ b/src/about/newtab/newtab/tiles.js
@@ -22,7 +22,7 @@ import type {Action, Model} from "./tiles"
 
 
 export const init =
-  ()/*:[Model, Effects<Action>]*/ =>
+  ():[Model, Effects<Action>] =>
   [ hardcodedTiles
   , Effects.none
   ];
@@ -30,7 +30,7 @@ export const init =
 const TileAction = tag('Tile')
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model:Model, action:Action):[Model, Effects<Action>] =>
   Unknown.update(model, action)
 
 const styleSheet = StyleSheet.create
@@ -49,7 +49,7 @@ const styleSheet = StyleSheet.create
   );
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/, isDark/*:boolean*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>, isDark:boolean):DOM =>
   html.div
   ( { className: 'tiles'
     , style: styleSheet.tiles

--- a/src/about/newtab/newtab/tiles.js
+++ b/src/about/newtab/newtab/tiles.js
@@ -4,21 +4,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {tag} from "../../../common/prelude"
-import {Effects, html, thunk, forward} from "reflex"
-import {Style, StyleSheet} from "../../../common/style";
-import * as Tile from './tile';
+import type { Tagged } from '../../../common/prelude'
+import { tag } from '../../../common/prelude'
+import type { Address, DOM } from 'reflex'
+import { Effects, html, thunk, forward } from 'reflex'
+import { StyleSheet } from '../../../common/style'
+import * as Tile from './tile'
+import hardcodedTiles from '../tiles.json'
+import * as Unknown from '../../../common/unknown'
+import type { Action, Model } from './tiles'
 // @TODO hard-coded until we get history support in Servo.
-import hardcodedTiles from '../tiles.json';
-import * as Unknown from "../../../common/unknown";
-import {cursor} from "../../../common/cursor";
-
-
-import type {Address, DOM} from "reflex"
-import type {Tagged} from "../../../common/prelude"
-import type {Action, Model} from "./tiles"
-
-
 
 
 export const init =

--- a/src/about/newtab/newtab/wallpaper.js
+++ b/src/about/newtab/newtab/wallpaper.js
@@ -16,7 +16,7 @@ import type {Address, DOM} from "reflex"
 import type {Model, Action, URI, Color} from "./wallpaper"
 
 
-const Choose/*:Action*/ =
+const Choose:Action =
   { type: 'Choose'
   };
 
@@ -34,7 +34,7 @@ const styleSheet = Style.createSheet
   );
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>):DOM =>
   ( html.div
     ( { className: 'wallpaper-choice'
       , onClick: forward(address, always(Choose))

--- a/src/about/newtab/newtab/wallpaper.js
+++ b/src/about/newtab/newtab/wallpaper.js
@@ -11,10 +11,10 @@ import * as Unknown from "../../../common/unknown";
 
 import hardcodedWallpaper from "../wallpaper.json";
 
-/*::
+
 import type {Address, DOM} from "reflex"
 import type {Model, Action, URI, Color} from "./wallpaper"
-*/
+
 
 const Choose/*:Action*/ =
   { type: 'Choose'

--- a/src/about/newtab/newtab/wallpaper.js
+++ b/src/about/newtab/newtab/wallpaper.js
@@ -4,16 +4,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Effects, html, thunk, forward} from "reflex"
-import {merge, always, tagged} from "../../../common/prelude"
-import * as Style from "../../../common/style";
-import * as Unknown from "../../../common/unknown";
-
-import hardcodedWallpaper from "../wallpaper.json";
-
-
-import type {Address, DOM} from "reflex"
-import type {Model, Action, URI, Color} from "./wallpaper"
+import type { Address, DOM } from 'reflex'
+import { html, forward } from 'reflex'
+import { always } from '../../../common/prelude'
+import * as Style from '../../../common/style'
+import type { Model, Action, URI, Color } from './wallpaper'
 
 
 const Choose:Action =

--- a/src/about/newtab/newtab/wallpapers.js
+++ b/src/about/newtab/newtab/wallpapers.js
@@ -18,7 +18,7 @@ import type {Model, Action, ID} from "./wallpapers"
 
 
 export const init =
-  ()/*:[Model, Effects<Action>]*/ =>
+  ():[Model, Effects<Action>] =>
   [ hardcodedWallpaper
   , Effects.none
   ];
@@ -54,11 +54,11 @@ const notFound =
   }
 
 export const active =
-  ({entries, active}/*:Model*/)/*:Wallpaper.Model*/ =>
+  ({entries, active}:Model):Wallpaper.Model =>
   ( entries[active] || notFound )
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model:Model, action:Action):[Model, Effects<Action>] =>
   ( action.type === 'ChooseWallpaper'
   ? [ merge(model, {active: action.id})
     , Effects.none
@@ -84,7 +84,7 @@ const styleSheet = StyleSheet.create
   );
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>):DOM =>
   html.div
   ( { className: 'wallpaper'
     , style: styleSheet.base

--- a/src/about/newtab/newtab/wallpapers.js
+++ b/src/about/newtab/newtab/wallpapers.js
@@ -12,10 +12,10 @@ import * as Unknown from "../../../common/unknown";
 import hardcodedWallpaper from "../wallpaper.json";
 import * as Wallpaper from "./wallpaper";
 
-/*::
+
 import type {Address, DOM} from "reflex"
 import type {Model, Action, ID} from "./wallpapers"
-*/
+
 
 export const init =
   ()/*:[Model, Effects<Action>]*/ =>

--- a/src/about/newtab/newtab/wallpapers.js
+++ b/src/about/newtab/newtab/wallpapers.js
@@ -4,17 +4,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Effects, html, thunk, forward} from "reflex"
-import {merge, tagged} from "../../../common/prelude"
-import {Style, StyleSheet} from "../../../common/style";
-import * as Unknown from "../../../common/unknown";
-
-import hardcodedWallpaper from "../wallpaper.json";
-import * as Wallpaper from "./wallpaper";
-
-
-import type {Address, DOM} from "reflex"
-import type {Model, Action, ID} from "./wallpapers"
+import type { Address, DOM } from 'reflex'
+import { Effects, html, thunk, forward } from 'reflex'
+import { merge } from '../../../common/prelude'
+import { StyleSheet } from '../../../common/style'
+import * as Unknown from '../../../common/unknown'
+import hardcodedWallpaper from '../wallpaper.json'
+import * as Wallpaper from './wallpaper'
+import type { Model, Action, ID } from './wallpapers'
 
 
 export const init =

--- a/src/about/repl/main.js
+++ b/src/about/repl/main.js
@@ -4,10 +4,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import "babel-polyfill";
-import {start, Effects} from "reflex";
-import * as UI from "./repl";
-import {Renderer} from "@driver";
+import 'babel-polyfill'
+import { start, Effects } from 'reflex'
+import * as UI from './repl'
+import { Renderer } from '@driver'
 
 const isReload = window.application != null;
 

--- a/src/about/repl/repl.js
+++ b/src/about/repl/repl.js
@@ -73,7 +73,7 @@ const CellAction =
 
 
 export const init =
-  ()/*:[Model, Effects<Action>]*/ =>
+  ():[Model, Effects<Action>] =>
   createCell
   ( { nextID: 0
     , order: []
@@ -169,7 +169,7 @@ const print = (model, action) =>
   );
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model:Model, action:Action):[Model, Effects<Action>] =>
   ( action.type === 'Cell'
   ? updateCell(model, action.id, action.source)
   : action.type === 'Evaluate'
@@ -202,7 +202,7 @@ const styleSheet = StyleSheet.create
   );
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>):DOM =>
   html.div
   ( { style: styleSheet.base
     , id: 'repl'

--- a/src/about/repl/repl.js
+++ b/src/about/repl/repl.js
@@ -14,10 +14,10 @@ import * as Host from './repl/host';
 
 import {onWindow} from "@driver";
 
-/*::
+
 import type {Address, DOM} from "reflex"
 import type {Model, Action} from "./repl"
-*/
+
 
 
 // Actions

--- a/src/about/repl/repl.js
+++ b/src/about/repl/repl.js
@@ -4,20 +4,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, thunk, forward, Effects} from 'reflex';
-import {merge, always, batch, tag, tagged} from "../../common/prelude";
-import {Style, StyleSheet} from '../../common/style';
-import * as Cell from './repl/cell';
-import * as Settings from '../../common/settings';
-import * as Unknown from '../../common/unknown';
-import * as Host from './repl/host';
-
-import {onWindow} from "@driver";
-
-
-import type {Address, DOM} from "reflex"
-import type {Model, Action} from "./repl"
-
+import type { Address, DOM } from 'reflex'
+import { html, forward, Effects } from 'reflex'
+import { merge, always, batch } from '../../common/prelude'
+import { StyleSheet } from '../../common/style'
+import * as Cell from './repl/cell'
+import * as Unknown from '../../common/unknown'
+import * as Host from './repl/host'
+import { onWindow } from '@driver'
+import type { Model, Action } from './repl'
 
 
 // Actions

--- a/src/about/repl/repl/cell.js
+++ b/src/about/repl/repl/cell.js
@@ -12,10 +12,10 @@ import {cursor} from '../../../common/cursor';
 import * as Input from './input';
 import * as Output from './output';
 
-/*::
+
 import type {Address, DOM} from "reflex"
 import type {ID, Model, Action} from "./cell"
-*/
+
 
 export const Print =
   (output/*:Output.Model*/)/*:Action*/ =>

--- a/src/about/repl/repl/cell.js
+++ b/src/about/repl/repl/cell.js
@@ -18,18 +18,18 @@ import type {ID, Model, Action} from "./cell"
 
 
 export const Print =
-  (output/*:Output.Model*/)/*:Action*/ =>
+  (output:Output.Model):Action =>
   ( { type: "Print"
     , print: output
     }
   )
 
-export const Remove/*:Action*/ =
+export const Remove:Action =
   { type: "Remove"
   }
 
 const InputAction =
-  (action/*:Input.Action*/)/*:Action*/ =>
+  (action:Input.Action):Action =>
   ( action.type === "Submit"
   ? { type: "Submit"
     , source: action.source
@@ -40,18 +40,18 @@ const InputAction =
   );
 
 const OutputAction =
-  (action/*:Output.Action*/)/*:Action*/ =>
+  (action:Output.Action):Action =>
   ( { type: "Output"
     , output: action
     }
   );
 
-export const Edit/*:Action*/ =
+export const Edit:Action =
   InputAction(Input.Edit);
 
 
 export const init =
-  (id/*:ID*/)/*:[Model, Effects<Action>]*/ => {
+  (id:ID):[Model, Effects<Action>] => {
     const [input, inputFX] = Input.init(0, '', true);
     const [output, outputFX] = Output.init(0);
     const model =
@@ -104,7 +104,7 @@ const submit =
   );
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model:Model, action:Action):[Model, Effects<Action>] =>
   ( action.type === 'Input'
   ? updateInput(model, action.input)
   : action.type === 'Submit'
@@ -143,7 +143,7 @@ const styleSheet = StyleSheet.create
 
 
 export const render =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>):DOM =>
   html.form
   ( { id: `cell-${model.id}`
     , style: Style
@@ -167,5 +167,5 @@ export const render =
   );
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>):DOM =>
   thunk(model.id, render, model, address);

--- a/src/about/repl/repl/cell.js
+++ b/src/about/repl/repl/cell.js
@@ -4,17 +4,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, thunk, forward, Effects} from 'reflex';
-import {merge, batch, tag, tagged} from "../../../common/prelude";
-import {Style, StyleSheet} from '../../../common/style';
-import * as Unknown from '../../../common/unknown';
-import {cursor} from '../../../common/cursor';
-import * as Input from './input';
-import * as Output from './output';
-
-
-import type {Address, DOM} from "reflex"
-import type {ID, Model, Action} from "./cell"
+import type { Address, DOM } from 'reflex'
+import { html, thunk, forward, Effects } from 'reflex'
+import { merge } from '../../../common/prelude'
+import { Style, StyleSheet } from '../../../common/style'
+import * as Unknown from '../../../common/unknown'
+import { cursor } from '../../../common/cursor'
+import * as Input from './input'
+import * as Output from './output'
+import type { ID, Model, Action } from './cell'
 
 
 export const Print =

--- a/src/about/repl/repl/host/window.js
+++ b/src/about/repl/repl/host/window.js
@@ -69,7 +69,7 @@ const evalContext =
   }
 
 export const evaluate =
-  (id/*:ID*/, code/*:string*/)/*:Task<Never, EvaluationResult>*/ =>
+  (id:ID, code:string):Task<Never, EvaluationResult> =>
   new Task((succeed, fail) => void(new Promise((resolve, reject) => {
     try {
       const out = executeWith(evalContext, () => window.eval(code));

--- a/src/about/repl/repl/host/window.js
+++ b/src/about/repl/repl/host/window.js
@@ -8,10 +8,10 @@ import {html, thunk, forward, Effects, Task} from 'reflex';
 import {merge, batch, tag, tagged} from "../../../../common/prelude";
 import {ok, error} from "../../../../common/result";
 
-/*::
+
 import type {ID, EvaluationResult} from "../host"
 import type {Never} from "reflex"
-*/
+
 
 const DELETE = new String('delete');
 const executeWith = (context, execute) => {

--- a/src/about/repl/repl/host/window.js
+++ b/src/about/repl/repl/host/window.js
@@ -4,13 +4,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, thunk, forward, Effects, Task} from 'reflex';
-import {merge, batch, tag, tagged} from "../../../../common/prelude";
-import {ok, error} from "../../../../common/result";
-
-
-import type {ID, EvaluationResult} from "../host"
-import type {Never} from "reflex"
+import type { Never } from 'reflex'
+import { html, thunk, forward, Effects, Task } from 'reflex'
+import { merge, batch, tag, tagged } from '../../../../common/prelude'
+import { ok, error } from '../../../../common/result'
+import type { ID, EvaluationResult } from '../host'
 
 
 const DELETE = new String('delete');

--- a/src/about/repl/repl/input.js
+++ b/src/about/repl/repl/input.js
@@ -17,7 +17,7 @@ import type {Model, Action} from "./input"
 
 
 export const Change =
-  (value/*:string*/)/*:Action*/ =>
+  (value:string):Action =>
   ( { type: "Change"
     , source: value
     }
@@ -25,22 +25,22 @@ export const Change =
 
 
 export const Submit =
-  (model/*:Model*/)/*:Action*/ =>
+  (model:Model):Action =>
   ( { type: "Submit"
     , source: model
     }
   );
 
-export const Edit/*:Action*/ = { type: "Edit" };
+export const Edit:Action = { type: "Edit" };
 const Enter = { type: "Enter" };
 const Abort = { type: "Abort" };
 
 
 export const init =
-  ( version/*:number*/
-  , value/*:string*/
-  , isEditing/*:boolean*/
-  )/*:[Model, Effects<Action>]*/ =>
+  ( version:number
+  , value:string
+  , isEditing:boolean
+  ):[Model, Effects<Action>] =>
   [ { value
     , isEditing
     , version
@@ -93,7 +93,7 @@ const decodeChange =
   Change(event.target.value);
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model:Model, action:Action):[Model, Effects<Action>] =>
   ( action.type === "Change"
   ? change(model, action.source)
   : action.type === "Edit"
@@ -197,5 +197,5 @@ const render =
   );
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>):DOM =>
   thunk('input', render, model, address);

--- a/src/about/repl/repl/input.js
+++ b/src/about/repl/repl/input.js
@@ -11,10 +11,10 @@ import * as Settings from '../../../common/settings';
 import * as Unknown from '../../../common/unknown';
 import {focus} from "@driver";
 
-/*::
+
 import type {Address, DOM} from "reflex"
 import type {Model, Action} from "./input"
-*/
+
 
 export const Change =
   (value/*:string*/)/*:Action*/ =>

--- a/src/about/repl/repl/input.js
+++ b/src/about/repl/repl/input.js
@@ -4,16 +4,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, thunk, forward, Effects} from 'reflex';
-import {merge, always} from "../../../common/prelude";
-import {Style, StyleSheet} from '../../../common/style';
-import * as Settings from '../../../common/settings';
-import * as Unknown from '../../../common/unknown';
-import {focus} from "@driver";
-
-
-import type {Address, DOM} from "reflex"
-import type {Model, Action} from "./input"
+import type { Address, DOM } from 'reflex'
+import { html, thunk, forward, Effects } from 'reflex'
+import { merge, always } from '../../../common/prelude'
+import { Style, StyleSheet } from '../../../common/style'
+import * as Unknown from '../../../common/unknown'
+import { focus } from '@driver'
+import type { Model, Action } from './input'
 
 
 export const Change =

--- a/src/about/repl/repl/output.js
+++ b/src/about/repl/repl/output.js
@@ -11,11 +11,11 @@ import * as Settings from '../../../common/settings';
 import * as Unknown from '../../../common/unknown';
 import {focus} from "@driver";
 
-/*::
+
 import type {Address, DOM} from "reflex"
 import type {EvaluationResult} from "./host"
 import type {Model, Action} from "./output"
-*/
+
 
 export const Print = tag("Print");
 

--- a/src/about/repl/repl/output.js
+++ b/src/about/repl/repl/output.js
@@ -20,9 +20,9 @@ import type {Model, Action} from "./output"
 export const Print = tag("Print");
 
 export const init =
-  ( version/*:number*/
-  , result/*:?EvaluationResult*/=null
-  )/*:[Model, Effects<Action>]*/ =>
+  ( version:number
+  , result:?EvaluationResult=null
+  ):[Model, Effects<Action>] =>
   [ { version
     , result
     }
@@ -40,7 +40,7 @@ const print = (model, output) =>
   ];
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model:Model, action:Action):[Model, Effects<Action>] =>
   ( action.type === 'Print'
   ? print(model, action.source)
   : Unknown.update(model, action)
@@ -113,5 +113,5 @@ const render =
   );
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>):DOM =>
   thunk('output', render, model, address);

--- a/src/about/repl/repl/output.js
+++ b/src/about/repl/repl/output.js
@@ -4,17 +4,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, thunk, forward, Effects} from 'reflex';
-import {merge, always, batch, tag, tagged} from "../../../common/prelude";
-import {Style, StyleSheet} from '../../../common/style';
-import * as Settings from '../../../common/settings';
-import * as Unknown from '../../../common/unknown';
-import {focus} from "@driver";
-
-
-import type {Address, DOM} from "reflex"
-import type {EvaluationResult} from "./host"
-import type {Model, Action} from "./output"
+import type { Address, DOM } from 'reflex'
+import { html, thunk, Effects } from 'reflex'
+import { merge, tag } from '../../../common/prelude'
+import { Style, StyleSheet } from '../../../common/style'
+import * as Unknown from '../../../common/unknown'
+import { focus } from '@driver'
+import type { EvaluationResult } from './host'
+import type { Model, Action } from './output'
 
 
 export const Print = tag("Print");

--- a/src/about/settings/main.js
+++ b/src/about/settings/main.js
@@ -4,10 +4,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import "babel-polyfill";
-import {start, Effects} from "reflex";
-import * as UI from "./settings";
-import {Renderer} from "@driver";
+import 'babel-polyfill'
+import { start, Effects } from 'reflex'
+import * as UI from './settings'
+import { Renderer } from '@driver'
 
 const isReload = window.application != null;
 

--- a/src/about/settings/setting.js
+++ b/src/about/settings/setting.js
@@ -21,7 +21,7 @@ import type {Value, Model, Action} from "./setting"
 
 
 const TextInputAction =
-  (action/*:TextInput.Action*/)/*:Action*/ =>
+  (action:TextInput.Action):Action =>
   ( action.type === "Blur"
   ? Abort
   : { type: "TextInput"
@@ -30,22 +30,22 @@ const TextInputAction =
   );
 
 
-export const Edit/*:Action*/ = { type: "Edit" };
-export const Abort/*:Action*/ = { type: "Abort" };
-export const Submit/*:Action*/ = { type: "Submit" };
+export const Edit:Action = { type: "Edit" };
+export const Abort:Action = { type: "Abort" };
+export const Submit:Action = { type: "Submit" };
 
 const Save = tag("Save");
 export const Change = tag("Change");
 
-const FocusInput/*:Action*/ = TextInputAction(TextInput.Focus);
-const DisableInput/*:Action*/ = TextInputAction(TextInput.Disable);
-const EnableInput/*:Action*/ = TextInputAction(TextInput.Enable);
+const FocusInput:Action = TextInputAction(TextInput.Focus);
+const DisableInput:Action = TextInputAction(TextInput.Disable);
+const EnableInput:Action = TextInputAction(TextInput.Enable);
 const ChangeInput = compose(TextInputAction, TextInput.Change);
 
 
 
 export const init =
-  (value/*:Value*/)/*:[Model, Effects<Action>]*/ => {
+  (value:Value):[Model, Effects<Action>] => {
     const [input, fx] = TextInput.init
       ( ( value == null
         ? ''
@@ -142,7 +142,7 @@ const parseInput =
   };
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model:Model, action:Action):[Model, Effects<Action>] =>
   ( action.type === 'Edit'
   ? edit(model)
   : action.type === 'Abort'
@@ -272,7 +272,7 @@ const viewInput = TextInput.view
 
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>):DOM =>
   html.form
   ( { onKeyDown:
       event => {

--- a/src/about/settings/setting.js
+++ b/src/about/settings/setting.js
@@ -15,10 +15,10 @@ import * as Focusable from '../../common/focusable';
 import * as Editable from '../../common/editable';
 import * as TextInput from '../../common/text-input';
 
-/*::
+
 import type {Address, DOM} from "reflex";
 import type {Value, Model, Action} from "./setting"
-*/
+
 
 const TextInputAction =
   (action/*:TextInput.Action*/)/*:Action*/ =>

--- a/src/about/settings/setting.js
+++ b/src/about/settings/setting.js
@@ -4,20 +4,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Style, StyleSheet} from '../../common/style';
-import {html, thunk, forward, Effects} from 'reflex';
-import {compose} from '../../lang/functional';
-import {merge, always, tag, tagged, batch} from "../../common/prelude"
-import {cursor} from "../../common/cursor"
-import {ok, error} from "../../common/result";
-import * as Unknown from '../../common/unknown';
-import * as Focusable from '../../common/focusable';
-import * as Editable from '../../common/editable';
-import * as TextInput from '../../common/text-input';
-
-
-import type {Address, DOM} from "reflex";
-import type {Value, Model, Action} from "./setting"
+import { Style, StyleSheet } from '../../common/style'
+import type { Address, DOM } from 'reflex'
+import { html, thunk, forward, Effects } from 'reflex'
+import { compose } from '../../lang/functional'
+import { merge, always, tag, batch } from '../../common/prelude'
+import { cursor } from '../../common/cursor'
+import { ok, error } from '../../common/result'
+import * as Unknown from '../../common/unknown'
+import * as TextInput from '../../common/text-input'
+import type { Value, Model, Action } from './setting'
 
 
 const TextInputAction =

--- a/src/about/settings/settings.js
+++ b/src/about/settings/settings.js
@@ -11,10 +11,10 @@ import * as Settings from '../../common/settings';
 import * as Unknown from '../../common/unknown';
 import * as Setting from './setting';
 
-/*::
+
 import type {Address, DOM} from "reflex";
 import type {Name, Value, Model, Action} from "./settings";
-*/
+
 
 // Actions
 

--- a/src/about/settings/settings.js
+++ b/src/about/settings/settings.js
@@ -61,7 +61,7 @@ const Changed =
 
 
 const SettingAction =
-  (name/*:Name*/, action/*:Setting.Action*/)/*:Action*/ =>
+  (name:Name, action:Setting.Action):Action =>
   ( action.type === 'Save'
   ? Save
     ( { [name]: action.source
@@ -74,7 +74,7 @@ const SettingAction =
   );
 
 const SettingActionByName =
-  (name/*:Name*/)/*:(action:Setting.Action) => Action*/ =>
+  (name:Name)/*:(action:Setting.Action) => Action*/ =>
   action =>
   SettingAction(name, action);
 
@@ -82,7 +82,7 @@ const ChangeSetting =
   (name, value) =>
   SettingAction(name, Setting.Change(value));
 
-export const init = ()/*:[Model, Effects<Action>]*/ => {
+export const init = ():[Model, Effects<Action>] => {
   const model =
     { settings: {}
     };
@@ -204,7 +204,7 @@ const updateSettingByName = (model, name, action) => {
 }
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model:Model, action:Action):[Model, Effects<Action>] =>
   ( action.type === 'Save'
   ? save(model, action.source)
 
@@ -273,7 +273,7 @@ const styleSheet = StyleSheet.create
 
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>):DOM =>
   html.div
   ( { key: 'settings'
     , style: styleSheet.base

--- a/src/about/settings/settings.js
+++ b/src/about/settings/settings.js
@@ -74,7 +74,7 @@ const SettingAction =
   );
 
 const SettingActionByName =
-  (name:Name)/*:(action:Setting.Action) => Action*/ =>
+  (name:Name):(action:Setting.Action) => Action =>
   action =>
   SettingAction(name, action);
 

--- a/src/about/settings/settings.js
+++ b/src/about/settings/settings.js
@@ -4,16 +4,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, thunk, forward, Effects} from 'reflex';
-import {merge, batch, always, tag, tagged} from "../../common/prelude";
-import {Style, StyleSheet} from '../../common/style';
-import * as Settings from '../../common/settings';
-import * as Unknown from '../../common/unknown';
-import * as Setting from './setting';
-
-
-import type {Address, DOM} from "reflex";
-import type {Name, Value, Model, Action} from "./settings";
+import type { Address, DOM } from 'reflex'
+import { html, thunk, forward, Effects } from 'reflex'
+import { merge, batch, always } from '../../common/prelude'
+import { Style, StyleSheet } from '../../common/style'
+import * as Settings from '../../common/settings'
+import * as Unknown from '../../common/unknown'
+import * as Setting from './setting'
+import type { Name, Value, Model, Action } from './settings'
 
 
 // Actions

--- a/src/browser.js
+++ b/src/browser.js
@@ -100,11 +100,11 @@ export class Model {
   devtools: Devtools.Model;
   
   constructor(
-    version/*:Version*/=Package.version
-  , shell/*:Shell.Model*/
-  , navigators/*:Navigators.Model*/
-  , sidebar/*:Sidebar.Model*/
-  , devtools/*:Devtools.Model*/
+    version:Version=Package.version
+  , shell:Shell.Model
+  , navigators:Navigators.Model
+  , sidebar:Sidebar.Model
+  , devtools:Devtools.Model
   ) {
     this.version = version
     this.shell = shell
@@ -123,7 +123,7 @@ const Modify =
     }
   )
 
-export const init = ()/*:[Model, Effects<Action>]*/ => {
+export const init = ():[Model, Effects<Action>] => {
   const [devtools, devtoolsFx] = Devtools.init({isActive: Config.devtools});
   const [shell, shellFx] = Shell.init();
   const [sidebar, sidebarFx] = Sidebar.init();
@@ -170,7 +170,7 @@ const SidebarAction = action =>
 
 
 const NavigatorsAction =
-  (action/*:Navigators.Action*/)/*:Action*/ => {
+  (action:Navigators.Action):Action => {
     switch (action.type) {
       case "ShowTabs":
         return ShowTabs
@@ -261,7 +261,7 @@ const updateSidebar = cursor({
   update: Sidebar.update
 });
 
-const Reloaded/*:Action*/ =
+const Reloaded:Action =
   { type: "Reloaded"
   };
 
@@ -275,56 +275,56 @@ const Failure = error =>
 // ### Mode changes
 
 
-export const OpenNewTab/*:Action*/ =
+export const OpenNewTab:Action =
   { type: 'OpenNewTab'
   };
 
-export const EditWebView/*:Action*/ =
+export const EditWebView:Action =
   { type: 'EditWebView'
   };
 
-export const ShowWebView/*:Action*/ =
+export const ShowWebView:Action =
   { type: 'ShowWebView'
   };
 
-export const ShowTabs/*:Action*/ =
+export const ShowTabs:Action =
   { type: 'ShowTabs'
   };
 
-export const SelectWebView/*:Action*/ =
+export const SelectWebView:Action =
   { type: 'SelectWebView'
   };
 
 // ### Actions that affect multilpe sub-components
 
-export const OpenWebView/*:Action*/ =
+export const OpenWebView:Action =
   { type: 'OpenWebView'
   };
 
-export const AttachSidebar/*:Action*/ =
+export const AttachSidebar:Action =
   { type: "AttachSidebar"
   , source: Sidebar.Attach
   };
 
-export const DetachSidebar/*:Action*/ =
+export const DetachSidebar:Action =
   { type: "DetachSidebar"
   , source: Sidebar.Detach
   };
 
-export const Escape/*:Action*/ =
+export const Escape:Action =
   { type: 'Escape'
   };
 
 
-export const Unload/*:Action*/ =
+export const Unload:Action =
   { type: 'Unload'
   };
 
-export const ReloadRuntime/*:Action*/ =
+export const ReloadRuntime:Action =
   { type: 'ReloadRuntime'
   };
 
-export const BlurInput/*:Action*/ =
+export const BlurInput:Action =
   { type: 'BlurInput'
   };
 
@@ -608,7 +608,7 @@ const reloadRuntime = model =>
 
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ => {
+  (model:Model, action:Action):[Model, Effects<Action>] => {
     switch (action.type) {
       case 'GoBack':
         return goBack(model);
@@ -704,7 +704,7 @@ const styleSheet = StyleSheet.create({
 });
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>):DOM =>
   html.main
   ( { className: 'root'
     , style: styleSheet.root

--- a/src/browser.js
+++ b/src/browser.js
@@ -92,13 +92,13 @@ import type {URI} from "./common/prelude"
 */
 
 export class Model {
-  /*::
+  
   version: Version;
   shell: Shell.Model;
   navigators: Navigators.Model;
   sidebar: Sidebar.Model;
   devtools: Devtools.Model;
-  */
+  
   constructor(
     version/*:Version*/=Package.version
   , shell/*:Shell.Model*/

--- a/src/browser.js
+++ b/src/browser.js
@@ -5,29 +5,21 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import * as Package from "../package.json";
-import * as Config from "../browserhtml.json";
-import {Effects, html, forward, thunk} from "reflex";
-
-import * as Shell from "./browser/shell";
-import * as Sidebar from './browser/Sidebar';
-import * as Devtools from "./common/devtools";
-import * as Runtime from "./common/runtime";
-import * as URL from './common/url-helper';
-import * as Unknown from "./common/unknown";
-import * as Focusable from "./common/focusable";
-import * as OS from './common/os';
-import * as Keyboard from './common/keyboard';
-import * as Stopwatch from "./common/stopwatch";
-import * as Easing from "eased";
-import {always, batch, tag, tagged} from "./common/prelude";
-import {cursor} from "./common/cursor";
-import {Style, StyleSheet} from './common/style';
-
-import {identity, compose} from "./lang/functional";
-
-import {onWindow, on} from "@driver";
-import * as Navigators from "./browser/Navigators";
+import * as Package from '../package.json'
+import * as Config from '../browserhtml.json'
+import { Effects, html, forward } from 'reflex'
+import * as Shell from './browser/shell'
+import * as Sidebar from './browser/Sidebar'
+import * as Devtools from './common/devtools'
+import * as Runtime from './common/runtime'
+import * as Unknown from './common/unknown'
+import * as OS from './common/os'
+import * as Keyboard from './common/keyboard'
+import { always, batch } from './common/prelude'
+import { cursor } from './common/cursor'
+import { StyleSheet } from './common/style'
+import { onWindow, on } from '@driver'
+import * as Navigators from './browser/Navigators'
 
 
 /*::

--- a/src/browser/Navigators.js
+++ b/src/browser/Navigators.js
@@ -67,10 +67,10 @@ export class Model {
   animation: Animation.Model<Display.Model>;
   
   constructor(
-    zoom/*:boolean*/
-  , shrink/*:boolean*/
-  , deck/*:Deck.Model*/
-  , animation/*:Animation.Model<Display.Model>*/
+    zoom:boolean
+  , shrink:boolean
+  , deck:Deck.Model
+  , animation:Animation.Model<Display.Model>
   ) {
     this.zoom = zoom;
     this.shrink = shrink;
@@ -95,7 +95,7 @@ const Card =
 
 
 const tagDeck =
-  (action/*:Deck.Action<Navigator.Action, Navigator.Flags>*/)/*:Action*/ => {
+  (action:Deck.Action<Navigator.Action, Navigator.Flags>):Action => {
     switch (action.type) {
       case "Modify":
         switch (action.modify.type) {
@@ -144,9 +144,9 @@ const tagOverlay = always(ShowWebView);
 
 
 export const init =
-  ( zoom/*:boolean*/=true
-  , shrink/*:boolean*/=false
-  )/*:[Model, Effects<Action>]*/ => {
+  ( zoom:boolean=true
+  , shrink:boolean=false
+  ):[Model, Effects<Action>] => {
     const flags =
       { input:
         { value: ''
@@ -195,7 +195,7 @@ export const init =
   }
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ => {
+  (model:Model, action:Action):[Model, Effects<Action>] => {
     switch (action.type) {
       case "Animation":
         return updateAnimation(model, action.animation);
@@ -432,9 +432,9 @@ const startAnimation =
 
 
 export const render =
-  ( model/*:Model*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  ( model:Model
+  , address:Address<Action>
+  ):DOM =>
   html.div
   ( { className: 'navigator-deck'
     , style:
@@ -459,9 +459,9 @@ export const render =
   )
 
 export const view =
-  ( model/*:Model*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  ( model:Model
+  , address:Address<Action>
+  ):DOM =>
   thunk
   ( 'Browser/NavigatorDeck'
   , render

--- a/src/browser/Navigators.js
+++ b/src/browser/Navigators.js
@@ -14,7 +14,7 @@ import * as Navigator from "./Navigators/Navigator"
 import * as URI from "../common/url-helper";
 import * as Tabs from "./Sidebar/Tabs";
 
-/*::
+
 import type {Address, DOM} from "reflex"
 
 export type Action =
@@ -38,7 +38,7 @@ export type Action =
   | { type: "Animation", animation: Animation.Action }
   | { type: "Tabs", tabs: Tabs.Action }
   | { type: "Deck", deck: Deck.Action<Navigator.Action, Navigator.Flags> }
-*/
+
 
 export const Expose = { type: "Expose" }
 export const Focus = { type: "Focus" }
@@ -60,12 +60,12 @@ export const SelectPrevious = { type: "SelectPrevious" }
 export const Close = { type: "Close" }
 
 export class Model {
-  /*::
+  
   zoom: boolean;
   shrink: boolean;
   deck: Deck.Model;
   animation: Animation.Model<Display.Model>;
-  */
+  
   constructor(
     zoom/*:boolean*/
   , shrink/*:boolean*/
@@ -292,7 +292,7 @@ const updateTabs =
   (model, action) =>
   // Flow inference seems to fail here, so we just make it believe
   // that we restructured action so it will suceed inferring.
-  (/*::
+  (
     action.type === "Modify"
   ? updateDeck
     ( model
@@ -304,7 +304,7 @@ const updateTabs =
         }
       }
     )
-  :*/updateDeck(model, action)
+  :updateDeck(model, action)
   )
 
 const selectNext =

--- a/src/browser/Navigators.js
+++ b/src/browser/Navigators.js
@@ -1,21 +1,19 @@
 /* @flow */
 
-import * as Deck from "../common/Deck"
-import * as Animation from "../common/Animation"
-import * as Unknown from "../common/unknown"
-import * as Display from "./Navigators/Display"
-import {Effects, html, forward, thunk} from "reflex"
-import {cursor} from "../common/cursor"
-import {always} from "../common/prelude"
-import * as Style from "../common/style"
-import * as Easing from "eased"
-import * as Overlay from "./Navigators/Overlay"
-import * as Navigator from "./Navigators/Navigator"
-import * as URI from "../common/url-helper";
-import * as Tabs from "./Sidebar/Tabs";
-
-
-import type {Address, DOM} from "reflex"
+import * as Deck from '../common/Deck'
+import * as Animation from '../common/Animation'
+import * as Unknown from '../common/unknown'
+import * as Display from './Navigators/Display'
+import type { Address, DOM } from 'reflex'
+import { Effects, html, forward, thunk } from 'reflex'
+import { cursor } from '../common/cursor'
+import { always } from '../common/prelude'
+import * as Style from '../common/style'
+import * as Easing from 'eased'
+import * as Overlay from './Navigators/Overlay'
+import * as Navigator from './Navigators/Navigator'
+import * as URI from '../common/url-helper'
+import * as Tabs from './Sidebar/Tabs'
 
 export type Action =
   | { type: "Expose" }

--- a/src/browser/Navigators/Display.js
+++ b/src/browser/Navigators/Display.js
@@ -7,10 +7,10 @@
 import * as Easing from "eased";
 
 export class Model {
-  /*::
+  
   rightOffset: number;
   depth: number;
-  */
+  
   constructor(depth/*:number*/, rightOffset/*:number*/=0) {
     this.depth = depth
     this.rightOffset = rightOffset

--- a/src/browser/Navigators/Display.js
+++ b/src/browser/Navigators/Display.js
@@ -11,7 +11,7 @@ export class Model {
   rightOffset: number;
   depth: number;
   
-  constructor(depth/*:number*/, rightOffset/*:number*/=0) {
+  constructor(depth:number, rightOffset:number=0) {
     this.depth = depth
     this.rightOffset = rightOffset
   }
@@ -25,10 +25,10 @@ export const expose = new Model(-200, 0)
 export const exposeShrinked = new Model(-200, 50)
 
 export const interpolate =
-  ( from/*:Model*/
-  , to/*:Model*/
-  , progress/*:number*/
-  )/*:Model*/ =>
+  ( from:Model
+  , to:Model
+  , progress:number
+  ):Model =>
   new Model
   ( Easing.float(from.depth, to.depth, progress)
   , Easing.float(from.rightOffset, to.rightOffset, progress)

--- a/src/browser/Navigators/Display.js
+++ b/src/browser/Navigators/Display.js
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import * as Easing from "eased";
+import * as Easing from 'eased'
 
 export class Model {
   

--- a/src/browser/Navigators/Navigator.js
+++ b/src/browser/Navigators/Navigator.js
@@ -252,7 +252,7 @@ const tagAnimation =
   };
 
 export const Navigate =
-  ( destination/*:string*/)/*:Action*/ =>
+  ( destination:string):Action =>
   ( { type: "Navigate"
     , uri: URL.read(destination)
     }
@@ -282,16 +282,16 @@ export class Model {
   animation: Animation.Model<Display.Model>;
   
   constructor(
-    isSelected/*:boolean*/
-  , isClosed/*:boolean*/
-  , isPinned/*:boolean*/
-  , isInputEmbedded/*:boolean*/
-  , input/*:Input.Model*/
-  , output/*:Output.Model*/
-  , assistant/*:Assistant.Model*/
-  , overlay/*:Overlay.Model*/
-  , progress/*:Progress.Model*/
-  , animation/*:Animation.Model<Display.Model>*/
+    isSelected:boolean
+  , isClosed:boolean
+  , isPinned:boolean
+  , isInputEmbedded:boolean
+  , input:Input.Model
+  , output:Output.Model
+  , assistant:Assistant.Model
+  , overlay:Overlay.Model
+  , progress:Progress.Model
+  , animation:Animation.Model<Display.Model>
   ) {
     this.isSelected = isSelected
     this.isClosed = isClosed
@@ -346,7 +346,7 @@ const assemble =
 
 
 export const init =
-  (options/*:Flags*/)/*:[Model, Effects<Action>]*/ =>
+  (options:Flags):[Model, Effects<Action>] =>
   assemble
   ( options.output.disposition != 'background-tab'
   , false
@@ -365,9 +365,9 @@ export const init =
   )
 
 export const update =
-  ( model/*:Model*/
-  , action/*:Action*/
-  )/*:[Model, Effects<Action>]*/ => {
+  ( model:Model
+  , action:Action
+  ):[Model, Effects<Action>] => {
     // console.log(action)
     switch (action.type) {
       case 'NoOp':
@@ -466,14 +466,14 @@ export const update =
   };
 
 const nofx =
-  (model/*:Model*/)/*:[Model, Effects<Action>]*/ =>
+  (model:Model):[Model, Effects<Action>] =>
   [ model
   , Effects.none
   ];
 
 export const select =
-  ( model/*:Model*/
-  )/*:[Model, Effects<Action>]*/ =>
+  ( model:Model
+  ):[Model, Effects<Action>] =>
   ( model.isSelected
   ? nofx(model)
   : startAnimation
@@ -489,8 +489,8 @@ export const select =
   )
 
 export const deselect =
-  ( model/*:Model*/
-  )/*:[Model, Effects<Action>]*/ =>
+  ( model:Model
+  ):[Model, Effects<Action>] =>
   ( model.isSelected
   ? startAnimation
     ( model
@@ -506,8 +506,8 @@ export const deselect =
   )
 
 export const close =
-  ( model/*:Model*/
-  )/*:[Model, Effects<Action>]*/ =>
+  ( model:Model
+  ):[Model, Effects<Action>] =>
   ( model.isPinned
   ? [ model
     , Effects.receive(Select)
@@ -891,7 +891,7 @@ const endAnimation =
   )
 
 export const render =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>):DOM =>
   html.dialog
   ( { className: `navigator ${mode(model.output)}`
     , open: true
@@ -928,7 +928,7 @@ export const render =
   )
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>):DOM =>
   thunk
   ( model.output.ref.value
   , render

--- a/src/browser/Navigators/Navigator.js
+++ b/src/browser/Navigators/Navigator.js
@@ -25,7 +25,7 @@ import * as Tab from "../Sidebar/Tab";
 
 import {readTitle, isSecure, isDark, canGoBack} from './Navigator/WebView/Util';
 
-/*::
+
 import type {Address, DOM} from "reflex"
 import type {URI, Time} from "./Navigator/WebView"
 
@@ -106,7 +106,7 @@ export type Action =
   // Animation
   | { type: "Animation", animation: Animation.Action }
   | { type: "AnimationEnd" }
-*/
+
 
 const SubmitInput = { type: "SubmitInput" }
 const EscapeInput = { type: "EscapeInput" }
@@ -269,7 +269,7 @@ const SetSelectedInputValue =
   )
 
 export class Model {
-  /*::
+  
   isSelected: boolean;
   isClosed: boolean;
   isPinned: boolean;
@@ -280,7 +280,7 @@ export class Model {
   assistant: Assistant.Model;
   progress: Progress.Model;
   animation: Animation.Model<Display.Model>;
-  */
+  
   constructor(
     isSelected/*:boolean*/
   , isClosed/*:boolean*/

--- a/src/browser/Navigators/Navigator.js
+++ b/src/browser/Navigators/Navigator.js
@@ -4,30 +4,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Effects, html, forward, thunk} from "reflex"
-import {merge, always, batch} from "../../common/prelude";
-import {cursor} from "../../common/cursor";
-import * as Style from "../../common/style";
-
-import * as Assistant from "./Navigator/Assistant";
-import * as Overlay from "./Navigator/Overlay";
-import * as Input from "./Navigator/Input";
-import * as Output from "./Navigator/WebView";
-import * as Unknown from "../../common/unknown";
-import * as URL from '../../common/url-helper';
-import * as Header from './Navigator/Header';
-import * as Title from './Navigator/Title';
-import * as Progress from './Navigator/Progress';
-import * as Display from './Navigator/Display';
-import * as Animation from "../../common/Animation";
-import * as Easing from "eased";
-import * as Tab from "../Sidebar/Tab";
-
-import {readTitle, isSecure, isDark, canGoBack} from './Navigator/WebView/Util';
-
-
-import type {Address, DOM} from "reflex"
-import type {URI, Time} from "./Navigator/WebView"
+import type { Address, DOM } from 'reflex'
+import { Effects, html, forward, thunk } from 'reflex'
+import { always, batch } from '../../common/prelude'
+import { cursor } from '../../common/cursor'
+import * as Style from '../../common/style'
+import * as Assistant from './Navigator/Assistant'
+import * as Overlay from './Navigator/Overlay'
+import * as Input from './Navigator/Input'
+import type { URI, Time } from './Navigator/WebView'
+import * as Output from './Navigator/WebView'
+import * as Unknown from '../../common/unknown'
+import * as URL from '../../common/url-helper'
+import * as Header from './Navigator/Header'
+import * as Title from './Navigator/Title'
+import * as Progress from './Navigator/Progress'
+import * as Display from './Navigator/Display'
+import * as Animation from '../../common/Animation'
+import * as Easing from 'eased'
+import * as Tab from '../Sidebar/Tab'
+import { readTitle, isSecure, isDark, canGoBack } from './Navigator/WebView/Util'
 
 export type Flags =
   { output: Output.Flags

--- a/src/browser/Navigators/Navigator/Assistant.js
+++ b/src/browser/Navigators/Navigator/Assistant.js
@@ -12,7 +12,7 @@ import {StyleSheet, Style} from '../../../common/style';
 import {cursor} from '../../../common/cursor';
 import * as Unknown from '../../../common/unknown';
 
-/*::
+
 import type {Address, DOM} from "reflex";
 
 export type Flags = boolean
@@ -43,7 +43,7 @@ export type Action =
   | { type: "Suggest", suggest: Suggestion }
   | { type: "Search", search: Search.Action }
   | { type: "History", history: History.Action }
-*/
+
 
 
 export const Open/*:Action*/ = { type: "Open" };

--- a/src/browser/Navigators/Navigator/Assistant.js
+++ b/src/browser/Navigators/Navigator/Assistant.js
@@ -46,22 +46,22 @@ export type Action =
 
 
 
-export const Open/*:Action*/ = { type: "Open" };
-export const Close/*:Action*/ = { type: "Close" };
-export const Expand/*:Action*/ = { type: "Expand" };
-export const Unselect/*:Action*/ = { type: "Unselect" };
-export const Reset/*:Action*/ = { type: "Reset" };
-export const SuggestNext/*:Action*/ = { type: "SuggestNext" };
-export const SuggestPrevious/*:Action*/ = { type: "SuggestPrevious" };
+export const Open:Action = { type: "Open" };
+export const Close:Action = { type: "Close" };
+export const Expand:Action = { type: "Expand" };
+export const Unselect:Action = { type: "Unselect" };
+export const Reset:Action = { type: "Reset" };
+export const SuggestNext:Action = { type: "SuggestNext" };
+export const SuggestPrevious:Action = { type: "SuggestPrevious" };
 export const Suggest =
-  (suggestion/*:Suggestion*/)/*:Action*/ =>
+  (suggestion:Suggestion):Action =>
   ( { type: "Suggest"
     , suggest: suggestion
     }
   )
 
 export const Query =
-  (input/*:string*/)/*:Action*/ =>
+  (input:string):Action =>
   ( { type: "Query"
     , query: input
     }
@@ -85,9 +85,9 @@ const HistoryAction =
   );
 
 export const init =
-  ( isOpen/*:boolean*/=false
-  , isExpanded/*:boolean*/=false
-  )/*:[Model, Effects<Action>]*/ => {
+  ( isOpen:boolean=false
+  , isExpanded:boolean=false
+  ):[Model, Effects<Action>] => {
     const query = ''
     const [search, fx1] = Search.init(query, 5);
     const [history, fx2] = History.init(query, 5);
@@ -203,9 +203,9 @@ const suggestPrevious =
   updateSearch(model, Search.SelectPrevious);
 
 export const update =
-  ( model/*:Model*/
-  , action/*:Action*/
-  )/*:[Model, Effects<Action>]*/ => {
+  ( model:Model
+  , action:Action
+  ):[Model, Effects<Action>] => {
     switch (action.type) {
       case "Open":
         return open(model)
@@ -269,7 +269,7 @@ const styleSheet = StyleSheet.create
   );
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>):DOM =>
   html.div
   ( { className: 'assistant'
     , style: Style

--- a/src/browser/Navigators/Navigator/Assistant.js
+++ b/src/browser/Navigators/Navigator/Assistant.js
@@ -4,16 +4,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {always, batch, merge, take, move} from "../../../common/prelude"
-import {Effects, html, thunk, forward} from "reflex"
-import * as History from "./Assistant/history"
-import * as Search from "./Assistant/search"
-import {StyleSheet, Style} from '../../../common/style';
-import {cursor} from '../../../common/cursor';
-import * as Unknown from '../../../common/unknown';
-
-
-import type {Address, DOM} from "reflex";
+import { batch, merge } from '../../../common/prelude'
+import type { Address, DOM } from 'reflex'
+import { Effects, html, forward } from 'reflex'
+import * as History from './Assistant/history'
+import * as Search from './Assistant/search'
+import { StyleSheet, Style } from '../../../common/style'
+import { cursor } from '../../../common/cursor'
+import * as Unknown from '../../../common/unknown'
 
 export type Flags = boolean
 

--- a/src/browser/Navigators/Navigator/Assistant/history.js
+++ b/src/browser/Navigators/Navigator/Assistant/history.js
@@ -32,14 +32,14 @@ const Abort =
   );
 
 export const Query =
-  (input/*:string*/)/*:Action*/ =>
+  (input:string):Action =>
   ( { type: "Query"
     , source: input
     }
   );
 
 const UpdateMatches =
-  (result/*:Result<Error, Array<Match>>*/)/*:Action*/ =>
+  (result:Result<Error, Array<Match>>):Action =>
   ( { type: "UpdateMatches"
     , source: result
     }
@@ -60,19 +60,19 @@ const byURI =
 const pendingRequests = Object.create(null);
 
 const abort =
-  (id/*:number*/)/*:Task<Never, number>*/ =>
+  (id:number):Task<Never, number> =>
   new Task(succeed => void(0))
 
 const search =
-  ( id/*:number*/
-  , input/*:string*/
-  , limit/*:number*/
-  )/*:Task<Never, Result<Error, Array<Match>>>*/ =>
+  ( id:number
+  , input:string
+  , limit:number
+  ):Task<Never, Result<Error, Array<Match>>> =>
   new Task(succeed => void(0))
 
 
 export const init =
-  (query/*:string*/, limit/*:number*/)/*:[Model, Effects<Action>]*/ =>
+  (query:string, limit:number):[Model, Effects<Action>] =>
   [ { query
     , size: 0
     , queryID: 0
@@ -177,7 +177,7 @@ const retainSelected = (model, {matches, items}) => {
 };
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model:Model, action:Action):[Model, Effects<Action>] =>
   ( action.type === "Query"
   ? updateQuery(model, action.source)
   : action.type === "SelectNext"
@@ -200,7 +200,7 @@ const innerView =
 
 
 export const render =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>):DOM =>
   html.section
   ( { style: {borderColor: 'inherit' } }
   , model.items.map
@@ -217,7 +217,7 @@ export const render =
   )
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>):DOM =>
   thunk
   ( 'history'
   , render

--- a/src/browser/Navigators/Navigator/Assistant/history.js
+++ b/src/browser/Navigators/Navigator/Assistant/history.js
@@ -16,11 +16,11 @@ import * as Icon from "./icon";
 import * as Suggestion from "./suggestion";
 import * as Unknown from '../../../../common/unknown';
 
-/*::
+
 import type {Address, DOM, Never} from "reflex";
 import type {Result} from "../../../../common/result";
 import type {Completion, Match, Model, Action} from "./history";
-*/
+
 
 const NoOp = always({type: "NoOp"});
 

--- a/src/browser/Navigators/Navigator/Assistant/history.js
+++ b/src/browser/Navigators/Navigator/Assistant/history.js
@@ -5,21 +5,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {Effects, Task, html, forward, thunk} from "reflex";
-import {merge, always, batch} from "../../../../common/prelude";
-import {Style, StyleSheet} from '../../../../common/style';
-import {ok, error} from '../../../../common/result';
-
-import * as Title from "./title";
-import * as URL from "./url";
-import * as Icon from "./icon";
-import * as Suggestion from "./suggestion";
-import * as Unknown from '../../../../common/unknown';
-
-
-import type {Address, DOM, Never} from "reflex";
-import type {Result} from "../../../../common/result";
-import type {Completion, Match, Model, Action} from "./history";
+import type { Address, DOM, Never } from 'reflex'
+import { Effects, Task, html, forward, thunk } from 'reflex'
+import { merge, always } from '../../../../common/prelude'
+import type { Result } from '../../../../common/result'
+import * as Title from './title'
+import * as URL from './url'
+import * as Icon from './icon'
+import * as Suggestion from './suggestion'
+import * as Unknown from '../../../../common/unknown'
+import type { Completion, Match, Model, Action } from './history'
 
 
 const NoOp = always({type: "NoOp"});

--- a/src/browser/Navigators/Navigator/Assistant/icon.js
+++ b/src/browser/Navigators/Navigator/Assistant/icon.js
@@ -9,9 +9,9 @@ import {Effects, html, forward, thunk} from "reflex";
 import {merge, always, batch} from "../../../../common/prelude";
 import {Style, StyleSheet} from '../../../../common/style';
 
-/*::
+
 import type {Address, DOM} from "reflex"
-*/
+
 
 
 const styleSheet = StyleSheet.create

--- a/src/browser/Navigators/Navigator/Assistant/icon.js
+++ b/src/browser/Navigators/Navigator/Assistant/icon.js
@@ -35,7 +35,7 @@ const styleSheet = StyleSheet.create
   );
 
 export const render =
-  (content/*:string*/, isSelected/*:boolean*/)/*:DOM*/ =>
+  (content:string, isSelected:boolean):DOM =>
   html.span
   ( { className: 'assistant icon'
     , style: Style
@@ -51,7 +51,7 @@ export const render =
   );
 
 export const view =
-  (content/*:string*/, isSelected/*:boolean*/)/*:DOM*/ =>
+  (content:string, isSelected:boolean):DOM =>
   thunk
   ( `${content}`
   , render

--- a/src/browser/Navigators/Navigator/Assistant/icon.js
+++ b/src/browser/Navigators/Navigator/Assistant/icon.js
@@ -5,13 +5,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {Effects, html, forward, thunk} from "reflex";
-import {merge, always, batch} from "../../../../common/prelude";
-import {Style, StyleSheet} from '../../../../common/style';
-
-
-import type {Address, DOM} from "reflex"
-
+import type { Address, DOM } from 'reflex'
+import { html, thunk } from 'reflex'
+import { Style, StyleSheet } from '../../../../common/style'
 
 
 const styleSheet = StyleSheet.create

--- a/src/browser/Navigators/Navigator/Assistant/search.js
+++ b/src/browser/Navigators/Navigator/Assistant/search.js
@@ -16,11 +16,11 @@ import * as Icon from "./icon";
 import * as Suggestion from "./suggestion";
 import * as Unknown from '../../../../common/unknown';
 
-/*::
+
 import type {Address, DOM, Never} from "reflex";
 import type {Result} from "../../../../common/result";
 import type {Completion, Match, Model, Action} from "./search";
-*/
+
 
 const NoOp = always({type: "NoOp"});
 

--- a/src/browser/Navigators/Navigator/Assistant/search.js
+++ b/src/browser/Navigators/Navigator/Assistant/search.js
@@ -34,21 +34,21 @@ const Abort =
 export const SelectNext = { type: "SelectNext" };
 export const SelectPrevious = { type: "SelectPrevious" };
 export const Suggest =
-  (suggestion/*:Completion*/)/*:Action*/ =>
+  (suggestion:Completion):Action =>
   ( { type: "Suggest"
     , source: suggestion
     }
   );
 
 export const Query =
-  (input/*:string*/)/*:Action*/ =>
+  (input:string):Action =>
   ( { type: "Query"
     , source: input
     }
   );
 
 export const Activate =
-  ()/*:Action*/ =>
+  ():Action =>
   ( { type: "Activate"
     }
   );
@@ -61,7 +61,7 @@ const Load =
   );
 
 const UpdateMatches =
-  (result/*:Result<Error, Array<Match>>*/)/*:Action*/ =>
+  (result:Result<Error, Array<Match>>):Action =>
   ( { type: "UpdateMatches"
     , source: result
     }
@@ -126,10 +126,10 @@ const abort =
   })
 
 const search =
-  ( id/*:number*/
-  , input/*:string*/
-  , limit/*:number*/
-  )/*:Task<Never, Result<Error, Array<Match>>>*/ =>
+  ( id:number
+  , input:string
+  , limit:number
+  ):Task<Never, Result<Error, Array<Match>>> =>
   new Task((succeed, fail) => {
     const request = new XMLHttpRequest({ mozSystem: true });
     pendingRequests[id] = request;
@@ -157,7 +157,7 @@ const search =
 
 
 export const init =
-  (query/*:string*/, limit/*:number*/)/*:[Model, Effects<Action>]*/ =>
+  (query:string, limit:number):[Model, Effects<Action>] =>
   [ { query
     , size: 0
     , queryID: 0
@@ -314,7 +314,7 @@ const activate =
   ]
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model:Model, action:Action):[Model, Effects<Action>] =>
   ( action.type === "Query"
   ? updateQuery(model, action.source)
   : action.type === "SelectNext"
@@ -339,7 +339,7 @@ const innerView =
   ];
 
 export const render =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>):DOM =>
   html.section
   ( { style: {borderColor: 'inherit' } }
   , model
@@ -359,7 +359,7 @@ export const render =
   )
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>):DOM =>
   thunk
   ( 'search'
   , render

--- a/src/browser/Navigators/Navigator/Assistant/search.js
+++ b/src/browser/Navigators/Navigator/Assistant/search.js
@@ -5,21 +5,17 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {Effects, Task, html, forward, thunk} from "reflex";
-import {merge, always, batch} from "../../../../common/prelude";
-import {Style, StyleSheet} from '../../../../common/style';
-import {indexOfOffset} from "../../../../common/selector";
-import {ok, error} from '../../../../common/result';
-
-import * as Title from "./title";
-import * as Icon from "./icon";
-import * as Suggestion from "./suggestion";
-import * as Unknown from '../../../../common/unknown';
-
-
-import type {Address, DOM, Never} from "reflex";
-import type {Result} from "../../../../common/result";
-import type {Completion, Match, Model, Action} from "./search";
+import type { Address, DOM, Never } from 'reflex'
+import { Effects, Task, html, forward, thunk } from 'reflex'
+import { merge, always } from '../../../../common/prelude'
+import { indexOfOffset } from '../../../../common/selector'
+import type { Result } from '../../../../common/result'
+import { ok, error } from '../../../../common/result'
+import * as Title from './title'
+import * as Icon from './icon'
+import * as Suggestion from './suggestion'
+import * as Unknown from '../../../../common/unknown'
+import type { Completion, Match, Model, Action } from './search'
 
 
 const NoOp = always({type: "NoOp"});

--- a/src/browser/Navigators/Navigator/Assistant/suggestion.js
+++ b/src/browser/Navigators/Navigator/Assistant/suggestion.js
@@ -8,9 +8,9 @@
 import {html, thunk} from "reflex";
 import {Style, StyleSheet} from '../../../../common/style';
 
-/*::
+
 import type {Address, DOM} from "reflex"
-*/
+
 
 
 const styleSheet = StyleSheet.create

--- a/src/browser/Navigators/Navigator/Assistant/suggestion.js
+++ b/src/browser/Navigators/Navigator/Assistant/suggestion.js
@@ -42,7 +42,7 @@ const styleSheet = StyleSheet.create
   );
 
 export const render =
-  (isSelected/*:boolean*/, content/*:Array<DOM>*/)/*:DOM*/ =>
+  (isSelected:boolean, content:Array<DOM>):DOM =>
   html.li
   ( { className: 'assistant suggestion'
     , style: Style

--- a/src/browser/Navigators/Navigator/Assistant/suggestion.js
+++ b/src/browser/Navigators/Navigator/Assistant/suggestion.js
@@ -5,12 +5,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {html, thunk} from "reflex";
-import {Style, StyleSheet} from '../../../../common/style';
-
-
-import type {Address, DOM} from "reflex"
-
+import type { Address, DOM } from 'reflex'
+import { html } from 'reflex'
+import { Style, StyleSheet } from '../../../../common/style'
 
 
 const styleSheet = StyleSheet.create

--- a/src/browser/Navigators/Navigator/Assistant/title.js
+++ b/src/browser/Navigators/Navigator/Assistant/title.js
@@ -29,7 +29,7 @@ const styleSheet = StyleSheet.create
   );
 
 export const render =
-  (title/*:?string*/, isSelected/*:boolean*/)/*:DOM*/ =>
+  (title:?string, isSelected:boolean):DOM =>
   html.span
   ( { className: 'assistant title'
     , style: Style
@@ -48,7 +48,7 @@ export const render =
   );
 
 export const view =
-  (title/*:?string*/, isSelected/*:boolean*/)/*:DOM*/ =>
+  (title:?string, isSelected:boolean):DOM =>
   thunk
   ( `${title}`
   , render

--- a/src/browser/Navigators/Navigator/Assistant/title.js
+++ b/src/browser/Navigators/Navigator/Assistant/title.js
@@ -9,9 +9,9 @@ import {Effects, html, forward, thunk} from "reflex";
 import {merge, always, batch} from "../../../../common/prelude";
 import {Style, StyleSheet} from '../../../../common/style';
 
-/*::
+
 import type {Address, DOM} from "reflex"
-*/
+
 
 
 const styleSheet = StyleSheet.create

--- a/src/browser/Navigators/Navigator/Assistant/title.js
+++ b/src/browser/Navigators/Navigator/Assistant/title.js
@@ -5,13 +5,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {Effects, html, forward, thunk} from "reflex";
-import {merge, always, batch} from "../../../../common/prelude";
-import {Style, StyleSheet} from '../../../../common/style';
-
-
-import type {Address, DOM} from "reflex"
-
+import type { Address, DOM } from 'reflex'
+import { html, thunk } from 'reflex'
+import { Style, StyleSheet } from '../../../../common/style'
 
 
 const styleSheet = StyleSheet.create

--- a/src/browser/Navigators/Navigator/Assistant/url.js
+++ b/src/browser/Navigators/Navigator/Assistant/url.js
@@ -35,7 +35,7 @@ const preventDefault =
   event.preventDefault();
 
 export const render =
-  (uri/*:URI*/, isSelected/*:boolean*/)/*:DOM*/ =>
+  (uri:URI, isSelected:boolean):DOM =>
   html.a
   ( { className: 'assistant url'
     , style: Style
@@ -53,7 +53,7 @@ export const render =
   );
 
 export const view =
-  (uri/*:URI*/, isSelected/*:boolean*/)/*:DOM*/ =>
+  (uri:URI, isSelected:boolean):DOM =>
   thunk
   ( uri
   , render

--- a/src/browser/Navigators/Navigator/Assistant/url.js
+++ b/src/browser/Navigators/Navigator/Assistant/url.js
@@ -10,10 +10,10 @@ import {merge, always, batch} from "../../../../common/prelude";
 import {Style, StyleSheet} from '../../../../common/style';
 import * as URL from '../../../../common/url-helper';
 
-/*::
+
 import type {Address, DOM} from "reflex";
 import type {URI} from "./url";
-*/
+
 
 
 const styleSheet = StyleSheet.create

--- a/src/browser/Navigators/Navigator/Assistant/url.js
+++ b/src/browser/Navigators/Navigator/Assistant/url.js
@@ -5,15 +5,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {Effects, html, forward, thunk} from "reflex";
-import {merge, always, batch} from "../../../../common/prelude";
-import {Style, StyleSheet} from '../../../../common/style';
-import * as URL from '../../../../common/url-helper';
-
-
-import type {Address, DOM} from "reflex";
-import type {URI} from "./url";
-
+import type { Address, DOM } from 'reflex'
+import { html, thunk } from 'reflex'
+import { Style, StyleSheet } from '../../../../common/style'
+import * as URL from '../../../../common/url-helper'
+import type { URI } from './url'
 
 
 const styleSheet = StyleSheet.create

--- a/src/browser/Navigators/Navigator/Display.js
+++ b/src/browser/Navigators/Navigator/Display.js
@@ -11,7 +11,7 @@ export class Model {
   opacity: Float;
   
   constructor(
-    opacity/*:Float*/
+    opacity:Float
   ) {
     this.opacity = opacity
   }
@@ -22,10 +22,10 @@ export const deselected = new Model(0)
 export const closed = new Model(0)
 
 export const interpolate =
-  ( from/*:Model*/
-  , to/*:Model*/
-  , progress/*:Float*/
-  )/*:Model*/ =>
+  ( from:Model
+  , to:Model
+  , progress:Float
+  ):Model =>
   new Model
   ( Easing.float(from.opacity, to.opacity, progress)
   )

--- a/src/browser/Navigators/Navigator/Display.js
+++ b/src/browser/Navigators/Navigator/Display.js
@@ -2,14 +2,14 @@
 
 import * as Easing from "eased";
 
-/*::
+
 import type {Float} from "../../../common/prelude"
-*/
+
 
 export class Model {
-  /*::
+  
   opacity: Float;
-  */
+  
   constructor(
     opacity/*:Float*/
   ) {

--- a/src/browser/Navigators/Navigator/Display.js
+++ b/src/browser/Navigators/Navigator/Display.js
@@ -1,9 +1,7 @@
 /* @flow */
 
-import * as Easing from "eased";
-
-
-import type {Float} from "../../../common/prelude"
+import * as Easing from 'eased'
+import type { Float } from '../../../common/prelude'
 
 
 export class Model {

--- a/src/browser/Navigators/Navigator/Header.js
+++ b/src/browser/Navigators/Navigator/Header.js
@@ -8,7 +8,7 @@ import * as ShowTabsButton from './Header/ShowTabsButton';
 import * as NewTabButton from './Header/NewTabButton';
 import * as BackButton from './Header/BackButton';
 
-/*::
+
 import type {Address, DOM} from "reflex"
 
 export type Model = string
@@ -16,7 +16,7 @@ export type Action =
   | { type: "ShowTabs" }
   | { type: "OpenNewTab" }
   | { type: "GoBack" }
-*/
+
 
 const tagShowTabs = always({ type: "ShowTabs" });
 const tagNewTab = always({ type: "OpenNewTab" });

--- a/src/browser/Navigators/Navigator/Header.js
+++ b/src/browser/Navigators/Navigator/Header.js
@@ -25,9 +25,9 @@ const tagGoBack = always({ type: "GoBack" });
 export const height = Title.outerHeight;
 
 export const render =
-  ( canGoBack/*:boolean*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  ( canGoBack:boolean
+  , address:Address<Action>
+  ):DOM =>
   html.header
   ( { className: 'topbar'
     , style: styleSheet.base
@@ -46,9 +46,9 @@ export const render =
   );
 
 export const view =
-  ( canGoBack/*:boolean*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  ( canGoBack:boolean
+  , address:Address<Action>
+  ):DOM =>
   thunk
   ( 'Browser/NavigatorDeck/Navigator/Header'
   , render

--- a/src/browser/Navigators/Navigator/Header.js
+++ b/src/browser/Navigators/Navigator/Header.js
@@ -1,15 +1,13 @@
 /* @flow */
 
-import {html, thunk, forward} from 'reflex';
-import * as Style from '../../../common/style';
-import {always} from '../../../common/prelude';
-import * as Title from './Title';
-import * as ShowTabsButton from './Header/ShowTabsButton';
-import * as NewTabButton from './Header/NewTabButton';
-import * as BackButton from './Header/BackButton';
-
-
-import type {Address, DOM} from "reflex"
+import type { Address, DOM } from 'reflex'
+import { html, thunk, forward } from 'reflex'
+import * as Style from '../../../common/style'
+import { always } from '../../../common/prelude'
+import * as Title from './Title'
+import * as ShowTabsButton from './Header/ShowTabsButton'
+import * as NewTabButton from './Header/NewTabButton'
+import * as BackButton from './Header/BackButton'
 
 export type Model = string
 export type Action =

--- a/src/browser/Navigators/Navigator/Header/BackButton.js
+++ b/src/browser/Navigators/Navigator/Header/BackButton.js
@@ -5,11 +5,11 @@ import * as Style from '../../../../common/style'
 import {always} from '../../../../common/prelude'
 import * as Title from '../Title'
 
-/*::
+
 import type {Address, DOM} from "reflex"
 export type Action =
   | { type: "Click" }
-*/
+
 
 const Click = always({ type: "Click" })
 

--- a/src/browser/Navigators/Navigator/Header/BackButton.js
+++ b/src/browser/Navigators/Navigator/Header/BackButton.js
@@ -1,12 +1,10 @@
 /* @flow */
 
-import {html, thunk, forward} from 'reflex'
+import type { Address, DOM } from 'reflex'
+import { html, thunk, forward } from 'reflex'
 import * as Style from '../../../../common/style'
-import {always} from '../../../../common/prelude'
+import { always } from '../../../../common/prelude'
 import * as Title from '../Title'
-
-
-import type {Address, DOM} from "reflex"
 export type Action =
   | { type: "Click" }
 

--- a/src/browser/Navigators/Navigator/Header/NewTabButton.js
+++ b/src/browser/Navigators/Navigator/Header/NewTabButton.js
@@ -4,11 +4,11 @@ import {html, thunk, forward} from 'reflex'
 import * as Style from '../../../../common/style'
 import {always} from '../../../../common/prelude'
 
-/*::
+
 import type {Address, DOM} from "reflex"
 export type Action =
   | { type: "Click" }
-*/
+
 
 const Click = always({ type: "Click" })
 

--- a/src/browser/Navigators/Navigator/Header/NewTabButton.js
+++ b/src/browser/Navigators/Navigator/Header/NewTabButton.js
@@ -1,11 +1,9 @@
 /* @flow */
 
-import {html, thunk, forward} from 'reflex'
+import type { Address, DOM } from 'reflex'
+import { html, thunk, forward } from 'reflex'
 import * as Style from '../../../../common/style'
-import {always} from '../../../../common/prelude'
-
-
-import type {Address, DOM} from "reflex"
+import { always } from '../../../../common/prelude'
 export type Action =
   | { type: "Click" }
 

--- a/src/browser/Navigators/Navigator/Header/ShowTabsButton.js
+++ b/src/browser/Navigators/Navigator/Header/ShowTabsButton.js
@@ -4,11 +4,11 @@ import {html, thunk, forward} from 'reflex'
 import * as Style from '../../../../common/style'
 import {always} from '../../../../common/prelude'
 
-/*::
+
 import type {Address, DOM} from "reflex"
 export type Action =
   | { type: "Click" }
-*/
+
 
 const Click = always({ type: "Click" })
 

--- a/src/browser/Navigators/Navigator/Header/ShowTabsButton.js
+++ b/src/browser/Navigators/Navigator/Header/ShowTabsButton.js
@@ -1,11 +1,9 @@
 /* @flow */
 
-import {html, thunk, forward} from 'reflex'
+import type { Address, DOM } from 'reflex'
+import { html, thunk, forward } from 'reflex'
 import * as Style from '../../../../common/style'
-import {always} from '../../../../common/prelude'
-
-
-import type {Address, DOM} from "reflex"
+import { always } from '../../../../common/prelude'
 export type Action =
   | { type: "Click" }
 

--- a/src/browser/Navigators/Navigator/Input.js
+++ b/src/browser/Navigators/Navigator/Input.js
@@ -59,23 +59,23 @@ export type Action =
 // Create a new input submit action.
 export const Query/*:()=>Action*/ = always({ type: 'Query' });
 export const Suggest =
-  (suggestion/*:Suggestion*/)/*:Action*/ =>
+  (suggestion:Suggestion):Action =>
   ( { type: "Suggest"
     , suggest: suggestion
     }
   );
 
-export const SuggestNext/*:Action*/ = { type: 'SuggestNext' };
-export const SuggestPrevious/*:Action*/ = { type: 'SuggestPrevious' };
-export const Submit/*:Action*/ = {type: 'Submit'};
-export const Abort/*:Action*/ = {type: 'Abort'};
-export const Enter/*:Action*/ = {type: 'Enter'};
-export const Focus/*:Action*/ = {type: 'Focus', source: Focusable.Focus };
-export const Blur/*:Action*/ = {type: 'Blur', source: Focusable.Blur };
-export const Show/*:Action*/ = {type: 'Show'};
-export const Hide/*:Action*/ = {type: 'Hide'};
+export const SuggestNext:Action = { type: 'SuggestNext' };
+export const SuggestPrevious:Action = { type: 'SuggestPrevious' };
+export const Submit:Action = {type: 'Submit'};
+export const Abort:Action = {type: 'Abort'};
+export const Enter:Action = {type: 'Enter'};
+export const Focus:Action = {type: 'Focus', source: Focusable.Focus };
+export const Blur:Action = {type: 'Blur', source: Focusable.Blur };
+export const Show:Action = {type: 'Show'};
+export const Hide:Action = {type: 'Hide'};
 export const EnterSelection =
-  (value/*:string*/)/*:Action*/ =>
+  (value:string):Action =>
   ( { type: 'EnterSelection'
     , value
     }
@@ -98,7 +98,7 @@ const EditableAction =
     }
   );
 
-const Clear/*:Action*/ = EditableAction(Editable.Clear);
+const Clear:Action = EditableAction(Editable.Clear);
 
 const updateFocusable = cursor({
   tag: FocusableAction,
@@ -136,7 +136,7 @@ const defaultFlags =
   }
 
 export const init =
-  (flags/*:Flags*/=defaultFlags)/*:[Model, Effects<Action>]*/ =>
+  (flags:Flags=defaultFlags):[Model, Effects<Action>] =>
   [ ( { value: flags.value
       , isFocused: !!flags.isFocused
       , isVisible: !!flags.isVisible
@@ -158,7 +158,7 @@ const suggest = (model, {query, match, hint}) =>
   )
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ => {
+  (model:Model, action:Action):[Model, Effects<Action>] => {
     switch (action.type) {
       case 'Abort':
         return [merge(model, {isVisible: false}), Effects.none];
@@ -302,7 +302,7 @@ const style = Style.createSheet({
 
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>):DOM =>
   html.form({
     className: 'input-combobox',
     style: Style.mix

--- a/src/browser/Navigators/Navigator/Input.js
+++ b/src/browser/Navigators/Navigator/Input.js
@@ -16,7 +16,7 @@ import * as Keyboard from '../../../common/keyboard';
 import * as Unknown from '../../../common/unknown';
 import * as Style from '../../../common/style';
 
-/*::
+
 import type {Address, DOM} from "reflex"
 
 export type Flags =
@@ -54,7 +54,7 @@ export type Action =
   | { type: "Change", value: string, selection: Editable.Selection }
   | { type: 'Editable', editable: Editable.Action }
   | { type: 'Focusable', focusable: Focusable.Action }
-*/
+
 
 // Create a new input submit action.
 export const Query/*:()=>Action*/ = always({ type: 'Query' });

--- a/src/browser/Navigators/Navigator/Input.js
+++ b/src/browser/Navigators/Navigator/Input.js
@@ -57,7 +57,7 @@ export type Action =
 
 
 // Create a new input submit action.
-export const Query/*:()=>Action*/ = always({ type: 'Query' });
+export const Query:()=>Action = always({ type: 'Query' });
 export const Suggest =
   (suggestion:Suggestion):Action =>
   ( { type: "Suggest"

--- a/src/browser/Navigators/Navigator/Input.js
+++ b/src/browser/Navigators/Navigator/Input.js
@@ -4,20 +4,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, forward, Effects} from 'reflex';
-import {on, focus, selection} from '@driver';
-import {identity} from '../../../lang/functional';
-import {always, merge} from '../../../common/prelude';
-import {cursor} from "../../../common/cursor";
-import {compose, debounce} from '../../../lang/functional';
-import * as Focusable from '../../../common/focusable';
-import * as Editable from '../../../common/editable';
-import * as Keyboard from '../../../common/keyboard';
-import * as Unknown from '../../../common/unknown';
-import * as Style from '../../../common/style';
-
-
-import type {Address, DOM} from "reflex"
+import type { Address, DOM } from 'reflex'
+import { html, forward, Effects } from 'reflex'
+import { on, focus, selection } from '@driver'
+import { compose } from '../../../lang/functional'
+import { always, merge } from '../../../common/prelude'
+import { cursor } from '../../../common/cursor'
+import * as Focusable from '../../../common/focusable'
+import * as Editable from '../../../common/editable'
+import * as Keyboard from '../../../common/keyboard'
+import * as Unknown from '../../../common/unknown'
+import * as Style from '../../../common/style'
 
 export type Flags =
   { isVisible?: boolean

--- a/src/browser/Navigators/Navigator/Overlay.js
+++ b/src/browser/Navigators/Navigator/Overlay.js
@@ -13,7 +13,7 @@ import * as Animation from "../../../common/Animation"
 import * as Unknown from "../../../common/unknown";
 import * as Display from "./Overlay/Display"
 
-/*::
+
 import type {Address, DOM} from "reflex"
 import type {Time} from "../../../common/prelude"
 
@@ -24,13 +24,13 @@ export type Action =
   | { type: "Show" }
   | { type: "Hide" }
   | { type: "Animation", animation: Animation.Action }
-*/
+
 
 export class Model {
-  /*::
+  
   animation: Animation.Model<Display.Model>;
   isVisible: boolean;
-  */
+  
   constructor(
     isVisible/*:boolean*/
   , animation/*:Animation.Model<Display.Model>*/

--- a/src/browser/Navigators/Navigator/Overlay.js
+++ b/src/browser/Navigators/Navigator/Overlay.js
@@ -32,8 +32,8 @@ export class Model {
   isVisible: boolean;
   
   constructor(
-    isVisible/*:boolean*/
-  , animation/*:Animation.Model<Display.Model>*/
+    isVisible:boolean
+  , animation:Animation.Model<Display.Model>
   ) {
     this.isVisible = isVisible;
     this.animation = animation;
@@ -52,8 +52,8 @@ const tagAnimation =
   );
 
 export const init =
-  ( isVisible/*:boolean*/=false
-  )/*:[Model, Effects<Action>]*/ => {
+  ( isVisible:boolean=false
+  ):[Model, Effects<Action>] => {
     const display =
       ( isVisible
       ? Display.visible
@@ -76,7 +76,7 @@ export const init =
 
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ => {
+  (model:Model, action:Action):[Model, Effects<Action>] => {
     switch (action.type) {
       case "Animation":
         return updateAnimation(model, action.animation)
@@ -158,9 +158,9 @@ const nofx =
   ]
 
 export const render =
-  ( model/*:Model*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  ( model:Model
+  , address:Address<Action>
+  ):DOM =>
   html.div
   ( { className: 'overlay'
     , style: Style.mix
@@ -178,9 +178,9 @@ export const render =
 
 
 export const view =
-  ( model/*:Model*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  ( model:Model
+  , address:Address<Action>
+  ):DOM =>
   thunk
   ( 'Browser/NavigatorDeck/Navigator/Overaly'
   , render

--- a/src/browser/Navigators/Navigator/Overlay.js
+++ b/src/browser/Navigators/Navigator/Overlay.js
@@ -4,18 +4,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Effects, html, thunk, forward} from "reflex";
-import {merge, always} from "../../../common/prelude";
-import {cursor} from "../../../common/cursor";
-import * as Style from "../../../common/style";
-import * as Easing from "eased";
-import * as Animation from "../../../common/Animation"
-import * as Unknown from "../../../common/unknown";
-import * as Display from "./Overlay/Display"
-
-
-import type {Address, DOM} from "reflex"
-import type {Time} from "../../../common/prelude"
+import type { Address, DOM } from 'reflex'
+import { Effects, html, thunk, forward } from 'reflex'
+import type { Time } from '../../../common/prelude'
+import { always } from '../../../common/prelude'
+import { cursor } from '../../../common/cursor'
+import * as Style from '../../../common/style'
+import * as Easing from 'eased'
+import * as Animation from '../../../common/Animation'
+import * as Unknown from '../../../common/unknown'
+import * as Display from './Overlay/Display'
 
 export type Flags = boolean
 

--- a/src/browser/Navigators/Navigator/Overlay/Display.js
+++ b/src/browser/Navigators/Navigator/Overlay/Display.js
@@ -10,7 +10,7 @@ export class Model {
   
   opacity: Float;
   
-  constructor(opacity/*:Float*/) {
+  constructor(opacity:Float) {
     this.opacity = opacity
   }
 }
@@ -19,10 +19,10 @@ export const visible = new Model(0.1)
 export const invisible = new Model(0)
 
 export const interpolate =
-  ( from/*:Model*/
-  , to/*:Model*/
-  , progress/*:number*/
-  )/*:Model*/ =>
+  ( from:Model
+  , to:Model
+  , progress:number
+  ):Model =>
   new Model
   ( Easing.float(from.opacity, to.opacity, progress)
   )

--- a/src/browser/Navigators/Navigator/Overlay/Display.js
+++ b/src/browser/Navigators/Navigator/Overlay/Display.js
@@ -2,14 +2,14 @@
 
 import * as Easing from "eased"
 
-/*::
+
 import type {Float} from "../../../../common/prelude"
-*/
+
 
 export class Model {
-  /*::
+  
   opacity: Float;
-  */
+  
   constructor(opacity/*:Float*/) {
     this.opacity = opacity
   }

--- a/src/browser/Navigators/Navigator/Overlay/Display.js
+++ b/src/browser/Navigators/Navigator/Overlay/Display.js
@@ -1,9 +1,7 @@
 /* @flow */
 
-import * as Easing from "eased"
-
-
-import type {Float} from "../../../../common/prelude"
+import * as Easing from 'eased'
+import type { Float } from '../../../../common/prelude'
 
 
 export class Model {

--- a/src/browser/Navigators/Navigator/Progress.js
+++ b/src/browser/Navigators/Navigator/Progress.js
@@ -49,13 +49,13 @@ export class Model {
   loadEnd: Time;
   
   constructor(
-    ref/*:Ref.Model*/
-  , value/*:Percentage*/
+    ref:Ref.Model
+  , value:Percentage
 
-  , updateTime/*:Time*/
-  , loadStart/*:Time*/
-  , connectTime/*:Time*/
-  , loadEnd/*:Time*/
+  , updateTime:Time
+  , loadStart:Time
+  , connectTime:Time
+  , loadEnd:Time
   ) {
     this.ref = ref
     this.value = value
@@ -69,28 +69,28 @@ export class Model {
 const NoOp = always({ type: "NoOp" })
 
 export const LoadStart =
-  (time/*:Time*/)/*:Action*/ =>
+  (time:Time):Action =>
   ( { type: "LoadStart"
     , time
     }
   );
 
 export const Connect =
-  (time/*:Time*/)/*:Action*/ =>
+  (time:Time):Action =>
   ( { type: 'Connect'
     , time
     }
   );
 
 export const LoadEnd =
-  (time/*:Time*/)/*:Action*/ =>
+  (time:Time):Action =>
   ( { type: "LoadEnd"
     , time
     }
   );
 
 const Tick =
-  (time/*:Time*/)/*:Action*/ =>
+  (time:Time):Action =>
   ( { type: "Tick"
     , time
     }
@@ -136,7 +136,7 @@ const progress =
   , connect
   , end
   , now
-  )/*:LoadProgress*/ =>
+  ):LoadProgress =>
   ( end > 0
   ? progressLoaded(start, connect, end, now)
   : connect > 0
@@ -148,9 +148,9 @@ const progress =
 
 // Start a new progress cycle.
 export const loadStart =
-  ( model/*:Model*/
-  , time/*:Time*/
-  )/*:[Model, Effects<Action>]*/ =>
+  ( model:Model
+  , time:Time
+  ):[Model, Effects<Action>] =>
   [ new Model
     ( model.ref
     , 0
@@ -171,9 +171,9 @@ export const loadStart =
 
 
 export const connect =
-  ( model/*:Model*/
-  , time/*:Time*/
-  )/*:[Model, Effects<Action>]*/ =>
+  ( model:Model
+  , time:Time
+  ):[Model, Effects<Action>] =>
   [ new Model
     ( model.ref
     , model.value
@@ -192,9 +192,9 @@ export const connect =
 
 // Invoked on End action and returns model with updated `timeStamp`:
 export const loadEnd =
-  ( model/*:Model*/
-  , time/*:Time*/
-  )/*:[Model, Effects<Action>]*/ =>
+  ( model:Model
+  , time:Time
+  ):[Model, Effects<Action>] =>
   [ new Model
     ( model.ref
     , model.value
@@ -214,9 +214,9 @@ export const loadEnd =
 // Update the progress and request another tick.
 // Returns a new model and a tick effect.
 export const tick =
-  ( model/*:Model*/
-  , time/*:Time*/
-  )/*:[Model, Effects<Action>]*/ => {
+  ( model:Model
+  , time:Time
+  ):[Model, Effects<Action>] => {
     if (model.loadStart === 0) {
       const fx =
         Effects
@@ -267,7 +267,7 @@ export const tick =
 
 
 export const init =
-  ()/*:[Model, Effects<Action>]*/ =>
+  ():[Model, Effects<Action>] =>
   [ new Model
     ( Ref.create()
     , 0
@@ -280,7 +280,7 @@ export const init =
   ];
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ => {
+  (model:Model, action:Action):[Model, Effects<Action>] => {
     switch (action.type) {
       case "LoadStart":
         return loadStart(model, action.time);
@@ -399,7 +399,7 @@ const standalone =
 
 
 export const view =
-  (model/*:Model*/)/*:DOM*/ =>
+  (model:Model):DOM =>
   ( Runtime.isServo
   ? PolyfillView.view(model.ref, model.value)
   : ProgressView.view(model.ref, model.value)

--- a/src/browser/Navigators/Navigator/Progress.js
+++ b/src/browser/Navigators/Navigator/Progress.js
@@ -15,7 +15,7 @@ import * as Ref from '../../../common/ref';
 import * as PolyfillView from './Progress/PolyfillView';
 import * as ProgressView from './Progress/ProgressView';
 
-/*::
+
 import type {Address, DOM} from "reflex"
 import type {Time, Float} from "../../../common/prelude"
 
@@ -34,12 +34,12 @@ export type Action =
   | { type: "Connect", time: Time }
   | { type: "Tick", time: Time }
   | { type: "NoOp" }
-*/
+
 
 const second = 1000;
 
 export class Model {
-  /*::
+  
   ref: Ref.Model;
   value: Percentage;
 
@@ -47,7 +47,7 @@ export class Model {
   loadStart: Time;
   connectTime: Time;
   loadEnd: Time;
-  */
+  
   constructor(
     ref/*:Ref.Model*/
   , value/*:Percentage*/

--- a/src/browser/Navigators/Navigator/Progress.js
+++ b/src/browser/Navigators/Navigator/Progress.js
@@ -5,19 +5,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {Effects, Task, html} from 'reflex';
-import {ease, easeOutQuart, float} from 'eased';
-import * as Style from '../../../common/style';
-import {always} from '../../../common/prelude';
-import * as Unknown from '../../../common/unknown';
-import * as Runtime from '../../../common/runtime';
-import * as Ref from '../../../common/ref';
-import * as PolyfillView from './Progress/PolyfillView';
-import * as ProgressView from './Progress/ProgressView';
-
-
-import type {Address, DOM} from "reflex"
-import type {Time, Float} from "../../../common/prelude"
+import type { Address, DOM } from 'reflex'
+import { Effects, Task } from 'reflex'
+import type { Time, Float } from '../../../common/prelude'
+import { always } from '../../../common/prelude'
+import * as Unknown from '../../../common/unknown'
+import * as Runtime from '../../../common/runtime'
+import * as Ref from '../../../common/ref'
+import * as PolyfillView from './Progress/PolyfillView'
+import * as ProgressView from './Progress/ProgressView'
 
 // Implied to be 0.0 - 1.0 range
 export type LoadProgress = Float

--- a/src/browser/Navigators/Navigator/Progress/PolyfillView.js
+++ b/src/browser/Navigators/Navigator/Progress/PolyfillView.js
@@ -9,7 +9,7 @@ import type {DOM} from 'reflex';
 */
 
 export const render =
-  (ref/*:Ref.Model*/, value/*:number*/)/*:DOM*/ =>
+  (ref:Ref.Model, value:number):DOM =>
   html.div
   ( { className: "progress"
     , style: styleSheet.base
@@ -27,7 +27,7 @@ export const render =
   )
 
 export const view =
-  (ref/*:Ref.Model*/, value/*:number*/)/*:DOM*/ =>
+  (ref:Ref.Model, value:number):DOM =>
   thunk
   ( 'Browser/NavigtorDeck/Navigator/Progress/PolyfillView'
   , render

--- a/src/browser/Navigators/Navigator/Progress/PolyfillView.js
+++ b/src/browser/Navigators/Navigator/Progress/PolyfillView.js
@@ -1,7 +1,7 @@
 /* @flow */
 
-import {thunk, html} from 'reflex';
-import * as Style from '../../../../common/style';
+import { thunk, html } from 'reflex'
+import * as Style from '../../../../common/style'
 
 /*::
 import * as Ref from '../../../../common/ref';

--- a/src/browser/Navigators/Navigator/Progress/ProgressView.js
+++ b/src/browser/Navigators/Navigator/Progress/ProgressView.js
@@ -9,7 +9,7 @@ import type {DOM} from 'reflex';
 */
 
 export const render =
-  (ref/*:Ref.Model*/, value/*:number*/)/*:DOM*/ =>
+  (ref:Ref.Model, value:number):DOM =>
   html.progress
   ( { [ref.name]: ref.value
     , style: Style.mix
@@ -26,7 +26,7 @@ export const render =
   )
 
 export const view =
-  (ref/*:Ref.Model*/, value/*:number*/)/*:DOM*/ =>
+  (ref:Ref.Model, value:number):DOM =>
   thunk
   ( 'Browser/NavigtorDeck/Navigator/Progress/ProgressView'
   , render

--- a/src/browser/Navigators/Navigator/Progress/ProgressView.js
+++ b/src/browser/Navigators/Navigator/Progress/ProgressView.js
@@ -1,7 +1,7 @@
 /* @flow */
 
-import {thunk, html} from 'reflex';
-import * as Style from '../../../../common/style';
+import { thunk, html } from 'reflex'
+import * as Style from '../../../../common/style'
 
 /*::
 import * as Ref from '../../../../common/ref';

--- a/src/browser/Navigators/Navigator/Title.js
+++ b/src/browser/Navigators/Navigator/Title.js
@@ -15,11 +15,11 @@ const Activate = always({ type: "Activate" })
 
 
 export const render =
-  ( isDisabled/*:boolean*/
-  , title/*:string*/
-  , secure/*:boolean*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  ( isDisabled:boolean
+  , title:string
+  , secure:boolean
+  , address:Address<Action>
+  ):DOM =>
   html.summary
   ( { className: 'webview-combobox'
     , style: Style.mix
@@ -59,11 +59,11 @@ export const render =
   );
 
 export const view =
-  ( isDisabled/*:boolean*/
-  , title/*:string*/
-  , secure/*:boolean*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  ( isDisabled:boolean
+  , title:string
+  , secure:boolean
+  , address:Address<Action>
+  ):DOM =>
   thunk
   ( 'Browser/NavigatorDeck/Navigator/Header/Title'
   , render

--- a/src/browser/Navigators/Navigator/Title.js
+++ b/src/browser/Navigators/Navigator/Title.js
@@ -4,12 +4,12 @@ import {html, thunk, forward} from 'reflex';
 import * as Style from '../../../common/style';
 import {always} from '../../../common/prelude';
 
-/*::
+
 import type {Address, DOM} from "reflex"
 
 export type Action =
   | { type: "Activate" }
-*/
+
 
 const Activate = always({ type: "Activate" })
 

--- a/src/browser/Navigators/Navigator/Title.js
+++ b/src/browser/Navigators/Navigator/Title.js
@@ -1,11 +1,9 @@
 /* @flow */
 
-import {html, thunk, forward} from 'reflex';
-import * as Style from '../../../common/style';
-import {always} from '../../../common/prelude';
-
-
-import type {Address, DOM} from "reflex"
+import type { Address, DOM } from 'reflex'
+import { html, thunk, forward } from 'reflex'
+import * as Style from '../../../common/style'
+import { always } from '../../../common/prelude'
 
 export type Action =
   | { type: "Activate" }

--- a/src/browser/Navigators/Navigator/WebView.js
+++ b/src/browser/Navigators/Navigator/WebView.js
@@ -26,7 +26,7 @@ import * as ElectronFrame from './WebView/ElectronFrame';
 import * as Ref from '../../../common/ref';
 import * as Tab from '../../Sidebar/Tab';
 
-/*::
+
 import type {Address, DOM} from "reflex"
 import type {URI, Time, Integer, Float} from "../../../common/prelude"
 import type {Icon} from "../../../common/favicon"
@@ -113,10 +113,10 @@ export type Action =
     , title: string
     , message: string
     }
-*/
+
 
 export class Model {
-  /*::
+  
   ref: Ref.Model;
   guestInstanceId: ?string;
   name: string;
@@ -126,7 +126,7 @@ export class Model {
   navigation: Navigation.Model;
   security: Security.Model;
   page: Page.Model;
-  */
+  
   constructor(
     ref/*: Ref.Model*/
   , guestInstanceId/*: ?string*/

--- a/src/browser/Navigators/Navigator/WebView.js
+++ b/src/browser/Navigators/Navigator/WebView.js
@@ -128,15 +128,15 @@ export class Model {
   page: Page.Model;
   
   constructor(
-    ref/*: Ref.Model*/
-  , guestInstanceId/*: ?string*/
-  , name/*: string*/
-  , features/*: string*/
-  , tab/*: Tab.Model*/
-  , shell/*: Shell.Model*/
-  , navigation/*: Navigation.Model*/
-  , security/*: Security.Model*/
-  , page/*: Page.Model*/
+    ref: Ref.Model
+  , guestInstanceId: ?string
+  , name: string
+  , features: string
+  , tab: Tab.Model
+  , shell: Shell.Model
+  , navigation: Navigation.Model
+  , security: Security.Model
+  , page: Page.Model
   ) {
     this.ref = ref
     this.guestInstanceId = guestInstanceId
@@ -152,36 +152,36 @@ export class Model {
 
 const NoOp = always({ type: "NoOp" });
 
-export const Close/*:Action*/ =
+export const Close:Action =
   { type: "Close"
   };
 
-export const Select/*:Action*/ =
+export const Select:Action =
   { type: "Select"
   };
 
-export const Closed/*:Action*/ =
+export const Closed:Action =
   { type: "Closed"
   };
 
-export const Edit/*:Action*/ =
+export const Edit:Action =
   { type: "Edit"
   };
 
-export const ShowTabs/*:Action*/ =
+export const ShowTabs:Action =
   { type: 'ShowTabs'
   };
 
-export const Create/*:Action*/ =
+export const Create:Action =
   { type: 'Create'
   };
 
-export const Focus/*:Action*/ =
+export const Focus:Action =
   { type: 'Focus'
   };
 
 export const Load =
-  (uri/*:URI*/)/*:Action*/ =>
+  (uri:URI):Action =>
   ( { type: 'Load'
     , uri
     }
@@ -194,12 +194,12 @@ const ShellAction = action =>
     }
   );
 
-export const ZoomIn/*:Action*/ = ShellAction(Shell.ZoomIn);
-export const ZoomOut/*:Action*/ = ShellAction(Shell.ZoomOut);
-export const ResetZoom/*:Action*/ = ShellAction(Shell.ResetZoom);
-export const MakeVisible/*:Action*/ =
+export const ZoomIn:Action = ShellAction(Shell.ZoomIn);
+export const ZoomOut:Action = ShellAction(Shell.ZoomOut);
+export const ResetZoom:Action = ShellAction(Shell.ResetZoom);
+export const MakeVisible:Action =
   ShellAction(Shell.MakeVisible);
-export const MakeNotVisible/*:Action*/ =
+export const MakeNotVisible:Action =
   ShellAction(Shell.MakeNotVisible);
 
 const NavigationAction = action =>
@@ -207,13 +207,13 @@ const NavigationAction = action =>
     , navigation: action
   });
 
-export const Stop/*:Action*/ =
+export const Stop:Action =
   NavigationAction(Navigation.Stop);
-export const Reload/*:Action*/ =
+export const Reload:Action =
   NavigationAction(Navigation.Reload);
-export const GoBack/*:Action*/ =
+export const GoBack:Action =
   NavigationAction(Navigation.GoBack);
-export const GoForward/*:Action*/ =
+export const GoForward:Action =
   NavigationAction(Navigation.GoForward);
 
 const SecurityAction = action =>
@@ -315,7 +315,7 @@ const updateNavigation = cursor
 
 
 export const init =
-  (options/*:Flags*/)/*:[Model, Effects<Action>]*/ => {
+  (options:Flags):[Model, Effects<Action>] => {
     const ref = Ref.create()
     return assemble(
         ref
@@ -331,15 +331,15 @@ export const init =
   };
 
 const assemble =
-  ( ref/*:Ref.Model*/
-  , guestInstanceId/*:?string*/
-  , name/*:string*/
-  , features/*:string*/
-  , [tab, $tab]/*:[Tab.Model, Effects<Tab.Action>]*/
-  , [shell, $shell]/*:[Shell.Model, Effects<Shell.Action>]*/
-  , [navigation, $navigation]/*:[Navigation.Model, Effects<Navigation.Action>]*/
-  , [security, $security]/*:[Security.Model, Effects<Security.Action>]*/
-  , [page, $page]/*:[Page.Model, Effects<Page.Action>]*/
+  ( ref:Ref.Model
+  , guestInstanceId:?string
+  , name:string
+  , features:string
+  , [tab, $tab]:[Tab.Model, Effects<Tab.Action>]
+  , [shell, $shell]:[Shell.Model, Effects<Shell.Action>]
+  , [navigation, $navigation]:[Navigation.Model, Effects<Navigation.Action>]
+  , [security, $security]:[Security.Model, Effects<Security.Action>]
+  , [page, $page]:[Page.Model, Effects<Page.Action>]
   ) => {
     const model = new Model
       ( ref
@@ -392,7 +392,7 @@ const endLoad = (model, time) =>
   );
 
 const nofx = /*::<model, action>*/
-  (model/*:model*/)/*:[model, Effects<action>]*/ =>
+  (model:model):[model, Effects<action>] =>
   [ model, Effects.none ]
 
 const connect = nofx;
@@ -410,7 +410,7 @@ const close = model =>
   [ model, Effects.receive(Closed) ];
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ => {
+  (model:Model, action:Action):[Model, Effects<Action>] => {
     switch (action.type) {
       case "NoOp":
         return [ model, Effects.none ];
@@ -491,5 +491,5 @@ const Frame =
 
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>):DOM =>
   Frame.view(styleSheet, model, address);

--- a/src/browser/Navigators/Navigator/WebView.js
+++ b/src/browser/Navigators/Navigator/WebView.js
@@ -5,32 +5,27 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {Effects, html, forward} from 'reflex';
-import {merge, always, batch} from '../../../common/prelude';
-import {cursor} from '../../../common/cursor';
-import {compose} from '../../../lang/functional';
-import {on} from '@driver';
-import {isElectron} from "../../../common/runtime";
-import * as Shell from './WebView/Shell';
-import * as Navigation from './WebView/Navigation';
-import * as Security from './WebView/Security';
-import * as Page from './WebView/Page';
-import * as Unknown from '../../../common/unknown';
-import {Style, StyleSheet} from '../../../common/style';
-import {readTitle, isDark, canGoBack} from './WebView/Util';
-import * as Driver from '@driver';
-import * as Focusable from '../../../common/focusable';
-import * as Easing from 'eased';
-import * as MozBrowserFrame from './WebView/MozBrowserFrame';
-import * as ElectronFrame from './WebView/ElectronFrame';
-import * as Ref from '../../../common/ref';
-import * as Tab from '../../Sidebar/Tab';
-
-
-import type {Address, DOM} from "reflex"
-import type {URI, Time, Integer, Float} from "../../../common/prelude"
-import type {Icon} from "../../../common/favicon"
-import {performance} from "../../../common/performance"
+import type { Address, DOM } from 'reflex'
+import { Effects } from 'reflex'
+import type { URI, Time, Integer, Float } from '../../../common/prelude'
+import { merge, always, batch } from '../../../common/prelude'
+import { cursor } from '../../../common/cursor'
+import { compose } from '../../../lang/functional'
+import { on } from '@driver'
+import { isElectron } from '../../../common/runtime'
+import * as Shell from './WebView/Shell'
+import * as Navigation from './WebView/Navigation'
+import * as Security from './WebView/Security'
+import * as Page from './WebView/Page'
+import * as Unknown from '../../../common/unknown'
+import { StyleSheet } from '../../../common/style'
+import { canGoBack } from './WebView/Util'
+import * as MozBrowserFrame from './WebView/MozBrowserFrame'
+import * as ElectronFrame from './WebView/ElectronFrame'
+import * as Ref from '../../../common/ref'
+import * as Tab from '../../Sidebar/Tab'
+import type { Icon } from '../../../common/favicon'
+import { performance } from '../../../common/performance'
 
 export type {URI, Time}
 

--- a/src/browser/Navigators/Navigator/WebView/ElectronFrame.js
+++ b/src/browser/Navigators/Navigator/WebView/ElectronFrame.js
@@ -23,7 +23,7 @@ const DocumentFirstPaint = always({ type: "DocumentFirstPaint" });
 
 
 export const view =
-  ( styleSheet/*:{ base: Style.Rules }*/
+  ( styleSheet:{ base: Style.Rules }
   , model:Model
   , address:Address<Action>
   ):DOM =>

--- a/src/browser/Navigators/Navigator/WebView/ElectronFrame.js
+++ b/src/browser/Navigators/Navigator/WebView/ElectronFrame.js
@@ -8,11 +8,11 @@ import {on} from '@driver';
 import {always} from '../../../../common/prelude';
 
 
-/*::
+
 import type {Address, DOM} from "reflex"
 import type {Model, Action} from "../WebView"
 import {performance} from "../../../../common/performance"
-*/
+
 
 const Blur = always({ type: "Blur" });
 const Focus = always({ type: "Focus" });

--- a/src/browser/Navigators/Navigator/WebView/ElectronFrame.js
+++ b/src/browser/Navigators/Navigator/WebView/ElectronFrame.js
@@ -24,9 +24,9 @@ const DocumentFirstPaint = always({ type: "DocumentFirstPaint" });
 
 export const view =
   ( styleSheet/*:{ base: Style.Rules }*/
-  , model/*:Model*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  , model:Model
+  , address:Address<Action>
+  ):DOM =>
   node
   ( 'webview'
   , { [model.ref.name]: model.ref.value

--- a/src/browser/Navigators/Navigator/WebView/ElectronFrame.js
+++ b/src/browser/Navigators/Navigator/WebView/ElectronFrame.js
@@ -1,17 +1,12 @@
 /* @flow */
 
-import {Effects, node, html, forward} from 'reflex';
-import * as URL from '../../../../common/url-helper';
-import * as Driver from '@driver';
-import * as Style from '../../../../common/style';
-import {on} from '@driver';
-import {always} from '../../../../common/prelude';
-
-
-
-import type {Address, DOM} from "reflex"
-import type {Model, Action} from "../WebView"
-import {performance} from "../../../../common/performance"
+import type { Address, DOM } from 'reflex'
+import { node, forward } from 'reflex'
+import { on } from '@driver'
+import * as Style from '../../../../common/style'
+import { always } from '../../../../common/prelude'
+import type { Model, Action } from '../WebView'
+import { performance } from '../../../../common/performance'
 
 
 const Blur = always({ type: "Blur" });

--- a/src/browser/Navigators/Navigator/WebView/MozBrowserFrame.js
+++ b/src/browser/Navigators/Navigator/WebView/MozBrowserFrame.js
@@ -22,9 +22,9 @@ const DocumentFirstPaint = always({ type: "DocumentFirstPaint" });
 
 export const view =
   ( styleSheet/*:{ base: Style.Rules }*/
-  , model/*:Model*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  , model:Model
+  , address:Address<Action>
+  ):DOM =>
   html.iframe
   ( { [model.ref.name]: model.ref.value
     , src: model.navigation.src

--- a/src/browser/Navigators/Navigator/WebView/MozBrowserFrame.js
+++ b/src/browser/Navigators/Navigator/WebView/MozBrowserFrame.js
@@ -8,11 +8,11 @@ import {on} from '@driver';
 import {always} from '../../../../common/prelude';
 
 
-/*::
+
 import type {Address, DOM} from "reflex"
 import type {Model, Action} from "../WebView"
 import {performance} from "../../../../common/performance"
-*/
+
 
 const Blur = always({ type: "Blur" });
 const Focus = always({ type: "Focus" });

--- a/src/browser/Navigators/Navigator/WebView/MozBrowserFrame.js
+++ b/src/browser/Navigators/Navigator/WebView/MozBrowserFrame.js
@@ -21,7 +21,7 @@ const FirstPaint = always({ type: "FirstPaint" });
 const DocumentFirstPaint = always({ type: "DocumentFirstPaint" });
 
 export const view =
-  ( styleSheet/*:{ base: Style.Rules }*/
+  ( styleSheet:{ base: Style.Rules }
   , model:Model
   , address:Address<Action>
   ):DOM =>

--- a/src/browser/Navigators/Navigator/WebView/MozBrowserFrame.js
+++ b/src/browser/Navigators/Navigator/WebView/MozBrowserFrame.js
@@ -1,17 +1,13 @@
 /* @flow */
 
-import {Effects, node, html, forward} from 'reflex';
-import * as URL from '../../../../common/url-helper';
-import * as Driver from '@driver';
-import * as Style from '../../../../common/style';
-import {on} from '@driver';
-import {always} from '../../../../common/prelude';
-
-
-
-import type {Address, DOM} from "reflex"
-import type {Model, Action} from "../WebView"
-import {performance} from "../../../../common/performance"
+import type { Address, DOM } from 'reflex'
+import { html, forward } from 'reflex'
+import * as URL from '../../../../common/url-helper'
+import { on } from '@driver'
+import * as Style from '../../../../common/style'
+import { always } from '../../../../common/prelude'
+import type { Model, Action } from '../WebView'
+import { performance } from '../../../../common/performance'
 
 
 const Blur = always({ type: "Blur" });

--- a/src/browser/Navigators/Navigator/WebView/Navigation.js
+++ b/src/browser/Navigators/Navigator/WebView/Navigation.js
@@ -10,7 +10,7 @@ import {Effects, Task} from 'reflex';
 import * as Unknown from '../../../../common/unknown'
 import * as Ref from '../../../../common/ref';
 
-/*::
+
 import type {Never} from "reflex";
 import type {Result} from '../../../../common/result';
 import type {ID, URI, Time} from "../../../../common/prelude"
@@ -49,10 +49,10 @@ export type Action =
   | { type: "WentForward"
     , wentForward: Result<Error, void>
     }
-*/
+
 
 export class Model {
-  /*::
+  
   ref: Ref.Model;
   canGoBack: boolean;
   canGoForward: boolean;
@@ -69,7 +69,7 @@ export class Model {
   // `currentURI` as that would cause iframe a reload every time the user
   // navigates away & also destroy navgation history along the way.
   src: URI;
-  */
+  
   constructor(
     ref/*: Ref.Model*/
   , canGoBack/*: boolean*/

--- a/src/browser/Navigators/Navigator/WebView/Navigation.js
+++ b/src/browser/Navigators/Navigator/WebView/Navigation.js
@@ -71,11 +71,11 @@ export class Model {
   src: URI;
   
   constructor(
-    ref/*: Ref.Model*/
-  , canGoBack/*: boolean*/
-  , canGoForward/*: boolean*/
-  , currentURI/*: URI*/
-  , src/*: URI*/
+    ref: Ref.Model
+  , canGoBack: boolean
+  , canGoForward: boolean
+  , currentURI: URI
+  , src: URI
   ) {
     this.ref = ref
     this.canGoBack = canGoBack
@@ -87,18 +87,18 @@ export class Model {
 
 
 // User interaction interaction may also triggered following actions:
-export const Stop/*:Action*/ = {type: "Stop"};
-export const Reload/*:Action*/ = {type: "Reload"};
-export const GoBack/*:Action*/ = {type: "GoBack"};
-export const GoForward/*:Action*/ = {type: "GoForward"};
+export const Stop:Action = {type: "Stop"};
+export const Reload:Action = {type: "Reload"};
+export const GoBack:Action = {type: "GoBack"};
+export const GoForward:Action = {type: "GoForward"};
 
 const NoOp = always({type: "NoOp"});
 export const Load =
-  (uri/*:URI*/)/*:Action*/ =>
+  (uri:URI):Action =>
   ({type: "Load", uri});
 
 export const LocationChanged =
-  (uri/*:URI*/, canGoBack/*:?boolean*/, canGoForward/*:?boolean*/)/*:Action*/ =>
+  (uri:URI, canGoBack:?boolean, canGoForward:?boolean):Action =>
   ({type: "LocationChanged", uri, canGoBack, canGoForward});
 
 const CanGoBackChanged =
@@ -142,7 +142,7 @@ const WentForward = result =>
   );
 
 export const canGoBack =
-  (ref/*:Ref.Model*/)/*:Task<Never, Result<Error, boolean>>*/ =>
+  (ref:Ref.Model):Task<Never, Result<Error, boolean>> =>
   Ref
   .deref(ref)
   .chain(elementCanGoBack);
@@ -162,7 +162,7 @@ const elementCanGoBack =
   });
 
 export const canGoForward =
-  (ref/*:Ref.Model*/)/*:Task<Never, Result<Error, boolean>>*/ =>
+  (ref:Ref.Model):Task<Never, Result<Error, boolean>> =>
   Ref
   .deref(ref)
   .chain(elementCanGoForward);
@@ -185,7 +185,7 @@ const elementCanGoForward =
 const invoke =
   name => {
     const elementInvoke = /*::<value>*/
-      (element/*:HTMLElement*/)/*:Task<Never, Result<Error, value>>*/ =>
+      (element:HTMLElement):Task<Never, Result<Error, value>> =>
       new Task((succeed, fail) => {
         try {
           // @FlowIgnore: We know that method may not exist.
@@ -196,7 +196,7 @@ const invoke =
       })
 
     const task = /*::<value>*/
-      (ref/*:Ref.Model*/)/*:Task<Never, Result<Error, value>>*/ =>
+      (ref:Ref.Model):Task<Never, Result<Error, value>> =>
       Ref
       .deref(ref)
       .chain(elementInvoke)
@@ -216,11 +216,11 @@ const report =
   });
 
 export const init =
-  ( ref/*:Ref.Model*/=Ref.create()
-  , uri/*:URI*/='about:blank'
-  , canGoBack/*: boolean*/ = false
-  , canGoForward/*: boolean*/ = false
-  )/*:[Model, Effects<Action>]*/ =>
+  ( ref:Ref.Model=Ref.create()
+  , uri:URI='about:blank'
+  , canGoBack: boolean = false
+  , canGoForward: boolean = false
+  ):[Model, Effects<Action>] =>
   [ new Model
     ( ref
     , canGoBack
@@ -304,9 +304,9 @@ const updateLocation =
   );
 
 export const load =
-  ( model/*:Model*/
-  , uri/*:URI*/='about:blank'
-  )/*:[Model, Effects<Action>]*/ =>
+  ( model:Model
+  , uri:URI='about:blank'
+  ):[Model, Effects<Action>] =>
   [ new Model
     ( model.ref
     , false
@@ -322,7 +322,7 @@ export const load =
   ]
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ => {
+  (model:Model, action:Action):[Model, Effects<Action>] => {
     switch (action.type) {
       case "CanGoForwardChanged":
         return  (

--- a/src/browser/Navigators/Navigator/WebView/Navigation.js
+++ b/src/browser/Navigators/Navigator/WebView/Navigation.js
@@ -4,16 +4,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {always} from '../../../../common/prelude';
-import {ok, error} from '../../../../common/result';
-import {Effects, Task} from 'reflex';
+import type { ID, URI, Time } from '../../../../common/prelude'
+import { always } from '../../../../common/prelude'
+import type { Result } from '../../../../common/result'
+import { ok, error } from '../../../../common/result'
+import type { Never } from 'reflex'
+import { Effects, Task } from 'reflex'
 import * as Unknown from '../../../../common/unknown'
-import * as Ref from '../../../../common/ref';
-
-
-import type {Never} from "reflex";
-import type {Result} from '../../../../common/result';
-import type {ID, URI, Time} from "../../../../common/prelude"
+import * as Ref from '../../../../common/ref'
 
 export type Action =
   | { type: "NoOp" }

--- a/src/browser/Navigators/Navigator/WebView/Page.js
+++ b/src/browser/Navigators/Navigator/WebView/Page.js
@@ -11,7 +11,7 @@ import * as Pallet from '../../../../browser/pallet';
 import * as Unknown from '../../../../common/unknown';
 import * as Ref from '../../../../common/ref';
 
-/*::
+
 import type {URI} from "../../../../common/prelude"
 import type {Icon} from "../../../../common/favicon"
 
@@ -43,10 +43,10 @@ export type Action =
   | { type: "LocationChanged"
     , uri: URI
     }
-*/
+
 
 export class Model {
-  /*::
+  
   uri: URI;
   title: ?string;
   faviconURI: ?URI;
@@ -56,7 +56,7 @@ export class Model {
   curatedColor: ?Pallet.Theme;
 
   pallet: Pallet.Model;
-  */
+  
   constructor(
     uri/*: URI*/
   , title/*: ?string*/

--- a/src/browser/Navigators/Navigator/WebView/Page.js
+++ b/src/browser/Navigators/Navigator/WebView/Page.js
@@ -58,15 +58,15 @@ export class Model {
   pallet: Pallet.Model;
   
   constructor(
-    uri/*: URI*/
-  , title/*: ?string*/
-  , faviconURI/*: ?URI*/
-  , icon/*: ?Icon*/
+    uri: URI
+  , title: ?string
+  , faviconURI: ?URI
+  , icon: ?Icon
 
-  , themeColor/*: ?string*/
-  , curatedColor/*: ?Pallet.Theme*/
+  , themeColor: ?string
+  , curatedColor: ?Pallet.Theme
 
-  , pallet/*: Pallet.Model*/
+  , pallet: Pallet.Model
   ) {
     this.uri = uri
     this.title = title
@@ -78,48 +78,48 @@ export class Model {
   }
 }
 
-export const DocumentFirstPaint/*:Action*/ =
+export const DocumentFirstPaint:Action =
   {type: "DocumentFirstPaint"};
 
-export const FirstPaint/*:Action*/ =
+export const FirstPaint:Action =
   {type: "FirstPaint"};
 
 export const MetaChanged =
-  (name/*:string*/, content/*:string*/)/*:Action*/ =>
+  (name:string, content:string):Action =>
   ({type: "MetaChanged", name, content});
 
 
 export const TitleChanged =
-  (title/*:string*/)/*:Action*/ =>
+  (title:string):Action =>
  ({type: "TitleChanged", title});
 
 export const IconChanged =
-  (icon/*:Icon*/)/*:Action*/ =>
+  (icon:Icon):Action =>
   ({type: "IconChanged", icon});
 
 export const OverflowChanged =
-  (isOverflown/*:boolean*/)/*:Action*/ =>
+  (isOverflown:boolean):Action =>
   ({type: "OverflowChanged", isOverflown});
 
 export const Scrolled =
-  (detail/*:any*/)/*:Action*/ =>
+  (detail:any):Action =>
   ({type: "Scrolled", detail});
 
 export const CuratedColorUpdate =
-  (color/*:?Pallet.Theme*/)/*:Action*/ =>
+  (color:?Pallet.Theme):Action =>
   ({type: "CuratedColorUpdate", color});
 
-export const CreatePallet/*:Action*/ =
+export const CreatePallet:Action =
   {type: "CreatePallet"};
 
-export const LoadStart/*:Action*/ =
+export const LoadStart:Action =
   {type: "LoadStart"};
 
-export const LoadEnd/*:Action*/ =
+export const LoadEnd:Action =
   {type: "LoadEnd"};
 
 export const LocationChanged =
-  (uri/*:URI*/)/*:Action*/ =>
+  (uri:URI):Action =>
   ({type: "LocationChanged", uri});
 
 
@@ -183,7 +183,7 @@ const updatePallet = (model, _) =>
   ];
 
 export const init =
-  (uri/*:URI*/)/*:[Model, Effects<Action>]*/ =>
+  (uri:URI):[Model, Effects<Action>] =>
   [ new Model
     ( uri
     , null
@@ -268,7 +268,7 @@ const updateURI =
   );
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ => {
+  (model:Model, action:Action):[Model, Effects<Action>] => {
     switch (action.type) {
       case "LoadStart":
         return loadStart(model);

--- a/src/browser/Navigators/Navigator/WebView/Page.js
+++ b/src/browser/Navigators/Navigator/WebView/Page.js
@@ -4,16 +4,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Effects, Task} from 'reflex';
-import {merge} from '../../../../common/prelude';
-import * as Favicon from '../../../../common/favicon';
-import * as Pallet from '../../../../browser/pallet';
-import * as Unknown from '../../../../common/unknown';
-import * as Ref from '../../../../common/ref';
-
-
-import type {URI} from "../../../../common/prelude"
-import type {Icon} from "../../../../common/favicon"
+import { Effects } from 'reflex'
+import type { URI } from '../../../../common/prelude'
+import type { Icon } from '../../../../common/favicon'
+import * as Favicon from '../../../../common/favicon'
+import * as Pallet from '../../../../browser/pallet'
+import * as Unknown from '../../../../common/unknown'
 
 export type Action =
   | { type: "LoadStart" }

--- a/src/browser/Navigators/Navigator/WebView/Security.js
+++ b/src/browser/Navigators/Navigator/WebView/Security.js
@@ -29,9 +29,9 @@ export class Model {
   extendedValidation: boolean;
   
   constructor(
-    state/*:State*/
-  , secure/*:boolean*/
-  , extendedValidation/*:boolean*/
+    state:State
+  , secure:boolean
+  , extendedValidation:boolean
   ) {
     this.state = state
     this.secure = secure
@@ -45,12 +45,12 @@ const insecure = new Model
   , false
   )
 
-export const LoadStart/*:Action*/ =
+export const LoadStart:Action =
   { type: "LoadStart"
   };
 
 export const Changed =
-  (state/*:State*/, extendedValidation/*:boolean*/)/*:Action*/ =>
+  (state:State, extendedValidation:boolean):Action =>
   ( { type: "SecurityChanged"
     , state
     , extendedValidation
@@ -58,7 +58,7 @@ export const Changed =
   );
 
 export const init =
-  ()/*:[Model, Effects<Action>]*/ =>
+  ():[Model, Effects<Action>] =>
   [ insecure
   , Effects.none
   ]
@@ -78,7 +78,7 @@ const updateSecurity =
   ]
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ => {
+  (model:Model, action:Action):[Model, Effects<Action>] => {
     switch (action.type) {
       case "LoadStart":
         return loadStart(model);

--- a/src/browser/Navigators/Navigator/WebView/Security.js
+++ b/src/browser/Navigators/Navigator/WebView/Security.js
@@ -8,7 +8,7 @@ import {Effects} from 'reflex';
 import * as Unknown from '../../../../common/unknown';
 
 
-/*::
+
 export type State =
   | "broken"
   | "secure"
@@ -20,14 +20,14 @@ export type Action =
     , state: State
     , extendedValidation: boolean
     }
-*/
+
 
 export class Model {
-  /*::
+  
   state: State;
   secure: boolean;
   extendedValidation: boolean;
-  */
+  
   constructor(
     state/*:State*/
   , secure/*:boolean*/

--- a/src/browser/Navigators/Navigator/WebView/Security.js
+++ b/src/browser/Navigators/Navigator/WebView/Security.js
@@ -4,9 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Effects} from 'reflex';
-import * as Unknown from '../../../../common/unknown';
-
+import { Effects } from 'reflex'
+import * as Unknown from '../../../../common/unknown'
 
 
 export type State =

--- a/src/browser/Navigators/Navigator/WebView/Shell.js
+++ b/src/browser/Navigators/Navigator/WebView/Shell.js
@@ -42,10 +42,10 @@ export class Model {
   isFocused: boolean;
   
   constructor(
-    ref/*:Ref.Model*/
-  , zoom/*:Float*/
-  , isVisible/*:boolean*/
-  , isFocused/*:boolean*/
+    ref:Ref.Model
+  , zoom:Float
+  , isVisible:boolean
+  , isFocused:boolean
   ) {
     this.ref = ref
     this.zoom = zoom
@@ -54,19 +54,19 @@ export class Model {
   }
 }
 
-export const MakeVisible/*:Action*/ =
+export const MakeVisible:Action =
   ({type: "MakeVisible"});
 
-export const MakeNotVisible/*:Action*/ =
+export const MakeNotVisible:Action =
   ({type: "MakeNotVisible"});
 
-export const ZoomIn/*:Action*/ =
+export const ZoomIn:Action =
   ({type: "ZoomIn"});
 
-export const ZoomOut/*:Action*/ =
+export const ZoomOut:Action =
   ({type: "ZoomOut"});
 
-export const ResetZoom/*:Action*/ =
+export const ResetZoom:Action =
   ({type: "ResetZoom"});
 
 const FocusableAction =
@@ -80,8 +80,8 @@ const Panic =
     }
   )
 
-export const Focus/*:Action*/ = Focusable.Focus;
-export const Blur/*:Action*/ = Focusable.Blur;
+export const Focus:Action = Focusable.Focus;
+export const Blur:Action = Focusable.Blur;
 
 const NoOp = always({type: "NoOp"});
 
@@ -100,7 +100,7 @@ const ZoomChanged =
   );
 
 const setZoom =
-  (ref/*:Ref.Model*/, level/*:Float*/)/*:Task<Error, Float>*/ =>
+  (ref:Ref.Model, level:Float):Task<Error, Float> =>
   Ref
   .deref(ref)
   .chain(element => setElementZoom(element, level))
@@ -122,19 +122,19 @@ const ZOOM_MAX = 2;
 const ZOOM_STEP = 0.1;
 
 export const zoomIn =
-  (ref/*:Ref.Model*/, zoom/*:number*/)/*:Task<Error, number>*/ =>
+  (ref:Ref.Model, zoom:number):Task<Error, number> =>
   setZoom(ref, Math.min(ZOOM_MAX, zoom + ZOOM_STEP));
 
 export const zoomOut =
-  (ref/*:Ref.Model*/, zoom/*:number*/)/*:Task<Error, number>*/ =>
+  (ref:Ref.Model, zoom:number):Task<Error, number> =>
   setZoom(ref, Math.max(ZOOM_MIN, zoom - ZOOM_STEP));
 
 export const resetZoom =
-  (ref/*:Ref.Model*/)/*:Task<Error, number>*/ =>
+  (ref:Ref.Model):Task<Error, number> =>
   setZoom(ref, 1);
 
 export const setVisibility =
-  (ref/*:Ref.Model*/, isVisible/*:boolean*/)/*:Task<Error, boolean>*/ =>
+  (ref:Ref.Model, isVisible:boolean):Task<Error, boolean> =>
   Ref
   .deref(ref)
   .chain(target => setElementVisibility(target, isVisible));
@@ -152,13 +152,13 @@ const setElementVisibility =
   })
 
 export const focus = /*::<value>*/
-  (ref/*:Ref.Model*/)/*:Task<Error, value>*/ =>
+  (ref:Ref.Model):Task<Error, value> =>
   Ref
   .deref(ref)
   .chain(focusElement);
 
 const focusElement = /*::<value>*/
-  (element/*:HTMLElement*/)/*:Task<Error, value>*/ =>
+  (element:HTMLElement):Task<Error, value> =>
   new Task((succeed, fail) => {
     try {
       if (element.ownerDocument.activeElement !== element) {
@@ -171,13 +171,13 @@ const focusElement = /*::<value>*/
   });
 
 export const blur = /*::<value>*/
-  (ref/*:Ref.Model*/)/*:Task<Error, value>*/ =>
+  (ref:Ref.Model):Task<Error, value> =>
   Ref
   .deref(ref)
   .chain(blurElement);
 
 const blurElement =/*::<value>*/
-  (element/*:HTMLElement*/)/*:Task<Error, value>*/ =>
+  (element:HTMLElement):Task<Error, value> =>
   new Task((succeed, fail) => {
     try {
       if (element.ownerDocument.activeElement === element) {
@@ -193,15 +193,15 @@ const blurElement =/*::<value>*/
 
 // Reports error as a warning in a console.
 const warn = /*::<value>*/
-  (error/*:Error*/)/*:Task<Never, value>*/ =>
+  (error:Error):Task<Never, value> =>
   new Task((succeed, fail) => {
     console.warn(error);
   });
 
 
 export const init =
-  ( ref/*:Ref.Model*/
-  , isFocused/*:boolean*/)/*:[Model, Effects<Action>]*/ =>
+  ( ref:Ref.Model
+  , isFocused:boolean):[Model, Effects<Action>] =>
   [ new Model
     ( ref
     , 1
@@ -253,7 +253,7 @@ const updateFocus =
 
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ => {
+  (model:Model, action:Action):[Model, Effects<Action>] => {
     switch (action.type) {
       case "ZoomIn":
         return [

--- a/src/browser/Navigators/Navigator/WebView/Shell.js
+++ b/src/browser/Navigators/Navigator/WebView/Shell.js
@@ -11,7 +11,7 @@ import {ok, error} from "../../../../common/result";
 import * as Focusable from "../../../../common/focusable";
 import * as Ref from '../../../../common/ref';
 
-/*::
+
 import type {Result} from "../../../../common/result"
 import type {Never} from "reflex"
 import type {Float} from "../../../../common/prelude"
@@ -32,15 +32,15 @@ export type Action =
     }
   | { type: "Focus" }
   | { type: "Blur" }
-*/
+
 
 export class Model {
-  /*::
+  
   ref: Ref.Model;
   zoom: Float;
   isVisible: boolean;
   isFocused: boolean;
-  */
+  
   constructor(
     ref/*:Ref.Model*/
   , zoom/*:Float*/

--- a/src/browser/Navigators/Navigator/WebView/Shell.js
+++ b/src/browser/Navigators/Navigator/WebView/Shell.js
@@ -4,17 +4,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Effects, Task} from "reflex";
-import {merge, always} from "../../../../common/prelude";
-import {cursor} from "../../../../common/cursor";
-import {ok, error} from "../../../../common/result";
-import * as Focusable from "../../../../common/focusable";
-import * as Ref from '../../../../common/ref';
-
-
-import type {Result} from "../../../../common/result"
-import type {Never} from "reflex"
-import type {Float} from "../../../../common/prelude"
+import type { Never } from 'reflex'
+import { Effects, Task } from 'reflex'
+import type { Float } from '../../../../common/prelude'
+import { always } from '../../../../common/prelude'
+import type { Result } from '../../../../common/result'
+import { ok, error } from '../../../../common/result'
+import * as Focusable from '../../../../common/focusable'
+import * as Ref from '../../../../common/ref'
 
 export type Action =
   | { type: "NoOp" }

--- a/src/browser/Navigators/Navigator/WebView/Util.js
+++ b/src/browser/Navigators/Navigator/WebView/Util.js
@@ -12,7 +12,7 @@ import * as WebView from "../WebView"
 */
 
 export const readTitle =
-  (model/*:WebView.Model*/, fallback/*:string*/)/*:string*/ =>
+  (model:WebView.Model, fallback:string):string =>
   ( ( model.page != null &&
       model.page.title != null &&
       model.page.title !== ''
@@ -24,23 +24,23 @@ export const readTitle =
   );
 
 export const readFaviconURI =
-  (model/*:WebView.Model*/)/*:string*/ =>
+  (model:WebView.Model):string =>
   ( (model.page && model.page.faviconURI)
   ? model.page.faviconURI
   : Favicon.getFallback(model.navigation.currentURI)
   );
 
 export const isDark =
-  (model/*:WebView.Model*/)/*:boolean*/ =>
+  (model:WebView.Model):boolean =>
   ( model.page != null
   ? model.page.pallet.isDark
   : false
   );
 
 export const canGoBack =
-  (model/*:WebView.Model*/)/*:boolean*/ =>
+  (model:WebView.Model):boolean =>
   model.navigation.canGoBack === true;
 
 export const isSecure =
-  (model/*:WebView.Model*/)/*:boolean*/ =>
+  (model:WebView.Model):boolean =>
   model.security.secure;

--- a/src/browser/Navigators/Navigator/WebView/Util.js
+++ b/src/browser/Navigators/Navigator/WebView/Util.js
@@ -4,8 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import * as URI from '../../../../common/url-helper';
-import * as Favicon from '../../../../common/favicon';
+import * as URI from '../../../../common/url-helper'
+import * as Favicon from '../../../../common/favicon'
 
 /*::
 import * as WebView from "../WebView"

--- a/src/browser/Navigators/Overlay.js
+++ b/src/browser/Navigators/Overlay.js
@@ -14,9 +14,9 @@ export type Action =
 const Click = always({ type: "Click" })
 
 export const render =
-  ( isOpen/*:boolean*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  ( isOpen:boolean
+  , address:Address<Action>
+  ):DOM =>
   html.button
   ( { className: "overlay"
     , style: Style.mix
@@ -31,9 +31,9 @@ export const render =
   )
 
 export const view =
-  ( isOpen/*:boolean*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  ( isOpen:boolean
+  , address:Address<Action>
+  ):DOM =>
   thunk
   ( "Browser/NavigatorDeck/Overlay"
   , render

--- a/src/browser/Navigators/Overlay.js
+++ b/src/browser/Navigators/Overlay.js
@@ -4,12 +4,12 @@ import {always} from "../../common/prelude"
 import * as Style from "../../common/style"
 import {html, forward, thunk} from "reflex"
 
-/*::
+
 import type {Address, DOM} from "reflex"
 
 export type Action =
   | { type: "Click" }
-*/
+
 
 const Click = always({ type: "Click" })
 

--- a/src/browser/Navigators/Overlay.js
+++ b/src/browser/Navigators/Overlay.js
@@ -1,11 +1,9 @@
 /* @flow */
 
-import {always} from "../../common/prelude"
-import * as Style from "../../common/style"
-import {html, forward, thunk} from "reflex"
-
-
-import type {Address, DOM} from "reflex"
+import { always } from '../../common/prelude'
+import * as Style from '../../common/style'
+import type { Address, DOM } from 'reflex'
+import { html, forward, thunk } from 'reflex'
 
 export type Action =
   | { type: "Click" }

--- a/src/browser/Sidebar.js
+++ b/src/browser/Sidebar.js
@@ -47,10 +47,10 @@ export class Model {
   toolbar: Toolbar.Model;
   
   constructor(
-    isAttached/*: boolean*/
-  , isExpanded/*: boolean*/
-  , toolbar/*: Toolbar.Model*/
-  , animation/*: Animation.Model<Display.Model>*/
+    isAttached: boolean
+  , isExpanded: boolean
+  , toolbar: Toolbar.Model
+  , animation: Animation.Model<Display.Model>
   ) {
     this.isAttached = isAttached
     this.isExpanded = isExpanded
@@ -76,9 +76,9 @@ const styleSheet = Style.createSheet({
 
 
 export const init =
-  ( isAttached/*:boolean*/ = false
-  , isExpanded/*:boolean*/ = false
-  )/*:[Model, Effects<Action>]*/ => {
+  ( isAttached:boolean = false
+  , isExpanded:boolean = false
+  ):[Model, Effects<Action>] => {
     const display =
       ( isExpanded
       ? Display.expanded
@@ -106,21 +106,21 @@ export const init =
     return [model, fx]
   }
 
-export const CreateWebView/*:Action*/ =
+export const CreateWebView:Action =
   { type: 'CreateWebView'
   };
 
-export const Attach/*:Action*/ =
+export const Attach:Action =
   {
     type: "Attach"
   };
 
-export const Detach/*:Action*/ =
+export const Detach:Action =
   { type: "Detach"
   };
 
-export const Expand/*:Action*/ = {type: "Expand"};
-export const Collapse/*:Action*/ = {type: "Collapse"};
+export const Expand:Action = {type: "Expand"};
+export const Collapse:Action = {type: "Collapse"};
 
 const tagTabs =
   action => {
@@ -199,7 +199,7 @@ const updateAnimation = cursor
   )
 
 const nofx = /*::<model, action>*/
-  (model/*:model*/)/*:[model, Effects<action>]*/ =>
+  (model:model):[model, Effects<action>] =>
   [ model
   , Effects.none
   ]
@@ -233,7 +233,7 @@ const expand =
   );
 
 const collapse =
-  (model/*:Model*/) =>
+  (model:Model) =>
   ( !model.isExpanded
   ? nofx(model)
   : startAnimation
@@ -312,7 +312,7 @@ const assemble =
   ]
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ => {
+  (model:Model, action:Action):[Model, Effects<Action>] => {
     switch (action.type) {
       case "Expand":
         return expand(model);
@@ -335,10 +335,10 @@ export const update =
 
 
 export const render =
-  ( model/*:Model*/
-  , navigators/*:Deck.Model<Navigator.Model>*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  ( model:Model
+  , navigators:Deck.Model<Navigator.Model>
+  , address:Address<Action>
+  ):DOM =>
   html.menu
   ( { key: 'sidebar'
     , className: 'sidebar'
@@ -363,10 +363,10 @@ export const render =
   );
 
 export const view =
-  ( model/*:Model*/
-  , navigators/*:Deck.Model<Navigator.Model>*/
-  , address/*:Address<Action>*/
-  )/*:DOM*/ =>
+  ( model:Model
+  , navigators:Deck.Model<Navigator.Model>
+  , address:Address<Action>
+  ):DOM =>
   thunk
   ( 'Browser/Sidebar'
   , render

--- a/src/browser/Sidebar.js
+++ b/src/browser/Sidebar.js
@@ -40,12 +40,12 @@ export type Action =
 
 
 export class Model {
-  /*::
+  
   isAttached: boolean;
   isExpanded: boolean;
   animation: Animation.Model<Display.Model>;
   toolbar: Toolbar.Model;
-  */
+  
   constructor(
     isAttached/*: boolean*/
   , isExpanded/*: boolean*/

--- a/src/browser/Sidebar.js
+++ b/src/browser/Sidebar.js
@@ -4,16 +4,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, thunk, forward, Effects} from 'reflex';
-import * as Style from '../common/style';
-import * as Toolbar from "./Sidebar/Toolbar";
-import * as Tabs from "./Sidebar/Tabs";
-import {merge, always} from "../common/prelude";
-import {cursor} from "../common/cursor";
-import * as Unknown from "../common/unknown";
-import * as Easing from "eased";
-import * as Display from "./Sidebar/Display";
-import * as Animation from "../common/Animation";
+import { html, thunk, forward, Effects } from 'reflex'
+import * as Style from '../common/style'
+import * as Toolbar from './Sidebar/Toolbar'
+import * as Tabs from './Sidebar/Tabs'
+import { cursor } from '../common/cursor'
+import * as Unknown from '../common/unknown'
+import * as Easing from 'eased'
+import * as Display from './Sidebar/Display'
+import * as Animation from '../common/Animation'
 
 
 /*::

--- a/src/browser/Sidebar/Display.js
+++ b/src/browser/Sidebar/Display.js
@@ -6,19 +6,19 @@
 
 import * as Easing from "eased";
 
-/*::
+
 import type {Integer, Float} from "../../common/prelude"
-*/
+
 
 export class Model {
-  /*::
+  
   x: Integer;
   shadow: Float;
   spacing: Integer;
   toolbarOpacity: Float;
   titleOpacity: Float;
   tabWidth: Integer;
-  */
+  
   constructor(
     x/*: Integer*/
   , shadow/*: Float*/

--- a/src/browser/Sidebar/Display.js
+++ b/src/browser/Sidebar/Display.js
@@ -20,12 +20,12 @@ export class Model {
   tabWidth: Integer;
   
   constructor(
-    x/*: Integer*/
-  , shadow/*: Float*/
-  , spacing/*: Integer*/
-  , toolbarOpacity/*: Float*/
-  , titleOpacity/*: Float*/
-  , tabWidth/*: Integer*/
+    x: Integer
+  , shadow: Float
+  , spacing: Integer
+  , toolbarOpacity: Float
+  , titleOpacity: Float
+  , tabWidth: Integer
   ) {
     this.x = x
     this.shadow = shadow
@@ -65,10 +65,10 @@ export const expanded = new Model
   )
 
 export const interpolate =
-  ( from/*:Model*/
-  , to/*:Model*/
-  , progress/*:Float*/
-  )/*:Model*/ =>
+  ( from:Model
+  , to:Model
+  , progress:Float
+  ):Model =>
   new Model
   ( Easing.float(from.x, to.x, progress)
   , Easing.float(from.shadow, to.shadow, progress)

--- a/src/browser/Sidebar/Display.js
+++ b/src/browser/Sidebar/Display.js
@@ -4,10 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import * as Easing from "eased";
-
-
-import type {Integer, Float} from "../../common/prelude"
+import * as Easing from 'eased'
+import type { Integer, Float } from '../../common/prelude'
 
 
 export class Model {

--- a/src/browser/Sidebar/Tab.js
+++ b/src/browser/Sidebar/Tab.js
@@ -33,9 +33,9 @@ export type Action =
 */
 
 export class Model {
-  /*::
+  
   isPointerOver: boolean;
-  */
+  
   constructor(isPointerOver/*:boolean*/) {
     this.isPointerOver = isPointerOver
   }

--- a/src/browser/Sidebar/Tab.js
+++ b/src/browser/Sidebar/Tab.js
@@ -36,7 +36,7 @@ export class Model {
   
   isPointerOver: boolean;
   
-  constructor(isPointerOver/*:boolean*/) {
+  constructor(isPointerOver:boolean) {
     this.isPointerOver = isPointerOver
   }
 }
@@ -67,11 +67,11 @@ const Out = TargetAction(Target.Out);
 const Over = TargetAction(Target.Over);
 
 export const init =
-  ()/*:[Model, Effects<Action>]*/ =>
+  ():[Model, Effects<Action>] =>
   transactOut;
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model:Model, action:Action):[Model, Effects<Action>] =>
   ( action.type === "Target"
   ? updateTarget(model, action.source)
   : Unknown.update(model, action)
@@ -213,10 +213,10 @@ const viewClose = (isSelected, tab, address) =>
   );
 
 export const render =
-  ( model/*:Navigator.Model*/
-  , address/*:Address<Action>*/
-  , {tabWidth, titleOpacity}/*:Context*/
-  )/*:DOM*/ =>
+  ( model:Navigator.Model
+  , address:Address<Action>
+  , {tabWidth, titleOpacity}:Context
+  ):DOM =>
   html.div
   ( { className: 'sidebar-tab'
     , style: Style.mix
@@ -262,10 +262,10 @@ export const render =
 
 
 export const view =
-  ( model/*:Navigator.Model*/
-  , address/*:Address<Action>*/
-  , context/*:Context*/
-  )/*:DOM*/ =>
+  ( model:Navigator.Model
+  , address:Address<Action>
+  , context:Context
+  ):DOM =>
   thunk
   ( `${model.output.ref.value}`
   , render

--- a/src/browser/Sidebar/Tab.js
+++ b/src/browser/Sidebar/Tab.js
@@ -4,15 +4,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, thunk, forward, Effects} from 'reflex';
-import * as Style from '../../common/style';
-import * as Image from '../../common/image';
-import * as Target from "../../common/target";
-import * as Unknown from "../../common/unknown";
-
-import {always, merge} from '../../common/prelude';
-import {readTitle, readFaviconURI} from '../Navigators/Navigator/WebView/Util';
-import {cursor} from '../../common/cursor';
+import { html, thunk, forward, Effects } from 'reflex'
+import * as Style from '../../common/style'
+import * as Image from '../../common/image'
+import * as Target from '../../common/target'
+import * as Unknown from '../../common/unknown'
+import { always } from '../../common/prelude'
+import { readTitle, readFaviconURI } from '../Navigators/Navigator/WebView/Util'
 
 
 /*::

--- a/src/browser/Sidebar/Tabs.js
+++ b/src/browser/Sidebar/Tabs.js
@@ -46,7 +46,7 @@ const styleSheet = Style.createSheet({
 });
 
 export const Close =
-  (id/*:ID*/)/*:Action*/ =>
+  (id:ID):Action =>
   ( { type: "Close"
     , id
     }
@@ -54,7 +54,7 @@ export const Close =
 
 
 export const Select =
-  (id/*:ID*/)/*:Action*/ =>
+  (id:ID):Action =>
   ( { type: "Select"
     , id
     }
@@ -84,7 +84,7 @@ const settings =
   }
 
 export const render =
-  (model/*:Model*/, address/*:Address<Action>*/, context/*:Context*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>, context:Context):DOM =>
   html.div
   ( settings
   , model
@@ -100,7 +100,7 @@ export const render =
   );
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/, context/*:Context*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>, context:Context):DOM =>
   thunk
   ( 'Browser/Sidebar/Tabs'
   , render

--- a/src/browser/Sidebar/Tabs.js
+++ b/src/browser/Sidebar/Tabs.js
@@ -4,13 +4,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, thunk, forward, Effects} from 'reflex';
-import {merge, setIn} from '../../common/prelude';
-import {cursor} from '../../common/cursor';
-import * as Style from '../../common/style';
-import * as Toolbar from './Toolbar';
-import * as Tab from './Tab';
-import * as Unknown from '../../common/unknown';
+import { html, thunk, forward } from 'reflex'
+import * as Style from '../../common/style'
+import * as Toolbar from './Toolbar'
+import * as Tab from './Tab'
 
 /*::
 import type {Address, DOM} from "reflex"

--- a/src/browser/Sidebar/Toolbar.js
+++ b/src/browser/Sidebar/Toolbar.js
@@ -12,7 +12,7 @@ import {merge} from "../../common/prelude";
 import {cursor} from "../../common/cursor";
 import * as Unknown from "../../common/unknown";
 
-/*::
+
 import type {Address, DOM} from "reflex"
 
 export type Context =
@@ -24,12 +24,12 @@ export type Action =
   | { type: "Detach" }
   | { type: "CreateWebView" }
   | { type: "Toggle", toggle: Toggle.Action }
-*/
+
 
 export class Model {
-  /*::
+  
   pin: Toggle.Model;
-  */
+  
   constructor(
     pin/*:Toggle.Model*/
   ) {

--- a/src/browser/Sidebar/Toolbar.js
+++ b/src/browser/Sidebar/Toolbar.js
@@ -31,21 +31,21 @@ export class Model {
   pin: Toggle.Model;
   
   constructor(
-    pin/*:Toggle.Model*/
+    pin:Toggle.Model
   ) {
     this.pin = pin
   }
 }
 
-export const Attach/*:Action*/ =
+export const Attach:Action =
   { type: "Attach"
   };
 
-export const Detach/*:Action*/ =
+export const Detach:Action =
   { type: "Detach"
   };
 
-export const CreateWebView/*:Action*/ =
+export const CreateWebView:Action =
   { type: "CreateWebView"
   };
 
@@ -68,7 +68,7 @@ const updateToggle = cursor({
   update: Toggle.update
 });
 
-export const init = ()/*:[Model, Effects<Action>]*/ => {
+export const init = ():[Model, Effects<Action>] => {
   const [pin, pinFX] = Toggle.init();
   return [
     new Model(pin),
@@ -81,7 +81,7 @@ export const init = ()/*:[Model, Effects<Action>]*/ => {
 }
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model:Model, action:Action):[Model, Effects<Action>] =>
   ( action.type === "Attach"
   ? updateToggle(model, Toggle.Check)
   : action.type === "Detach"
@@ -131,7 +131,7 @@ const viewPin = Toggle.view('pin-button', Style.createSheet({
 }));
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/, display/*:Context*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>, display:Context):DOM =>
   html.div({
     key: 'sidebar-toolbar',
     className: 'sidebar-toolbar',

--- a/src/browser/Sidebar/Toolbar.js
+++ b/src/browser/Sidebar/Toolbar.js
@@ -4,16 +4,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, thunk, forward, Effects} from 'reflex';
-import * as Style from '../../common/style';
-import * as Toggle from "../../common/toggle";
-import * as Button from "../../common/button";
-import {merge} from "../../common/prelude";
-import {cursor} from "../../common/cursor";
-import * as Unknown from "../../common/unknown";
-
-
-import type {Address, DOM} from "reflex"
+import type { Address, DOM } from 'reflex'
+import { html, thunk, forward, Effects } from 'reflex'
+import * as Style from '../../common/style'
+import * as Toggle from '../../common/toggle'
+import { cursor } from '../../common/cursor'
+import * as Unknown from '../../common/unknown'
 
 export type Context =
   { toolbarOpacity: number

--- a/src/browser/pallet.js
+++ b/src/browser/pallet.js
@@ -10,10 +10,10 @@ import tinycolor from 'tinycolor2';
 import {Effects, Task} from 'reflex';
 import {getDomainName} from '../common/url-helper';
 
-/*::
+
 import type {Address, DOM, Never} from "reflex"
 import type {URI, HexColor, Color, Model, Theme} from "./pallet";
-*/
+
 
 // Hand-curated themes for popular websites.
 const curated = {

--- a/src/browser/pallet.js
+++ b/src/browser/pallet.js
@@ -37,10 +37,10 @@ const curated = {
 // Calculate the distance from white, returning a boolean.
 // This is a pretty primitive check.
 const isHexBright =
-  (hexcolor/*:HexColor*/)/*:boolean*/ =>
+  (hexcolor:HexColor):boolean =>
   parseInt(hexcolor, 16) > 0xffffff/2;
 
-export const isDark = (color/*:Color*/)/*:boolean*/ => {
+export const isDark = (color:Color):boolean => {
   const tcolor = tinycolor(color);
   // tinycolor uses YIQ for brightness calculation, we also throw more
   // primitive hex based calculation and treat background as dark if any
@@ -48,14 +48,14 @@ export const isDark = (color/*:Color*/)/*:boolean*/ => {
   return (tcolor.isDark() || !isHexBright(tcolor.toHex()));
 }
 
-export const blank/*:Model*/ = {
+export const blank:Model = {
   isDark: false,
   foreground: null,
   background: null
 };
 
 export const create =
-  (background/*:Color*/, foreground/*:Color*/)/*:Model*/ =>
+  (background:Color, foreground:Color):Model =>
   ( { background
     , foreground
     , isDark: isDark(background)
@@ -63,7 +63,7 @@ export const create =
   );
 
 export const requestCuratedColor =
-  (uri/*:URI*/)/*:Task<Never, ?Theme>*/ =>
+  (uri:URI):Task<Never, ?Theme> =>
   new Task((succeed, fail) => {
     const hostname = getDomainName(uri);
     Promise.resolve

--- a/src/browser/pallet.js
+++ b/src/browser/pallet.js
@@ -6,13 +6,11 @@
 
 
 
-import tinycolor from 'tinycolor2';
-import {Effects, Task} from 'reflex';
-import {getDomainName} from '../common/url-helper';
-
-
-import type {Address, DOM, Never} from "reflex"
-import type {URI, HexColor, Color, Model, Theme} from "./pallet";
+import tinycolor from 'tinycolor2'
+import type { Address, DOM, Never } from 'reflex'
+import { Task } from 'reflex'
+import { getDomainName } from '../common/url-helper'
+import type { URI, HexColor, Color, Model, Theme } from './pallet'
 
 
 // Hand-curated themes for popular websites.

--- a/src/browser/shell.js
+++ b/src/browser/shell.js
@@ -23,7 +23,7 @@ const fetchFocus =
   new Task((succeed, fail) => succeed(document.hasFocus()));
 
 export const init =
-  ()/*:[Model, Effects<Action>]*/ => {
+  ():[Model, Effects<Action>] => {
   const [controls, fx] = Controls.init(false, false, false);
   return [
     ( { isFocused: false
@@ -43,23 +43,23 @@ export const init =
   ]
 }
 
-export const Focus/*:Action*/ =
+export const Focus:Action =
   { type: "Focus"
   };
 
-export const Blur/*:Action*/ =
+export const Blur:Action =
   { type: "Blur"
   };
 
-export const Close/*:Action*/ =
+export const Close:Action =
   { type: "Close"
   };
 
-export const Minimize/*:Action*/ =
+export const Minimize:Action =
   { type: "Minimize"
   };
 
-export const ToggleFullscreen/*:Action*/ =
+export const ToggleFullscreen:Action =
   { type: "ToggleFullscreen"
   };
 
@@ -159,7 +159,7 @@ const toggleFullscreen = model =>
 
 
 export const update =
-  (model/*:Model*/, action/*:Action*/) =>
+  (model:Model, action:Action) =>
   ( action.type === "Focus"
   ? focus(model)
   : action.type === "Blur"
@@ -188,7 +188,7 @@ export const update =
   );
 
 export const render =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ => {
+  (model:Model, address:Address<Action>):DOM => {
     if (!Runtime.useNativeTitlebar()) {
       return Controls.view(model.controls, forward(address, ControlsAction));
     } else {
@@ -197,7 +197,7 @@ export const render =
   }
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>):DOM =>
   thunk
   ( "Browser/Shell"
   , render

--- a/src/browser/shell.js
+++ b/src/browser/shell.js
@@ -13,10 +13,10 @@ import * as Runtime from "../common/runtime";
 import * as Controls from "./shell/controls";
 import * as Unknown from "../common/unknown";
 
-/*::
+
 import type {Address, DOM} from "reflex"
 import type {Model, Action} from "./shell"
-*/
+
 
 // @TODO: IO stuff should probably live elsewhere.
 const fetchFocus =

--- a/src/browser/shell.js
+++ b/src/browser/shell.js
@@ -4,18 +4,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Effects, Task, html, thunk, forward} from "reflex";
-import {merge, always} from "../common/prelude";
-import {cursor} from "../common/cursor";
-import * as Focusable from "../common/focusable";
-import * as Target from "../common/target";
-import * as Runtime from "../common/runtime";
-import * as Controls from "./shell/controls";
-import * as Unknown from "../common/unknown";
-
-
-import type {Address, DOM} from "reflex"
-import type {Model, Action} from "./shell"
+import type { Address, DOM } from 'reflex'
+import { Effects, Task, thunk, forward } from 'reflex'
+import { merge } from '../common/prelude'
+import { cursor } from '../common/cursor'
+import * as Runtime from '../common/runtime'
+import * as Controls from './shell/controls'
+import * as Unknown from '../common/unknown'
+import type { Model, Action } from './shell'
 
 
 // @TODO: IO stuff should probably live elsewhere.

--- a/src/browser/shell/controls.js
+++ b/src/browser/shell/controls.js
@@ -15,10 +15,10 @@ import {always, merge} from '../../common/prelude';
 import {cursor} from '../../common/cursor';
 
 
-/*::
+
 import type {Address, DOM} from "reflex"
 import type {Model, Action} from "./controls"
-*/
+
 
 export const CloseWindow/*:Action*/ = {type: "CloseWindow"};
 export const MinimizeWindow/*:Action*/ = {type: "MinimizeWindow"};

--- a/src/browser/shell/controls.js
+++ b/src/browser/shell/controls.js
@@ -20,16 +20,16 @@ import type {Address, DOM} from "reflex"
 import type {Model, Action} from "./controls"
 
 
-export const CloseWindow/*:Action*/ = {type: "CloseWindow"};
-export const MinimizeWindow/*:Action*/ = {type: "MinimizeWindow"};
-export const ToggleWindowFullscreen/*:Action*/ = {type: "ToggleWindowFullscreen"};
+export const CloseWindow:Action = {type: "CloseWindow"};
+export const MinimizeWindow:Action = {type: "MinimizeWindow"};
+export const ToggleWindowFullscreen:Action = {type: "ToggleWindowFullscreen"};
 
-export const FullscreenToggled/*:Action*/ = {type: "FullscreenToggled"};
-export const Ignore/*:Action*/ = {type: "Ignore"};
-export const Over/*:Action*/ = {type: "Over"};
-export const Out/*:Action*/ = {type: "Out"};
-export const Enable/*:Action*/ = {type: "Enable"};
-export const Disable/*:Action*/ = {type: "Disable"};
+export const FullscreenToggled:Action = {type: "FullscreenToggled"};
+export const Ignore:Action = {type: "Ignore"};
+export const Over:Action = {type: "Over"};
+export const Out:Action = {type: "Out"};
+export const Enable:Action = {type: "Enable"};
+export const Disable:Action = {type: "Disable"};
 
 const ignore = action =>
   ( action.type === "Target"
@@ -105,7 +105,7 @@ const updateToggle = cursor({
 });
 
 export const init =
-  (isDisabled/*:boolean*/, isPointerOver/*:boolean*/, isMaximized/*:boolean*/)/*:[Model, Effects<Action>]*/ => {
+  (isDisabled:boolean, isPointerOver:boolean, isMaximized:boolean):[Model, Effects<Action>] => {
   const [isFocused, isActive] = [false, false];
 
   const [close, closeFX] = Button.init
@@ -165,7 +165,7 @@ const updateButtons = (model, action) => {
 }
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model:Model, action:Action):[Model, Effects<Action>] =>
   ( action.type === 'Over'
   ? updateButtons(model, Button.Over)
   : action.type === 'Out'
@@ -262,7 +262,7 @@ const viewToggle = Toggle.view('window-toggle-fullscreen-button', StyleSheet.cre
 
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>):DOM =>
   html.div({
     key: 'window-controls',
     className: 'window-controls',

--- a/src/browser/shell/controls.js
+++ b/src/browser/shell/controls.js
@@ -4,20 +4,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, forward, Effects} from 'reflex';
-import {Style, StyleSheet} from '../../common/style';
-import * as Target from '../../common/target';
-import * as Button from '../../common/button';
-import * as Toggle from '../../common/toggle';
-import * as Unknown from '../../common/unknown';
-import {compose} from '../../lang/functional';
-import {always, merge} from '../../common/prelude';
-import {cursor} from '../../common/cursor';
-
-
-
-import type {Address, DOM} from "reflex"
-import type {Model, Action} from "./controls"
+import type { Address, DOM } from 'reflex'
+import { html, forward, Effects } from 'reflex'
+import { Style, StyleSheet } from '../../common/style'
+import * as Target from '../../common/target'
+import * as Button from '../../common/button'
+import * as Toggle from '../../common/toggle'
+import * as Unknown from '../../common/unknown'
+import { compose } from '../../lang/functional'
+import { always, merge } from '../../common/prelude'
+import { cursor } from '../../common/cursor'
+import type { Model, Action } from './controls'
 
 
 export const CloseWindow:Action = {type: "CloseWindow"};

--- a/src/common/Animation.js
+++ b/src/common/Animation.js
@@ -22,11 +22,11 @@ class Transition <model> {
   to: model;
   
   constructor(
-    from/*:model*/
-  , to/*:model*/
-  , now/*:Time*/
-  , elapsed/*:Time*/
-  , duration/*:Time*/
+    from:model
+  , to:model
+  , now:Time
+  , elapsed:Time
+  , duration:Time
   ) {
     this.from = from
     this.to = to
@@ -42,8 +42,8 @@ export class Model <model> {
   transition: ?Transition<model>;
   
   constructor(
-    state/*:model*/
-  , transition/*:?Transition<model>*/
+    state:model
+  , transition:?Transition<model>
   ) {
     this.state = state
     this.transition = transition
@@ -51,10 +51,10 @@ export class Model <model> {
 }
 
 export const transition = /*::<action, model>*/
-  ( model/*:Model<model>*/
-  , to/*:model*/
-  , duration/*:Time*/
-  )/*:[Model<model>, Effects<Action>]*/ =>
+  ( model:Model<model>
+  , to:model
+  , duration:Time
+  ):[Model<model>, Effects<Action>] =>
   ( model.transition == null
   ? startTransition
     ( model.state
@@ -73,7 +73,7 @@ export const transition = /*::<action, model>*/
   )
 
 const nofx = /*::<model, action>*/
-  (model/*:model*/)/*:[model, Effects<action>]*/ =>
+  (model:model):[model, Effects<action>] =>
   [model, Effects.none]
 
 const Tick =
@@ -92,11 +92,11 @@ const End =
 
 
 const startTransition = /*::<model>*/
-  ( from/*:model*/
-  , to/*:model*/
-  , elapsed/*:Time*/
-  , duration/*:Time*/
-  )/*:[Model<model>, Effects<Action>]*/ =>
+  ( from:model
+  , to:model
+  , elapsed:Time
+  , duration:Time
+  ):[Model<model>, Effects<Action>] =>
   [ new Model
     ( from
     , new Transition
@@ -112,8 +112,8 @@ const startTransition = /*::<model>*/
   ]
 
 const endTransition = /*::<model>*/
-  ( model/*:Model<model>*/
-  )/*:[Model<model>, Effects<Action>]*/ =>
+  ( model:Model<model>
+  ):[Model<model>, Effects<Action>] =>
   [ new Model
     ( model.state
     , null
@@ -123,11 +123,11 @@ const endTransition = /*::<model>*/
   ]
 
 const tickTransitionWith = /*::<model>*/
-  ( easing/*:Easing*/
-  , interpolation/*:Interpolation<model>*/
-  , model/*:Model<model>*/
+  ( easing:Easing
+  , interpolation:Interpolation<model>
+  , model:Model<model>
   , now/*Time*/
-  )/*:[Model<model>, Effects<Action>]*/ =>
+  ):[Model<model>, Effects<Action>] =>
   ( model.transition == null
   ? nofx(model)
   : interpolateTransitionWith
@@ -143,12 +143,12 @@ const tickTransitionWith = /*::<model>*/
   )
 
 const interpolateTransitionWith = /*::<model>*/
-  ( easing/*:Easing*/
-  , interpolation/*:Interpolation<model>*/
-  , transition/*:Transition<model>*/
-  , elapsed/*:Time*/
-  , now/*:Time*/
-  )/*:[Model<model>, Effects<Action>]*/ =>
+  ( easing:Easing
+  , interpolation:Interpolation<model>
+  , transition:Transition<model>
+  , elapsed:Time
+  , now:Time
+  ):[Model<model>, Effects<Action>] =>
   ( elapsed >= transition.duration
   ? [ new Model(transition.to, null)
     , Effects.receive(End(now))
@@ -176,11 +176,11 @@ const interpolateTransitionWith = /*::<model>*/
   )
 
 export const updateWith = /*::<model>*/
-  ( easing/*:Easing*/
-  , interpolation/*:Interpolation<model>*/
-  , model/*:Model<model>*/
-  , action/*:Action*/
-  )/*:[Model<model>, Effects<Action>]*/ => {
+  ( easing:Easing
+  , interpolation:Interpolation<model>
+  , model:Model<model>
+  , action:Action
+  ):[Model<model>, Effects<Action>] => {
     switch (action.type) {
       case "Tick":
         return tickTransitionWith(easing, interpolation, model, action.time);
@@ -192,5 +192,5 @@ export const updateWith = /*::<model>*/
   }
 
 export const init = /*::<model>*/
-  ( state/*:model*/ )/*:[Model<model>, Effects<Action>]*/ =>
+  ( state:model ):[Model<model>, Effects<Action>] =>
   nofx(new Model(state, null))

--- a/src/common/Animation.js
+++ b/src/common/Animation.js
@@ -4,23 +4,23 @@ import * as Unknown from "./unknown"
 import {Task, Effects} from "reflex"
 import {ease} from "eased"
 
-/*::
+
 export type Time = number
 export type Action =
   | { type: "Tick", time: Time }
   | { type: "End", time: Time }
 
 import type {Interpolation, Easing} from "eased"
-*/
 
-class Transition /*::<model>*/ {
-  /*::
+
+class Transition <model> {
+  
   duration: Time;
   now: Time;
   elapsed: Time;
   from: model;
   to: model;
-  */
+  
   constructor(
     from/*:model*/
   , to/*:model*/
@@ -36,11 +36,11 @@ class Transition /*::<model>*/ {
   }
 }
 
-export class Model /*::<model>*/ {
-  /*::
+export class Model <model> {
+  
   state: model;
   transition: ?Transition<model>;
-  */
+  
   constructor(
     state/*:model*/
   , transition/*:?Transition<model>*/

--- a/src/common/Animation.js
+++ b/src/common/Animation.js
@@ -1,16 +1,15 @@
 /* @flow */
 
-import * as Unknown from "./unknown"
-import {Task, Effects} from "reflex"
-import {ease} from "eased"
+import * as Unknown from './unknown'
+import { Task, Effects } from 'reflex'
+import type { Interpolation, Easing } from 'eased'
+import { ease } from 'eased'
 
 
 export type Time = number
 export type Action =
   | { type: "Tick", time: Time }
   | { type: "End", time: Time }
-
-import type {Interpolation, Easing} from "eased"
 
 
 class Transition <model> {

--- a/src/common/Deck.js
+++ b/src/common/Deck.js
@@ -424,7 +424,7 @@ const beneficiaryOf =
 
 const Tag = {
   modify: /*::<action, flags>*/
-    ( id:ID )/*:(action:action) => Action<action, flags>*/ =>
+    ( id:ID ):(action:action) => Action<action, flags> =>
     ( action ) =>
     ( { type: "Modify"
       , id
@@ -434,7 +434,7 @@ const Tag = {
 }
 
 export const renderCards = /*::<action, model, flags>*/
-  ( renderCard/*:(model:model, address:Address<action>) => DOM*/
+  ( renderCard:(model:model, address:Address<action>) => DOM
   , model:Model<model>
   , address:Address<Action<action, flags>>
   ):Array<DOM> =>

--- a/src/common/Deck.js
+++ b/src/common/Deck.js
@@ -62,10 +62,10 @@ export class Model <model> {
   selected: Maybe<ID>;
   
   constructor(
-    nextID/*:Integer*/
-  , index/*:Array<ID>*/
-  , cards/*:Dictionary<ID, model>*/
-  , selected/*:Maybe<ID>*/
+    nextID:Integer
+  , index:Array<ID>
+  , cards:Dictionary<ID, model>
+  , selected:Maybe<ID>
   ) {
     this.nextID = nextID
     this.index = index
@@ -76,20 +76,20 @@ export class Model <model> {
 
 
 export const init = /*::<action, model, flags>*/
-  ( nextID/*:Integer*/=0
-  , index/*:Array<ID>*/=[]
-  , cards/*:Dictionary<ID, model>*/={}
-  , selected/*:Maybe<ID>*/=null
-  )/*:Transaction<Action<action, flags>, Model<model>>*/ =>
+  ( nextID:Integer=0
+  , index:Array<ID>=[]
+  , cards:Dictionary<ID, model>={}
+  , selected:Maybe<ID>=null
+  ):Transaction<Action<action, flags>, Model<model>> =>
   [ new Model(nextID, index, cards, selected)
   , Effects.none
   ];
 
 export const update = /*::<action, model, flags>*/
-  ( card/*:Card<action, model, flags>*/
-  , model/*:Model<model>*/
-  , action/*:Action<action, flags>*/
-  )/*:Transaction<Action<action, flags>, Model<model>>*/ => {
+  ( card:Card<action, model, flags>
+  , model:Model<model>
+  , action:Action<action, flags>
+  ):Transaction<Action<action, flags>, Model<model>> => {
     switch (action.type) {
       case "NoOp":
         return nofx(model);
@@ -113,18 +113,18 @@ export const update = /*::<action, model, flags>*/
   }
 
 const nofx = /*::<model, action>*/
-  ( model/*:model*/ )/*:[model, Effects<action>]*/ =>
+  ( model:model ):[model, Effects<action>] =>
   [ model
   , Effects.none
   ]
 
 
 const updateByID = /*::<model, action, flags>*/
-  ( api/*:Card<action, model, flags>*/
-  , model/*:Model<model>*/
-  , id/*:ID*/
-  , action/*:action*/
-  )/*:Transaction<Action<action, flags>, Model<model>>*/ => {
+  ( api:Card<action, model, flags>
+  , model:Model<model>
+  , id:ID
+  , action:action
+  ):Transaction<Action<action, flags>, Model<model>> => {
     if (id in model.cards) {
       const [card, $card] = api.update(model.cards[id], action);
       const cards = merge(model.cards, {[id]: card});
@@ -144,10 +144,10 @@ const updateByID = /*::<model, action, flags>*/
   }
 
 export const open = /*::<action, model, flags>*/
-  ( api/*:Card<action, model, flags>*/
-  , model/*:Model<model>*/
-  , flags/*:flags*/
-  )/*:Transaction<Action<action, flags>, Model<model>>*/ => {
+  ( api:Card<action, model, flags>
+  , model:Model<model>
+  , flags:flags
+  ):Transaction<Action<action, flags>, Model<model>> => {
     const id = `${model.nextID}`;
     const [card, $card] = api.init(flags);
 
@@ -184,10 +184,10 @@ export const open = /*::<action, model, flags>*/
   }
 
 const closeByID = /*::<action, model, flags>*/
-  ( api/*:Card<action, model, flags>*/
-  , model/*:Model<model>*/
-  , id/*:ID*/
-  )/*:Transaction<Action<action, flags>, Model<model>>*/ => {
+  ( api:Card<action, model, flags>
+  , model:Model<model>
+  , id:ID
+  ):Transaction<Action<action, flags>, Model<model>> => {
     const [available, $available] =
       ( model.selected === id
       ? selectBeneficiaryByID(api, model, id)
@@ -222,10 +222,10 @@ const closeByID = /*::<action, model, flags>*/
   }
 
 export const removeByID = /*::<action, model, flags>*/
-  ( card/*:Card<action, model, flags>*/
-  , model/*:Model<model>*/
-  , id/*:ID*/
-  )/*:Transaction<Action<action, flags>, Model<model>>*/ => {
+  ( card:Card<action, model, flags>
+  , model:Model<model>
+  , id:ID
+  ):Transaction<Action<action, flags>, Model<model>> => {
     const [available, $available] =
       ( model.selected === id
       ? selectBeneficiaryByID(card, model, id)
@@ -254,15 +254,15 @@ export const removeByID = /*::<action, model, flags>*/
   }
 
 const cardNotFound = /*::<model, action>*/
-  ( model/*:model*/, id/*:ID*/)/*:[model, Effects<action>]*/ =>
+  ( model:model, id:ID):[model, Effects<action>] =>
   nofx(model)
 
 export const selectByID = /*::<action, model, flags>*/
-  ( api/*:Card<action, model, flags>*/
-  , model/*:Model<model>*/
-  , id/*:ID*/
-  , isSelectionChange/*:boolean*/=true
-  )/*:Transaction<Action<action, flags>, Model<model>>*/ => {
+  ( api:Card<action, model, flags>
+  , model:Model<model>
+  , id:ID
+  , isSelectionChange:boolean=true
+  ):Transaction<Action<action, flags>, Model<model>> => {
     if (id === model.selected) {
       return nofx(model)
     }
@@ -300,10 +300,10 @@ export const selectByID = /*::<action, model, flags>*/
   }
 
 export const deselectByID = /*::<action, model, flags>*/
-  ( api/*:Card<action, model, flags>*/
-  , model/*:Model<model>*/
-  , id/*:ID*/
-  )/*:Transaction<Action<action, flags>, Model<model>>*/ => {
+  ( api:Card<action, model, flags>
+  , model:Model<model>
+  , id:ID
+  ):Transaction<Action<action, flags>, Model<model>> => {
     if (model.selected !== id) {
       return nofx(model)
     }
@@ -332,10 +332,10 @@ export const deselectByID = /*::<action, model, flags>*/
   }
 
 const selectBeneficiaryByID = /*::<action, model, flags>*/
-  ( api/*:Card<action, model, flags>*/
-  , model/*:Model<model>*/
-  , id/*:ID*/
-  )/*:Transaction<Action<action, flags>, Model<model>>*/ => {
+  ( api:Card<action, model, flags>
+  , model:Model<model>
+  , id:ID
+  ):Transaction<Action<action, flags>, Model<model>> => {
     const selected = beneficiaryOf(id, model.index);
     if (selected != null) {
       return selectByID(api, model, selected, false)
@@ -346,10 +346,10 @@ const selectBeneficiaryByID = /*::<action, model, flags>*/
   }
 
 export const selectByOffset = /*::<action, model, flags>*/
-  ( api/*:Card<action, model, flags>*/
-  , model/*:Model<model>*/
-  , offset/*:Integer*/
-  )/*:Transaction<Action<action, flags>, Model<model>>*/ =>
+  ( api:Card<action, model, flags>
+  , model:Model<model>
+  , offset:Integer
+  ):Transaction<Action<action, flags>, Model<model>> =>
   ( model.index.length === 0
   ? nofx(model)
   : model.selected == null
@@ -366,15 +366,15 @@ export const selectByOffset = /*::<action, model, flags>*/
   );
 
 export const selectNext =/*::<action, model, flags>*/
-  ( api/*:Card<action, model, flags>*/
-  , model/*:Model<model>*/
-  )/*:Transaction<Action<action, flags>, Model<model>>*/ =>
+  ( api:Card<action, model, flags>
+  , model:Model<model>
+  ):Transaction<Action<action, flags>, Model<model>> =>
   selectByOffset(api, model, 1)
 
 export const selectPrevious = /*::<action, model, flags>*/
-  ( api/*:Card<action, model, flags>*/
-  , model/*:Model<model>*/
-  )/*:Transaction<Action<action, flags>, Model<model>>*/ =>
+  ( api:Card<action, model, flags>
+  , model:Model<model>
+  ):Transaction<Action<action, flags>, Model<model>> =>
   selectByOffset(api, model, -1)
 
 const relativeOf =
@@ -424,7 +424,7 @@ const beneficiaryOf =
 
 const Tag = {
   modify: /*::<action, flags>*/
-    ( id/*:ID*/ )/*:(action:action) => Action<action, flags>*/ =>
+    ( id:ID )/*:(action:action) => Action<action, flags>*/ =>
     ( action ) =>
     ( { type: "Modify"
       , id
@@ -435,9 +435,9 @@ const Tag = {
 
 export const renderCards = /*::<action, model, flags>*/
   ( renderCard/*:(model:model, address:Address<action>) => DOM*/
-  , model/*:Model<model>*/
-  , address/*:Address<Action<action, flags>>*/
-  )/*:Array<DOM>*/ =>
+  , model:Model<model>
+  , address:Address<Action<action, flags>>
+  ):Array<DOM> =>
   model
   .index
   .map
@@ -451,7 +451,7 @@ export const renderCards = /*::<action, model, flags>*/
   )
 
 const warn = /*::<message>*/
-  (message/*:message*/)/*:Task<Never, any>*/ =>
+  (message:message):Task<Never, any> =>
   new Task
   ((succeed, fail) => {
     console.warn(message)

--- a/src/common/Deck.js
+++ b/src/common/Deck.js
@@ -9,7 +9,7 @@ import {merge} from "../common/prelude"
 import * as Unknown from "../common/unknown"
 import {indexOfOffset} from "../common/selector"
 
-/*::
+
 import type {Address, DOM, Never} from "reflex"
 export type Integer = number
 export type ID = string
@@ -52,15 +52,15 @@ export type Card <action, model, flags> =
   , select: (model:model) => [model, Effects<action>]
   , deselect: (model:model) => [model, Effects<action>]
   }
-*/
 
-export class Model /*::<model>*/ {
-  /*::
+
+export class Model <model> {
+  
   nextID: Integer;
   index: Array<ID>;
   cards: Dictionary<ID, model>;
   selected: Maybe<ID>;
-  */
+  
   constructor(
     nextID/*:Integer*/
   , index/*:Array<ID>*/

--- a/src/common/Deck.js
+++ b/src/common/Deck.js
@@ -4,13 +4,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Effects, Task, html, forward, thunk} from "reflex"
-import {merge} from "../common/prelude"
-import * as Unknown from "../common/unknown"
-import {indexOfOffset} from "../common/selector"
-
-
-import type {Address, DOM, Never} from "reflex"
+import type { Address, DOM, Never } from 'reflex'
+import { Effects, Task, forward, thunk } from 'reflex'
+import { merge } from '../common/prelude'
+import * as Unknown from '../common/unknown'
+import { indexOfOffset } from '../common/selector'
 export type Integer = number
 export type ID = string
 

--- a/src/common/button.js
+++ b/src/common/button.js
@@ -106,11 +106,11 @@ export const update =
   );
 
 
-export const view =
-  (key:string, styleSheet:StyleSheet):(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM =>
-  ( model:Model
-  , address:Address<Action>
-  , contextStyle/*?:ContextStyle*/
+export function view(key:string,
+                     styleSheet:StyleSheet):(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM {
+  return ( model
+         , address
+         , contextStyle
   ):DOM =>
   html.button({
     key: key,
@@ -147,3 +147,4 @@ export const view =
     onClick: forward(address, always(Press)),
     onMouseUp: forward(address, always(Up))
   }, [model.text || '']);
+}

--- a/src/common/button.js
+++ b/src/common/button.js
@@ -107,7 +107,7 @@ export const update =
 
 
 export const view =
-  (key:string, styleSheet:StyleSheet)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>
+  (key:string, styleSheet:StyleSheet):(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM =>
   ( model:Model
   , address:Address<Action>
   , contextStyle/*?:ContextStyle*/

--- a/src/common/button.js
+++ b/src/common/button.js
@@ -14,10 +14,10 @@ import * as Control from "../common/control"
 import {Style} from "../common/style"
 import {html, Effects, forward} from "reflex"
 
-/*::
+
 import type {Model, Action, StyleSheet, ContextStyle} from "./button"
 import type {Address, DOM} from "reflex"
-*/
+
 
 const TargetAction =
   action =>

--- a/src/common/button.js
+++ b/src/common/button.js
@@ -73,12 +73,12 @@ const updateControl = cursor
   );
 
 export const init =
-  ( isDisabled/*:boolean*/
-  , isFocused/*:boolean*/
-  , isActive/*:boolean*/
-  , isPointerOver/*:boolean*/
-  , text/*:string*/=''
-  )/*:[Model, Effects<Action>]*/ =>
+  ( isDisabled:boolean
+  , isFocused:boolean
+  , isActive:boolean
+  , isPointerOver:boolean
+  , text:string=''
+  ):[Model, Effects<Action>] =>
   [ ({isDisabled: false
     , isFocused: false
     , isActive: false
@@ -89,7 +89,7 @@ export const init =
   ]
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model:Model, action:Action):[Model, Effects<Action>] =>
   ( action.type === "Down"
   ? [merge(model, {isActive: true}), Effects.none]
   : action.type === "Up"
@@ -107,11 +107,11 @@ export const update =
 
 
 export const view =
-  (key/*:string*/, styleSheet/*:StyleSheet*/)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>
-  ( model/*:Model*/
-  , address/*:Address<Action>*/
+  (key:string, styleSheet:StyleSheet)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>
+  ( model:Model
+  , address:Address<Action>
   , contextStyle/*?:ContextStyle*/
-  )/*:DOM*/ =>
+  ):DOM =>
   html.button({
     key: key,
     className: key,

--- a/src/common/button.js
+++ b/src/common/button.js
@@ -5,18 +5,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {merge, always, tag} from "../common/prelude"
-import {cursor} from "../common/cursor"
-import * as Unknown from "../common/unknown"
-import * as Target from "../common/target"
-import * as Focusable from "../common/focusable"
-import * as Control from "../common/control"
-import {Style} from "../common/style"
-import {html, Effects, forward} from "reflex"
-
-
-import type {Model, Action, StyleSheet, ContextStyle} from "./button"
-import type {Address, DOM} from "reflex"
+import { merge, always } from '../common/prelude'
+import { cursor } from '../common/cursor'
+import * as Unknown from '../common/unknown'
+import * as Target from '../common/target'
+import * as Focusable from '../common/focusable'
+import * as Control from '../common/control'
+import { Style } from '../common/style'
+import type { Address, DOM } from 'reflex'
+import { html, Effects, forward } from 'reflex'
+import type { Model, Action, StyleSheet, ContextStyle } from './button'
 
 
 const TargetAction =

--- a/src/common/control.js
+++ b/src/common/control.js
@@ -17,28 +17,28 @@ import {html, Effects, forward} from "reflex"
 import type {Model, Action} from "./control"
 
 
-export const Disable/*:Action*/ =
+export const Disable:Action =
   { type: "Disable"
   };
 
-export const Enable/*:Action*/ =
+export const Enable:Action =
   { type: "Enable"
   };
 
 const enable = /*::<model:Model>*/
-  (model/*:model*/)/*:[model, Effects<Action>]*/ =>
+  (model:model):[model, Effects<Action>] =>
   [ merge(model, {isDisabled: false})
   , Effects.none
   ];
 
 const disable = /*::<model:Model>*/
-  (model/*:model*/)/*:[model, Effects<Action>]*/ =>
+  (model:model):[model, Effects<Action>] =>
   [ merge(model, {isDisabled: true})
   , Effects.none
   ];
 
 export const update = /*::<model:Model>*/
-  (model/*:model*/, action/*:Action*/)/*:[model, Effects<Action>]*/ =>
+  (model:model, action:Action):[model, Effects<Action>] =>
   ( action.type === "Enable"
   ? enable(model)
   : action.type === "Disable"

--- a/src/common/control.js
+++ b/src/common/control.js
@@ -13,9 +13,9 @@ import * as Focusable from "../common/focusable"
 import {Style} from "../common/style"
 import {html, Effects, forward} from "reflex"
 
-/*::
+
 import type {Model, Action} from "./control"
-*/
+
 
 export const Disable/*:Action*/ =
   { type: "Disable"

--- a/src/common/control.js
+++ b/src/common/control.js
@@ -5,16 +5,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {merge, always} from "../common/prelude"
-import {cursor} from "../common/cursor"
-import * as Unknown from "../common/unknown"
-import * as Target from "../common/target"
-import * as Focusable from "../common/focusable"
-import {Style} from "../common/style"
-import {html, Effects, forward} from "reflex"
-
-
-import type {Model, Action} from "./control"
+import { merge } from '../common/prelude'
+import * as Unknown from '../common/unknown'
+import { Effects } from 'reflex'
+import type { Model, Action } from './control'
 
 
 export const Disable:Action =

--- a/src/common/cursor.js
+++ b/src/common/cursor.js
@@ -7,10 +7,10 @@
 
 import {Effects} from "reflex";
 
-/*::
+
 import type {Cursor} from "./cursor"
 export type {Cursor}
-*/
+
 
 export const cursor = /*::<from, to, in, out>*/
   (config/*:Cursor*/)/*:(model:from, action:in) => [from, Effects<out>]*/ => {

--- a/src/common/cursor.js
+++ b/src/common/cursor.js
@@ -8,28 +8,27 @@
 import {Effects} from "reflex";
 
 
-import type {Cursor} from "./cursor"
+import type {Cursor} from './cursor'
 export type {Cursor}
 
 
-export const cursor = /*::<from, to, in, out>*/
-  (config/*:Cursor*/)/*:(model:from, action:in) => [from, Effects<out>]*/ => {
+export function cursor<from, to, input, output>(config:Cursor):(model:from, action:input) => [from, Effects<output>] {
   const get = config.get;
   const set = config.set;
   const update = config.update;
   const tag = config.tag;
 
-  return (model, action) => {
+  return (model:from, action:input) => {
     const previous
-      = get == null
-      ? model
-      : get(model, action);
+        = get == null
+        ? model
+        : get(model, action);
 
     const [next, fx] = update(previous, action);
     const state
-      = set == null
-      ? next
-      : set(model, next);
+        = set == null
+        ? next
+        : set(model, next);
 
     return [state, tag == null ? fx : fx.map(tag)]
   }

--- a/src/common/cursor.js
+++ b/src/common/cursor.js
@@ -5,10 +5,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {Effects} from "reflex";
-
-
-import type {Cursor} from './cursor'
+import { Effects } from 'reflex'
+import type { Cursor } from './cursor'
 export type {Cursor}
 
 

--- a/src/common/devtools.js
+++ b/src/common/devtools.js
@@ -5,11 +5,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-/*::
+
 import type {Address, DOM} from "reflex"
 import type {Model, Action} from './devtools'
 import type {Result} from "./result"
-*/
+
 
 import * as Settings from '../common/settings';
 import * as Runtime from '../common/runtime';

--- a/src/common/devtools.js
+++ b/src/common/devtools.js
@@ -148,7 +148,7 @@ const report =
 
 
 export const init =
-  ({isActive}/*:{isActive:boolean}*/):[Model, Effects<Action>] => {
+  ({isActive}:{isActive:boolean}):[Model, Effects<Action>] => {
   const [settings, fx] =
     Settings.init(Object.keys(descriptions));
 

--- a/src/common/devtools.js
+++ b/src/common/devtools.js
@@ -52,11 +52,11 @@ const readValue = (key, value) =>
   : value
   );
 
-export const Toggle/*:Action*/ =
+export const Toggle:Action =
   { type: "Toggle"
   };
 
-export const Restart/*:Action*/ =
+export const Restart:Action =
   { type: "Restart"
   };
 
@@ -66,11 +66,11 @@ const Report = result =>
     }
   );
 
-export const CleanRestart/*:Action*/ =
+export const CleanRestart:Action =
   { type: "CleanRestart"
   };
 
-export const CleanReload/*:Action*/ =
+export const CleanReload:Action =
   { type: "CleanReload"
   };
 
@@ -136,7 +136,7 @@ const changeSetting = (model, {name, value}) =>
 
 
 const report =
-  (model/*:Model*/, result/*:Result<any, any>*/)/*:[Model, Effects<Action>]*/ =>
+  (model:Model, result:Result<any, any>):[Model, Effects<Action>] =>
   [ model
   , ( result.isOk
     ? Effects.none
@@ -148,7 +148,7 @@ const report =
 
 
 export const init =
-  ({isActive}/*:{isActive:boolean}*/)/*:[Model, Effects<Action>]*/ => {
+  ({isActive}/*:{isActive:boolean}*/):[Model, Effects<Action>] => {
   const [settings, fx] =
     Settings.init(Object.keys(descriptions));
 
@@ -165,7 +165,7 @@ export const init =
 
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model:Model, action:Action):[Model, Effects<Action>] =>
   ( action.type === 'Toggle'
   ? toggle(model)
 
@@ -258,7 +258,7 @@ const viewSettings = (settings, address) =>
            .map(key => thunk(key, viewSetting, key, settings[key], address)))
 
 export const view =
-  (model/*:Model*/, address/*:Address<Action>*/)/*:DOM*/ =>
+  (model:Model, address:Address<Action>):DOM =>
   html.div({
     className: 'devtools toolbox',
     key: 'devtools-toolbox',

--- a/src/common/devtools.js
+++ b/src/common/devtools.js
@@ -6,18 +6,16 @@
 
 
 
-import type {Address, DOM} from "reflex"
-import type {Model, Action} from './devtools'
-import type {Result} from "./result"
-
-
-import * as Settings from '../common/settings';
-import * as Runtime from '../common/runtime';
-import * as Unknown from '../common/unknown';
-import {merge, always} from '../common/prelude';
-import {cursor} from '../common/cursor';
-import {Effects, html, thunk, forward} from 'reflex';
-import {Style, StyleSheet} from '../common/style';
+import type { Address, DOM } from 'reflex'
+import { Effects, html, thunk, forward } from 'reflex'
+import type { Model, Action } from './devtools'
+import type { Result } from './result'
+import * as Settings from '../common/settings'
+import * as Runtime from '../common/runtime'
+import * as Unknown from '../common/unknown'
+import { merge, always } from '../common/prelude'
+import { cursor } from '../common/cursor'
+import { Style, StyleSheet } from '../common/style'
 
 
 const descriptions =

--- a/src/common/editable.js
+++ b/src/common/editable.js
@@ -16,32 +16,32 @@ import type {Model, Action, Selection} from "./editable"
 
 // Actions
 
-export const Clear/*:Action*/ = {type: "Clear"};
+export const Clear:Action = {type: "Clear"};
 
 export const Select =
-  (range/*:Selection*/)/*:Action*/ =>
+  (range:Selection):Action =>
   ({type: "Select", range});
 
 export const Change =
-  (value/*:string*/, selection/*:Selection*/)/*:Action*/ =>
+  (value:string, selection:Selection):Action =>
   ({type: "Change", value, selection});
 
 
 
 const select = /*::<model:Model>*/
-  (model/*:model*/, selection/*:Selection*/)/*:model*/ =>
+  (model:model, selection:Selection):model =>
   merge(model, {selection});
 
 const change = /*::<model:Model>*/
-  (model/*:model*/, value/*:string*/, selection/*:Selection*/)/*:model*/ =>
+  (model:model, value:string, selection:Selection):model =>
   merge(model, {selection, value});
 
 const clear = /*::<model:Model>*/
-  (model/*:model*/)/*:model*/ =>
+  (model:model):model =>
   merge(model, {value: "", selection: null});
 
 export const init =
-  (value/*:string*/, selection/*:?Selection*/=null)/*:[Model, Effects<Action>]*/ =>
+  (value:string, selection:?Selection=null):[Model, Effects<Action>] =>
   [ { value
     , selection
     }
@@ -49,7 +49,7 @@ export const init =
   ]
 
 export const update = /*::<model:Model>*/
-  (model/*:model*/, action/*:Action*/)/*:[model, Effects<Action>]*/ =>
+  (model:model, action:Action):[model, Effects<Action>] =>
   ( action.type === "Clear"
   ? [clear(model), Effects.none]
   : action.type === "Select"

--- a/src/common/editable.js
+++ b/src/common/editable.js
@@ -9,10 +9,10 @@ import {merge} from "../common/prelude";
 import * as Unknown from "../common/unknown";
 import {Effects} from "reflex";
 
-/*::
+
 import type {Address, DOM} from "reflex";
 import type {Model, Action, Selection} from "./editable"
-*/
+
 
 // Actions
 

--- a/src/common/editable.js
+++ b/src/common/editable.js
@@ -5,13 +5,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {merge} from "../common/prelude";
-import * as Unknown from "../common/unknown";
-import {Effects} from "reflex";
-
-
-import type {Address, DOM} from "reflex";
-import type {Model, Action, Selection} from "./editable"
+import { merge } from '../common/prelude'
+import * as Unknown from '../common/unknown'
+import type { Address, DOM } from 'reflex'
+import { Effects } from 'reflex'
+import type { Model, Action, Selection } from './editable'
 
 
 // Actions

--- a/src/common/favicon.js
+++ b/src/common/favicon.js
@@ -13,7 +13,7 @@ import type {Icon, URI} from "./favicon"
 const constructFaviconURI = (href, size) => `${href}#-moz-resolution=${size},${size}`;
 
 export const getFallback =
-  (pageURI/*:URI*/)/*:URI*/ =>
+  (pageURI:URI):URI =>
   constructFaviconURI(getOrigin(pageURI) + '/favicon.ico', FAVICON_SIZE);
 
 // Ideal size for a favicon.
@@ -28,7 +28,7 @@ const FAVICON_SIZE = 16 * window.devicePixelRatio;
  * }
  */
 export const getBestIcon =
-  (icons/*:Array<Icon>*/)/*:{ bestIcon: ?Icon, faviconURI: ?URI}*/ => {
+  (icons:Array<Icon>)/*:{ bestIcon: ?Icon, faviconURI: ?URI}*/ => {
 
   const allSizes = new Map(); // store icons per size
   const others = new Set();   // store icons without sizes or non-shortcut icons

--- a/src/common/favicon.js
+++ b/src/common/favicon.js
@@ -28,7 +28,7 @@ const FAVICON_SIZE = 16 * window.devicePixelRatio;
  * }
  */
 export const getBestIcon =
-  (icons:Array<Icon>)/*:{ bestIcon: ?Icon, faviconURI: ?URI}*/ => {
+  (icons:Array<Icon>):{ bestIcon: ?Icon, faviconURI: ?URI} => {
 
   const allSizes = new Map(); // store icons per size
   const others = new Set();   // store icons without sizes or non-shortcut icons

--- a/src/common/favicon.js
+++ b/src/common/favicon.js
@@ -6,9 +6,9 @@
 
 import {getOrigin} from '../common/url-helper';
 
-/*::
+
 import type {Icon, URI} from "./favicon"
-*/
+
 
 const constructFaviconURI = (href, size) => `${href}#-moz-resolution=${size},${size}`;
 

--- a/src/common/favicon.js
+++ b/src/common/favicon.js
@@ -4,10 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {getOrigin} from '../common/url-helper';
-
-
-import type {Icon, URI} from "./favicon"
+import { getOrigin } from '../common/url-helper'
+import type { Icon, URI } from './favicon'
 
 
 const constructFaviconURI = (href, size) => `${href}#-moz-resolution=${size},${size}`;

--- a/src/common/focusable.js
+++ b/src/common/focusable.js
@@ -9,9 +9,9 @@ import {merge} from "../common/prelude";
 import * as Unknown from "../common/unknown";
 import {Effects} from "reflex";
 
-/*::
+
 import type {Model, Action} from "./focusable"
-*/
+
 
 export const Focus/*:Action*/ =
   { type:"Focus"

--- a/src/common/focusable.js
+++ b/src/common/focusable.js
@@ -13,17 +13,17 @@ import {Effects} from "reflex";
 import type {Model, Action} from "./focusable"
 
 
-export const Focus/*:Action*/ =
+export const Focus:Action =
   { type:"Focus"
   };
 
-export const Blur/*:Action*/ =
+export const Blur:Action =
   { type: "Blur"
   };
 
 
 export const update = /*::<model:Model>*/
-  ( model/*:model*/, action/*:Action*/)/*:[model, Effects<Action>]*/ =>
+  ( model:model, action:Action):[model, Effects<Action>] =>
   ( action.type === "Focus"
   ? [ merge
       ( model

--- a/src/common/focusable.js
+++ b/src/common/focusable.js
@@ -5,12 +5,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {merge} from "../common/prelude";
-import * as Unknown from "../common/unknown";
-import {Effects} from "reflex";
-
-
-import type {Model, Action} from "./focusable"
+import { merge } from '../common/prelude'
+import * as Unknown from '../common/unknown'
+import { Effects } from 'reflex'
+import type { Model, Action } from './focusable'
 
 
 export const Focus:Action =

--- a/src/common/history.js
+++ b/src/common/history.js
@@ -11,7 +11,7 @@ import type {Integer} from "../common/prelude"
 
 
 export const readTitle = /*::<value, model:{title?:string}>*/
-  (model:model, fallback:value)/*: string | value*/ =>
+  (model:model, fallback:value): string | value =>
   model.title ? model.title : fallback;
 
 export const query = /*::<action>*/

--- a/src/common/history.js
+++ b/src/common/history.js
@@ -6,9 +6,9 @@
 
 import {Task, Effects} from "reflex"
 
-/*::
+
 import type {Integer} from "../common/prelude"
-*/
+
 
 export const readTitle = /*::<value, model:{title?:string}>*/
   (model/*:model*/, fallback/*:value*/)/*: string | value*/ =>

--- a/src/common/history.js
+++ b/src/common/history.js
@@ -11,11 +11,11 @@ import type {Integer} from "../common/prelude"
 
 
 export const readTitle = /*::<value, model:{title?:string}>*/
-  (model/*:model*/, fallback/*:value*/)/*: string | value*/ =>
+  (model:model, fallback:value)/*: string | value*/ =>
   model.title ? model.title : fallback;
 
 export const query = /*::<action>*/
-  (input/*:string*/, limit/*:Integer*/)/*:Effects<action>*/ =>
+  (input:string, limit:Integer):Effects<action> =>
   Effects.perform(new Task(deliver => {
 
   }))

--- a/src/common/history.js
+++ b/src/common/history.js
@@ -4,10 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Task, Effects} from "reflex"
-
-
-import type {Integer} from "../common/prelude"
+import { Task, Effects } from 'reflex'
+import type { Integer } from '../common/prelude'
 
 
 export const readTitle = /*::<value, model:{title?:string}>*/

--- a/src/common/image.js
+++ b/src/common/image.js
@@ -7,10 +7,10 @@
 import {html, thunk, forward, Effects} from 'reflex';
 import * as Style from '../common/style';
 
-/*::
+
 import type {Address, DOM} from "reflex"
 import type {Action, Model, StyleSheet, ContextStyle} from "./image"
-*/
+
 
 const baseStyleSheet/*:StyleSheet*/ = Style.createSheet
   ( { base:

--- a/src/common/image.js
+++ b/src/common/image.js
@@ -12,7 +12,7 @@ import type {Address, DOM} from "reflex"
 import type {Action, Model, StyleSheet, ContextStyle} from "./image"
 
 
-const baseStyleSheet/*:StyleSheet*/ = Style.createSheet
+const baseStyleSheet:StyleSheet = Style.createSheet
   ( { base:
       { backgroundSize: 'cover'
       , backgroundPosition: 'center center'
@@ -23,11 +23,11 @@ const baseStyleSheet/*:StyleSheet*/ = Style.createSheet
   );
 
 export const view =
-  (key/*:string*/, styleSheet/*:StyleSheet*/)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>
-  ( model/*:Model*/
-  , address/*:Address<Action>*/
+  (key:string, styleSheet:StyleSheet)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>
+  ( model:Model
+  , address:Address<Action>
   , contextStyle/*?:ContextStyle*/
-  )/*:DOM*/ =>
+  ):DOM =>
   html.figure
   ( { style: Style.mix
         ( baseStyleSheet.base

--- a/src/common/image.js
+++ b/src/common/image.js
@@ -22,19 +22,20 @@ const baseStyleSheet:StyleSheet = Style.createSheet
     }
   );
 
-export const view =
-  (key:string, styleSheet:StyleSheet):(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM =>
-  ( model:Model
-  , address:Address<Action>
-  , contextStyle/*?:ContextStyle*/
-  ):DOM =>
-  html.figure
-  ( { style: Style.mix
-        ( baseStyleSheet.base
-        , styleSheet.base
-        , { backgroundImage: `url(${model.uri})`
-          }
-        , contextStyle
-        )
-    }
-  )
+export function view(key:string,
+                     styleSheet:StyleSheet):(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM {
+  return ( model
+         , address
+         , contextStyle
+         ):DOM =>
+         html.figure
+         ( { style: Style.mix
+               ( baseStyleSheet.base
+               , styleSheet.base
+               , { backgroundImage: `url(${model.uri})`
+                 }
+               , contextStyle
+               )
+           }
+         )
+}

--- a/src/common/image.js
+++ b/src/common/image.js
@@ -23,7 +23,7 @@ const baseStyleSheet:StyleSheet = Style.createSheet
   );
 
 export const view =
-  (key:string, styleSheet:StyleSheet)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>
+  (key:string, styleSheet:StyleSheet):(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM =>
   ( model:Model
   , address:Address<Action>
   , contextStyle/*?:ContextStyle*/

--- a/src/common/image.js
+++ b/src/common/image.js
@@ -4,12 +4,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, thunk, forward, Effects} from 'reflex';
-import * as Style from '../common/style';
-
-
-import type {Address, DOM} from "reflex"
-import type {Action, Model, StyleSheet, ContextStyle} from "./image"
+import type { Address, DOM } from 'reflex'
+import { html } from 'reflex'
+import * as Style from '../common/style'
+import type { Action, Model, StyleSheet, ContextStyle } from './image'
 
 
 const baseStyleSheet:StyleSheet = Style.createSheet

--- a/src/common/keyboard.js
+++ b/src/common/keyboard.js
@@ -158,7 +158,7 @@ const writeChord = event => {
 
 
 export const bindings = /*::<Action>*/
-  (bindingTable/*:BindingTable<Action>*/)/*:(event:KeyboardEvent) => Action | Abort*/ => {
+  (bindingTable:BindingTable<Action>)/*:(event:KeyboardEvent) => Action | Abort*/ => {
   const bindings = Object.create(null);
   Object.keys(bindingTable).forEach(key => {
     bindings[readChord(key)] = bindingTable[key];

--- a/src/common/keyboard.js
+++ b/src/common/keyboard.js
@@ -158,7 +158,7 @@ const writeChord = event => {
 
 
 export const bindings = /*::<Action>*/
-  (bindingTable:BindingTable<Action>)/*:(event:KeyboardEvent) => Action | Abort*/ => {
+  (bindingTable:BindingTable<Action>):(event:KeyboardEvent) => Action | Abort => {
   const bindings = Object.create(null);
   Object.keys(bindingTable).forEach(key => {
     bindings[readChord(key)] = bindingTable[key];

--- a/src/common/keyboard.js
+++ b/src/common/keyboard.js
@@ -4,9 +4,9 @@
  * license, v. 2.0. if a copy of the mpl was not distributed with this
  * file, you can obtain one at http://mozilla.org/mpl/2.0/. */
 
-/*::
+
 import type {BindingTable, Abort, kind} from "./keyboard"
-*/
+
 
 import {Effects} from "reflex";
 import * as OS from './os';
@@ -92,7 +92,7 @@ if (!('key' in window.KeyboardEvent.prototype)) {
   ( window.KeyboardEvent.prototype
   , 'key'
   , { get: getKey
-    /*::, value: void(0)*/
+    , value: void(0)
     }
   );
 }

--- a/src/common/keyboard.js
+++ b/src/common/keyboard.js
@@ -5,11 +5,8 @@
  * file, you can obtain one at http://mozilla.org/mpl/2.0/. */
 
 
-import type {BindingTable, Abort, kind} from "./keyboard"
-
-
-import {Effects} from "reflex";
-import * as OS from './os';
+import type { BindingTable, Abort, kind } from './keyboard'
+import * as OS from './os'
 
 const platform = OS.platform();
 

--- a/src/common/os.js
+++ b/src/common/os.js
@@ -15,5 +15,5 @@ const PLATFORM = navigator.platform.startsWith('Win') ? 'win32' :
 
 // https://iojs.org/api/os.html#os_os_platform
 export const platform =
-  ()/*:string*/ =>
+  ():string =>
   PLATFORM;

--- a/src/common/performance.js
+++ b/src/common/performance.js
@@ -1,0 +1,3 @@
+declare class performance {
+  static now(): number;
+}

--- a/src/common/performance.js.flow
+++ b/src/common/performance.js.flow
@@ -1,3 +1,0 @@
-declare export class performance {
-  static now(): number;
-}

--- a/src/common/prelude.js
+++ b/src/common/prelude.js
@@ -7,9 +7,9 @@
 
 import {Effects} from "reflex"
 
-/*::
+
 import type {Tagged} from "./prelude"
-*/
+
 
 export const merge = /*::<model:{}>*/
   ( model/*:model*/

--- a/src/common/prelude.js
+++ b/src/common/prelude.js
@@ -12,9 +12,9 @@ import type {Tagged} from "./prelude"
 
 
 export const merge = /*::<model:{}>*/
-  ( model/*:model*/
+  ( model:model
   , changes/*:{[key:string]: any}*/
-  )/*:model*/ => {
+  ):model => {
   let result = model
   for (let key in changes) {
     if (changes.hasOwnProperty(key)) {
@@ -45,17 +45,17 @@ export const merge = /*::<model:{}>*/
 
 
 export const take = /*::<item>*/
-  (items/*:Array<item>*/, n/*:number*/)/*:Array<item>*/ =>
+  (items:Array<item>, n:number):Array<item> =>
   ( items.length <= n
   ? items
   : items.slice(0, n)
   )
 
 export const move = /*::<item>*/
-  ( items/*:Array<item>*/
-  , from/*:number*/
-  , to/*:number*/
-  )/*:Array<item>*/ => {
+  ( items:Array<item>
+  , from:number
+  , to:number
+  ):Array<item> => {
   const count = items.length
   if (from === to) {
     return items
@@ -72,7 +72,7 @@ export const move = /*::<item>*/
 }
 
 export const remove = /*::<item>*/
-  (items/*:Array<item>*/, index/*:number*/)/*:Array<item>*/ =>
+  (items:Array<item>, index:number):Array<item> =>
   ( index < 0
   ? items
   : index >= items.length
@@ -85,7 +85,7 @@ export const remove = /*::<item>*/
   );
 
 
-export const setIn = /*::<item>*/(items/*:Array<item>*/, index/*:number*/, item/*:item*/)/*:Array<item>*/ => {
+export const setIn = /*::<item>*/(items:Array<item>, index:number, item:item):Array<item> => {
   if (items[index] === item) {
     return items
   } else {
@@ -112,7 +112,7 @@ const Null = () => null;
 // @FlowIssue: Frow is unable to infer
 const Void = () => void(0);
 
-export const always = /*::<a>*/(a/*:a*/)/*:(...args:Array<any>)=>a*/ => {
+export const always = /*::<a>*/(a:a)/*:(...args:Array<any>)=>a*/ => {
   const value = a
   if (value === null) {
     return Null
@@ -144,9 +144,9 @@ export const always = /*::<a>*/(a/*:a*/)/*:(...args:Array<any>)=>a*/ => {
 // advantage of these to update same model in place.
 export const batch = /*:: <model, action>*/
   ( update/*:(m:model, a:action) => [model, Effects<action>]*/
-  , model/*:model*/
-  , actions/*:Array<action>*/
-  )/*:[model, Effects<action>]*/ =>
+  , model:model
+  , actions:Array<action>
+  ):[model, Effects<action>] =>
 {
   let effects = [];
   let index = 0;
@@ -163,10 +163,10 @@ export const batch = /*:: <model, action>*/
 }
 
 export const tag = /*::<tag:string, kind>*/
-  (tag/*:tag*/)/*:(value:kind) => Tagged<tag, kind>*/ =>
+  (tag:tag)/*:(value:kind) => Tagged<tag, kind>*/ =>
   value =>
   ({ type: tag, source: value });
 
 export const tagged = /*::<tag:string, kind>*/
-  (tag/*:tag*/, value/*:kind*/)/*:Tagged<tag, kind>*/ =>
+  (tag:tag, value:kind):Tagged<tag, kind> =>
   ({ type: tag, source: value });

--- a/src/common/prelude.js
+++ b/src/common/prelude.js
@@ -13,7 +13,7 @@ import type {Tagged} from "./prelude"
 
 export const merge = /*::<model:{}>*/
   ( model:model
-  , changes/*:{[key:string]: any}*/
+  , changes:{[key:string]: any}
   ):model => {
   let result = model
   for (let key in changes) {

--- a/src/common/prelude.js
+++ b/src/common/prelude.js
@@ -112,7 +112,7 @@ const Null = () => null;
 // @FlowIssue: Frow is unable to infer
 const Void = () => void(0);
 
-export const always = /*::<a>*/(a:a)/*:(...args:Array<any>)=>a*/ => {
+export const always = /*::<a>*/(a:a):(...args:Array<any>)=>a => {
   const value = a
   if (value === null) {
     return Null
@@ -143,7 +143,7 @@ export const always = /*::<a>*/(a:a)/*:(...args:Array<any>)=>a*/ => {
 // in place if `modlel` is "mutable". `batch` here wolud be able to take
 // advantage of these to update same model in place.
 export const batch = /*:: <model, action>*/
-  ( update/*:(m:model, a:action) => [model, Effects<action>]*/
+  ( update:(m:model, a:action) => [model, Effects<action>]
   , model:model
   , actions:Array<action>
   ):[model, Effects<action>] =>
@@ -163,7 +163,7 @@ export const batch = /*:: <model, action>*/
 }
 
 export const tag = /*::<tag:string, kind>*/
-  (tag:tag)/*:(value:kind) => Tagged<tag, kind>*/ =>
+  (tag:tag):(value:kind) => Tagged<tag, kind> =>
   value =>
   ({ type: tag, source: value });
 

--- a/src/common/prelude.js
+++ b/src/common/prelude.js
@@ -5,10 +5,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {Effects} from "reflex"
-
-
-import type {Tagged} from "./prelude"
+import { Effects } from 'reflex'
+import type { Tagged } from './prelude'
 
 
 export const merge = /*::<model:{}>*/

--- a/src/common/ref.js
+++ b/src/common/ref.js
@@ -2,7 +2,7 @@
 
 import {Effects, Task} from "reflex"
 
-/*::
+
 import type {Never} from "reflex"
 
 export type Model =
@@ -12,7 +12,7 @@ export type Model =
 
 export type Action =
   | Action
-*/
+
 
 const state =
   { nextRef: 0

--- a/src/common/ref.js
+++ b/src/common/ref.js
@@ -19,14 +19,14 @@ const state =
   };
 
 export const create =
-  ()/*:Model*/ =>
+  ():Model =>
   ( { name: 'data-ref'
     , value: `ref-${++state.nextRef}`
     }
   );
 
 export const deref =
-  (ref/*:Model*/)/*:Task<Error, HTMLElement>*/ =>
+  (ref:Model):Task<Error, HTMLElement> =>
   new Task
   ( (succeed, fail) => {
       const element = document.querySelector(`[${ref.name}='${ref.value}']`);

--- a/src/common/ref.js
+++ b/src/common/ref.js
@@ -1,9 +1,7 @@
 /* @flow */
 
-import {Effects, Task} from "reflex"
-
-
-import type {Never} from "reflex"
+import type { Never } from 'reflex'
+import { Task } from 'reflex'
 
 export type Model =
   { name: string

--- a/src/common/request-animation-frame.js
+++ b/src/common/request-animation-frame.js
@@ -1,9 +1,9 @@
 /* @flow */
 
 import * as Runtime from "./runtime"
-/*::
+
 import {performance} from "./performance"
-*/
+
 
 const state =
   { requests: []

--- a/src/common/request-animation-frame.js
+++ b/src/common/request-animation-frame.js
@@ -16,7 +16,7 @@ const state =
 const frameTime = 1000 / 60
 
 export const requestAnimationFrame =
-  (request/*:(time:number) => any*/):number => {
+  (request:(time:number) => any):number => {
     const id = ++state.nextID;
     state.ids.push(id);
     state.requests.push(request);

--- a/src/common/request-animation-frame.js
+++ b/src/common/request-animation-frame.js
@@ -16,7 +16,7 @@ const state =
 const frameTime = 1000 / 60
 
 export const requestAnimationFrame =
-  (request/*:(time:number) => any*/)/*:number*/ => {
+  (request/*:(time:number) => any*/):number => {
     const id = ++state.nextID;
     state.ids.push(id);
     state.requests.push(request);
@@ -32,7 +32,7 @@ export const requestAnimationFrame =
   }
 
 export const cancelAnimationFrame =
-  (id/*:number*/) => {
+  (id:number) => {
     const index = state.ids.indexOf(id);
     if (index >= 0) {
       state.ids.splice(index, 1);

--- a/src/common/request-animation-frame.js
+++ b/src/common/request-animation-frame.js
@@ -1,8 +1,7 @@
 /* @flow */
 
-import * as Runtime from "./runtime"
-
-import {performance} from "./performance"
+import * as Runtime from './runtime'
+import { performance } from './performance'
 
 
 const state =

--- a/src/common/result.js
+++ b/src/common/result.js
@@ -5,10 +5,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-/*::
+
 import type {Result, Ok, Error} from "./result"
 export type {Result, Ok, Error}
-*/
+
 
 export const ok = /*::<value>*/
   (value/*:value*/)/*:Ok<value>*/ =>

--- a/src/common/result.js
+++ b/src/common/result.js
@@ -11,7 +11,7 @@ export type {Result, Ok, Error}
 
 
 export const ok = /*::<value>*/
-  (value/*:value*/)/*:Ok<value>*/ =>
+  (value:value):Ok<value> =>
   ( { isOk: true
     , isError: false
     , value
@@ -19,7 +19,7 @@ export const ok = /*::<value>*/
   );
 
 export const error = /*::<error>*/
-  (error/*:error*/)/*:Error<error>*/ =>
+  (error:error):Error<error> =>
   ( { isOk: false
     , isError: true
     , error

--- a/src/common/result.js
+++ b/src/common/result.js
@@ -6,7 +6,7 @@
 
 
 
-import type {Result, Ok, Error} from "./result"
+import type { Result, Ok, Error } from './result'
 export type {Result, Ok, Error}
 
 

--- a/src/common/runtime.js
+++ b/src/common/runtime.js
@@ -5,12 +5,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-/*::
+
 import type {Never} from "reflex"
 import type {Result} from "../common/result"
 import type {RemoteDebugResponseType, DownloadUpdateType} from "./runtime"
 
-*/
+
 import {always} from "../common/prelude";
 import {Task} from "reflex";
 import {ok, error} from "../common/result";

--- a/src/common/runtime.js
+++ b/src/common/runtime.js
@@ -52,38 +52,38 @@ export const FullscreenToggled
 
 
 export const RemoteDebugResponse =
-  (value/*:boolean*/)/*:RemoteDebugResponseType*/ =>
+  (value:boolean):RemoteDebugResponseType =>
   ( { type: "RemoteDebugResponse"
     , value
     }
   );
 
 export const DownloadUpdate =
-  (result/*:string*/)/*:DownloadUpdateType*/ =>
+  (result:string):DownloadUpdateType =>
   ( { type: "DownloadUpdate"
     , result
     }
   );
 
-export const isServo/*:boolean*/ =
+export const isServo:boolean =
   window
   .navigator
   .userAgent
   .toLowerCase()
   .indexOf(' servo') != -1
 
-export const isElectron/*:boolean*/ =
+export const isElectron:boolean =
   window
   .navigator
   .userAgent
   .toLowerCase()
   .indexOf(' electron') != -1
 
-export const never/*:Task<Never, any>*/ =
+export const never:Task<Never, any> =
   new Task(succeed => void(0));
 
 export const respond = /*::<message>*/
-  (message/*:message*/)/*:Task<Never, message>*/ =>
+  (message:message):Task<Never, message> =>
   new Task
   ( (succeed, fail) =>
     void ( Promise
@@ -93,7 +93,7 @@ export const respond = /*::<message>*/
   );
 
 export const send = /*::<message>*/
-  (message/*:message*/)/*:Task<Never, void>*/ =>
+  (message:message):Task<Never, void> =>
   new Task(succeed => {
     window.dispatchEvent(new window.CustomEvent("mozContentEvent", {
       bubbles: true,
@@ -105,7 +105,7 @@ export const send = /*::<message>*/
   });
 
 export const receive = /*::<message>*/
-  (type/*:string*/)/*:Task<Never, message>*/ =>
+  (type:string):Task<Never, message> =>
   new Task(succeed => {
     const onMessage = ({detail: message}) => {
       if (message.type === type) {
@@ -118,12 +118,12 @@ export const receive = /*::<message>*/
 
 
 export const request = /*::<request, response>*/
-  (type/*:string*/, message/*:request*/)/*:Task<Never, response>*/ =>
+  (type:string, message:request):Task<Never, response> =>
   send(message)
   .chain(always(receive(type)));
 
 
-export const quit/*:Task<Never, Result<Error, void>>*/ =
+export const quit:Task<Never, Result<Error, void>> =
   ( isServo
   ? new Task((succeed, fail) => {
       try {
@@ -139,19 +139,19 @@ export const quit/*:Task<Never, Result<Error, void>>*/ =
     .chain(always(never))
   );
 
-export const minimize/*:Task<Never, Result<Error, void>>*/ =
+export const minimize:Task<Never, Result<Error, void>> =
   send({type: "minimize-native-window"})
   // We do not get event back when window is minimized so we just pretend
   // that we got it after a tick.
   .chain(always(respond(ok())))
 
-export const toggleFullscreen/*:Task<Never, Result<Error, void>>*/ =
+export const toggleFullscreen:Task<Never, Result<Error, void>> =
   send({type: "toggle-fullscreen-native-window"})
   // We do not get event back when window is maximized so we just pretend
   // that we got it after a tick.
   .chain(always(respond(ok())));
 
-export const reload/*:Task<Never, Result<Error, void>>*/ =
+export const reload:Task<Never, Result<Error, void>> =
   new Task(succeed => {
     try {
       window.location.reload();
@@ -162,15 +162,15 @@ export const reload/*:Task<Never, Result<Error, void>>*/ =
   });
 
 
-export const restart/*:Task<Never, Result<Error, void>>*/ =
+export const restart:Task<Never, Result<Error, void>> =
   send({type: "restart"})
   .chain(always(respond(error(Error(`Unsupported runtime task "restart" was triggered`)))));
 
-export const cleanRestart/*:Task<Never, Result<Error, void>>*/ =
+export const cleanRestart:Task<Never, Result<Error, void>> =
   send({type: "clear-cache-and-restart"})
   .chain(always(never));
 
-export const cleanReload/*:Task<Never, Result<Error, void>>*/ =
+export const cleanReload:Task<Never, Result<Error, void>> =
   ( isServo
   ? new Task(succeed => {
       try {
@@ -188,7 +188,7 @@ export const cleanReload/*:Task<Never, Result<Error, void>>*/ =
 // titlebar configuration.
 const platform = OS.platform()
 export const useNativeTitlebar =
-  ()/*:boolean*/ =>
+  ():boolean =>
   platform != "darwin";
 
 const Env =

--- a/src/common/runtime.js
+++ b/src/common/runtime.js
@@ -215,4 +215,4 @@ const Env =
     }
   }
 
-export const env/*:{[key:string]: ?string|?Array<?string>}*/ = Env();
+export const env:{[key:string]: ?string|?Array<?string>} = Env();

--- a/src/common/runtime.js
+++ b/src/common/runtime.js
@@ -6,17 +6,15 @@
 
 
 
-import type {Never} from "reflex"
-import type {Result} from "../common/result"
-import type {RemoteDebugResponseType, DownloadUpdateType} from "./runtime"
-
-
-import {always} from "../common/prelude";
-import {Task} from "reflex";
-import {ok, error} from "../common/result";
-import * as OS from '../common/os';
-import * as URL from '../common/url-helper';
-import * as QueryString from 'querystring';
+import type { Never } from 'reflex'
+import { Task } from 'reflex'
+import type { Result } from '../common/result'
+import { ok, error } from '../common/result'
+import type { RemoteDebugResponseType, DownloadUpdateType } from './runtime'
+import { always } from '../common/prelude'
+import * as OS from '../common/os'
+import * as URL from '../common/url-helper'
+import * as QueryString from 'querystring'
 
 // Actions
 export const RemoteDebugRequest

--- a/src/common/selector.js
+++ b/src/common/selector.js
@@ -13,11 +13,11 @@ import type {Integer} from "../common/prelude"
 // is out of bounds position is calculated by looping. Otherwise last / first
 // index is retuned.
 export const indexOfOffset =
-  ( index/*:Integer*/
-  , offset/*:Integer*/
-  , size/*:Integer*/
-  , loop/*:boolean*/
-  )/*:Integer*/ => {
+  ( index:Integer
+  , offset:Integer
+  , size:Integer
+  , loop:boolean
+  ):Integer => {
   const position = index + offset;
   if (size === 0) {
     return index

--- a/src/common/selector.js
+++ b/src/common/selector.js
@@ -4,9 +4,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/*::
+
 import type {Integer} from "../common/prelude"
-*/
+
 
 // Returns position that is `offset` by given number from the given `index` if
 // total number of items is equal to given `size`. If `loop` is true and offset

--- a/src/common/selector.js
+++ b/src/common/selector.js
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import type {Integer} from "../common/prelude"
+import type { Integer } from '../common/prelude'
 
 
 // Returns position that is `offset` by given number from the given `index` if

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -20,21 +20,21 @@ const NotSupported =
   ReferenceError('navigator.mozSettings API is not available');
 
 export const Fetched =
-  (result/*:Result<Error, Settings>*/)/*:Action*/ =>
+  (result:Result<Error, Settings>):Action =>
   ( { type: "Fetched"
     , result
     }
   );
 
 export const Updated =
-  (result/*:Result<Error, Settings>*/)/*:Action*/ =>
+  (result:Result<Error, Settings>):Action =>
   ( { type: "Updated"
     , result
     }
   );
 
 export const Changed =
-  (result/*:Result<Error, Settings>*/)/*:Action*/ =>
+  (result:Result<Error, Settings>):Action =>
   ( { type: "Changed"
     , result
     }
@@ -57,7 +57,7 @@ const merges =
   );
 
 export const fetch =
-  (names/*:Array<Name>*/)/*:Task<Never, Result<Error, Settings>>*/ =>
+  (names:Array<Name>):Task<Never, Result<Error, Settings>> =>
   new Task((succeed, fail) => {
     if (navigator.mozSettings != null) {
       const lock = navigator.mozSettings.createLock();
@@ -76,7 +76,7 @@ export const fetch =
 
 
 export const change =
-  (settings/*:Settings*/)/*:Task<Never, Result<Error, Settings>>*/ =>
+  (settings:Settings):Task<Never, Result<Error, Settings>> =>
   new Task((succeed, fail) => {
     if (navigator.mozSettings != null) {
       const lock = navigator.mozSettings.createLock();
@@ -92,7 +92,7 @@ export const change =
   });
 
 export const observe =
-  (namePattern/*:string*/)/*:Task<Never, Result<Error, Settings>>*/=>
+  (namePattern:string):Task<Never, Result<Error, Settings>>=>
   new Task((succeed, fail) => {
     const onChange = change => {
       if (navigator.mozSettings) {
@@ -121,7 +121,7 @@ export const observe =
 
 
 export const init =
-  (names/*:Array<Name>*/)/*:[Model, Effects<Action>]*/ =>
+  (names:Array<Name>):[Model, Effects<Action>] =>
   [ null
   , Effects
     .perform(fetch(names))
@@ -148,7 +148,7 @@ const report = (model, error) => {
 
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model:Model, action:Action):[Model, Effects<Action>] =>
   ( action.type === 'Fetched'
   ? ( action.result.isOk
     ? updateSettings(model, action.result.value)

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -9,11 +9,11 @@ import * as Unknown from '../common/unknown';
 import {merge, always} from '../common/prelude';
 import {Effects, Task} from 'reflex';
 
-/*::
+
 import type {Model, Action, Name, Value, Settings} from "./settings"
 import type {Address, Never} from "reflex"
 import type {Result} from "./result"
-*/
+
 
 
 const NotSupported =

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -4,16 +4,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {error, ok} from '../common/result';
-import * as Unknown from '../common/unknown';
-import {merge, always} from '../common/prelude';
-import {Effects, Task} from 'reflex';
-
-
-import type {Model, Action, Name, Value, Settings} from "./settings"
-import type {Address, Never} from "reflex"
-import type {Result} from "./result"
-
+import { error, ok } from '../common/result'
+import * as Unknown from '../common/unknown'
+import { merge, always } from '../common/prelude'
+import type { Address, Never } from 'reflex'
+import { Effects, Task } from 'reflex'
+import type { Model, Action, Name, Value, Settings } from './settings'
+import type { Result } from './result'
 
 
 const NotSupported =

--- a/src/common/stopwatch.js
+++ b/src/common/stopwatch.js
@@ -8,9 +8,9 @@ import {Effects, Task} from 'reflex';
 import {merge, always} from "../common/prelude";
 import * as Unknown from "../common/unknown";
 
-/*::
+
 import type {Action, Model, Time} from "./stopwatch"
-*/
+
 
 export const Start/*:Action*/ = {type: "Start"};
 export const End/*:Action*/ = {type: "End"};

--- a/src/common/stopwatch.js
+++ b/src/common/stopwatch.js
@@ -12,10 +12,10 @@ import * as Unknown from "../common/unknown";
 import type {Action, Model, Time} from "./stopwatch"
 
 
-export const Start/*:Action*/ = {type: "Start"};
-export const End/*:Action*/ = {type: "End"};
+export const Start:Action = {type: "Start"};
+export const End:Action = {type: "End"};
 export const Tick =
-  (time/*:Time*/)/*:Action*/ =>
+  (time:Time):Action =>
   ( { type: "Tick"
     , time
     }
@@ -23,11 +23,11 @@ export const Tick =
 
 
 export const init =
-  ()/*:[Model, Effects<Action>]*/ =>
+  ():[Model, Effects<Action>] =>
   [null, Effects.none];
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model:Model, action:Action):[Model, Effects<Action>] =>
   ( action.type === "End"
   ? [ null, Effects.none ]
   : action.type === "Start"

--- a/src/common/stopwatch.js
+++ b/src/common/stopwatch.js
@@ -4,12 +4,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Effects, Task} from 'reflex';
-import {merge, always} from "../common/prelude";
-import * as Unknown from "../common/unknown";
-
-
-import type {Action, Model, Time} from "./stopwatch"
+import { Effects, Task } from 'reflex'
+import { merge } from '../common/prelude'
+import * as Unknown from '../common/unknown'
+import type { Action, Model, Time } from './stopwatch'
 
 
 export const Start:Action = {type: "Start"};

--- a/src/common/style.js
+++ b/src/common/style.js
@@ -4,9 +4,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/*::
+
 import type {Rules, Sheet} from "./style"
-*/
+
 
 const composedStyles = Object.create(null);
 

--- a/src/common/style.js
+++ b/src/common/style.js
@@ -38,7 +38,7 @@ export const StyleSheet = {
 // Mix multiple style objects together. Will memoize the combination of styles
 // to minimize object creation. Returns style object that is the result of
 // mixing styles together.
-export const mix = (...styles/*:Array<?Rules>*/)/*:Rules*/ => {
+export function mix(...styles/*:Array<?Rules>*/)/*:Rules*/ {
   var length = styles.length;
   var index = 0;
   var id = null;

--- a/src/common/style.js
+++ b/src/common/style.js
@@ -14,7 +14,7 @@ const ID = Symbol('style-sheet/id');
 var id = 0;
 
 export const StyleSheet = {
-  create: /*::<sheet:Sheet>*/(sheet/*:sheet*/)/*:sheet*/ => {
+  create: /*::<sheet:Sheet>*/(sheet:sheet):sheet => {
     const result = {}
     for (var name in sheet) {
       if (sheet.hasOwnProperty(name)) {
@@ -38,7 +38,7 @@ export const StyleSheet = {
 // Mix multiple style objects together. Will memoize the combination of styles
 // to minimize object creation. Returns style object that is the result of
 // mixing styles together.
-export function mix(...styles/*:Array<?Rules>*/)/*:Rules*/ {
+export function mix(...styles:Array<?Rules>):Rules {
   var length = styles.length;
   var index = 0;
   var id = null;

--- a/src/common/style.js
+++ b/src/common/style.js
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import type {Rules, Sheet} from "./style"
+import type { Rules, Sheet } from './style'
 
 
 const composedStyles = Object.create(null);

--- a/src/common/target.js
+++ b/src/common/target.js
@@ -9,9 +9,9 @@ import {Effects} from "reflex";
 import {merge} from "../common/prelude";
 import * as Unknown from "../common/unknown";
 
-/*::
+
 import type {Action, Model} from "./target"
-*/
+
 
 export const Over/*:Action*/ = {type: "Over"};
 export const Out/*:Action*/ = {type: "Out"};

--- a/src/common/target.js
+++ b/src/common/target.js
@@ -13,11 +13,11 @@ import * as Unknown from "../common/unknown";
 import type {Action, Model} from "./target"
 
 
-export const Over/*:Action*/ = {type: "Over"};
-export const Out/*:Action*/ = {type: "Out"};
+export const Over:Action = {type: "Over"};
+export const Out:Action = {type: "Out"};
 
 export const update = /*::<model:Model>*/
-  (model/*:model*/, action/*:Action*/)/*:[model, Effects<Action>]*/ =>
+  (model:model, action:Action):[model, Effects<Action>] =>
   ( action.type == "Over"
   ? [merge(model, {isPointerOver: true}), Effects.none]
   : action.type == "Out"

--- a/src/common/target.js
+++ b/src/common/target.js
@@ -5,12 +5,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {Effects} from "reflex";
-import {merge} from "../common/prelude";
-import * as Unknown from "../common/unknown";
-
-
-import type {Action, Model} from "./target"
+import { Effects } from 'reflex'
+import { merge } from '../common/prelude'
+import * as Unknown from '../common/unknown'
+import type { Action, Model } from './target'
 
 
 export const Over:Action = {type: "Over"};

--- a/src/common/text-input.js
+++ b/src/common/text-input.js
@@ -122,7 +122,7 @@ const decodeChange = compose
 
 
 export const view =
-  (key:string, styleSheet:StyleSheet)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>
+  (key:string, styleSheet:StyleSheet):(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM =>
   ( model:Model
   , address:Address<Action>
   , contextStyle/*?:ContextStyle*/

--- a/src/common/text-input.js
+++ b/src/common/text-input.js
@@ -121,11 +121,11 @@ const decodeChange = compose
   );
 
 
-export const view =
-  (key:string, styleSheet:StyleSheet):(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM =>
-  ( model:Model
-  , address:Address<Action>
-  , contextStyle/*?:ContextStyle*/
+export function view(key:string,
+                     styleSheet:StyleSheet):(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM {
+  return ( model
+         , address
+         , contextStyle
   ):DOM =>
   html.input
   ( { key
@@ -154,3 +154,4 @@ export const view =
       )
     }
   )
+}

--- a/src/common/text-input.js
+++ b/src/common/text-input.js
@@ -25,7 +25,7 @@ import type {Action, Model, StyleSheet, ContextStyle} from './text-input'
 
 const EditableAction = tag("Editable");
 const FocusableAction =
-  (action/*:Focusable.Action*/)/*:Action*/ =>
+  (action:Focusable.Action):Action =>
   ( action.type === "Focus"
   ? Focus
   : action.type === "Blur"
@@ -35,18 +35,18 @@ const FocusableAction =
 const ControlAction = tag("Control");
 
 export const Change = Editable.Change;
-export const Focus/*:Action*/ = { type: "Focus" };
-export const Blur/*:Action*/ = { type: "Blur" };
-export const Enable/*:Action*/ = ControlAction(Control.Enable);
-export const Disable/*:Action*/ = ControlAction(Control.Disable);
+export const Focus:Action = { type: "Focus" };
+export const Blur:Action = { type: "Blur" };
+export const Enable:Action = ControlAction(Control.Enable);
+export const Disable:Action = ControlAction(Control.Disable);
 
 
 export const init =
-  ( value/*:string*/=''
-  , selection/*:?Editable.Selection*/=null
-  , placeholder/*:string*/=''
-  , isDisabled/*:boolean*/=false
-  )/*:[Model, Effects<Action>]*/ =>
+  ( value:string=''
+  , selection:?Editable.Selection=null
+  , placeholder:string=''
+  , isDisabled:boolean=false
+  ):[Model, Effects<Action>] =>
   [ { value
     , placeholder
     , selection
@@ -87,7 +87,7 @@ const updateControl = cursor
   );
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model:Model, action:Action):[Model, Effects<Action>] =>
   ( action.type === 'Change'
   ? updateEditable(model, action)
   : action.type === 'Editable'
@@ -122,11 +122,11 @@ const decodeChange = compose
 
 
 export const view =
-  (key/*:string*/, styleSheet/*:StyleSheet*/)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>
-  ( model/*:Model*/
-  , address/*:Address<Action>*/
+  (key:string, styleSheet:StyleSheet)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>
+  ( model:Model
+  , address:Address<Action>
   , contextStyle/*?:ContextStyle*/
-  )/*:DOM*/ =>
+  ):DOM =>
   html.input
   ( { key
     , type: 'input'

--- a/src/common/text-input.js
+++ b/src/common/text-input.js
@@ -16,10 +16,10 @@ import * as Control from '../common/control';
 
 import {on, focus, selection} from '@driver';
 
-/*::
+
 import type {Address, DOM} from "reflex"
 import type {Action, Model, StyleSheet, ContextStyle} from './text-input'
-*/
+
 
 
 

--- a/src/common/text-input.js
+++ b/src/common/text-input.js
@@ -4,23 +4,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, forward, Effects} from 'reflex';
-import {Style} from '../common/style';
-import {compose} from '../lang/functional';
-import {tag, tagged, merge, always} from '../common/prelude';
-import {cursor} from "../common/cursor"
-import * as Unknown from '../common/unknown';
-import * as Focusable from '../common/focusable';
-import * as Editable from '../common/editable';
-import * as Control from '../common/control';
-
-import {on, focus, selection} from '@driver';
-
-
-import type {Address, DOM} from "reflex"
-import type {Action, Model, StyleSheet, ContextStyle} from './text-input'
-
-
+import type { Address, DOM } from 'reflex'
+import { html, forward, Effects } from 'reflex'
+import { Style } from '../common/style'
+import { compose } from '../lang/functional'
+import { tag, tagged, merge, always } from '../common/prelude'
+import { cursor } from '../common/cursor'
+import * as Unknown from '../common/unknown'
+import * as Focusable from '../common/focusable'
+import * as Editable from '../common/editable'
+import * as Control from '../common/control'
+import { on, focus, selection } from '@driver'
+import type { Action, Model, StyleSheet, ContextStyle } from './text-input'
 
 
 const EditableAction = tag("Editable");

--- a/src/common/toggle.js
+++ b/src/common/toggle.js
@@ -101,11 +101,11 @@ export const update =
   );
 
 
-export const view =
-  (key:string, styleSheet:StyleSheet):(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM =>
-  ( model:Model
-  , address:Address<Action>
-  , contextStyle/*?:ContextStyle*/
+export function view(key:string,
+                     styleSheet:StyleSheet):(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM {
+  return ( model
+         , address
+         , contextStyle
   ):DOM =>
   html.button({
     key: key,
@@ -148,3 +148,4 @@ export const view =
 
     onClick: forward(address, always(Press))
   });
+}

--- a/src/common/toggle.js
+++ b/src/common/toggle.js
@@ -21,13 +21,13 @@ import type {Action, Model, StyleSheet, ContextStyle} from "./toggle"
 
 
 export const init =
-  ( isDisabled/*:boolean*/=false
-  , isFocused/*:boolean*/=false
-  , isActive/*:boolean*/=false
-  , isPointerOver/*:boolean*/=false
-  , isChecked/*:boolean*/=false
-  , text/*:string*/=""
-  )/*:[Model, Effects<Action>]*/ =>
+  ( isDisabled:boolean=false
+  , isFocused:boolean=false
+  , isActive:boolean=false
+  , isPointerOver:boolean=false
+  , isChecked:boolean=false
+  , text:string=""
+  ):[Model, Effects<Action>] =>
   [
     { isDisabled,
       isFocused,
@@ -39,22 +39,22 @@ export const init =
   , Effects.none
   ];
 
-export const Press/*:Action*/ = {type: "Press"};
-export const Check/*:Action*/ = {type: "Check"};
-export const Uncheck/*:Action*/ = {type: "Uncheck"};
+export const Press:Action = {type: "Press"};
+export const Check:Action = {type: "Check"};
+export const Uncheck:Action = {type: "Uncheck"};
 
 const TargetAction =action => ({type: "Target", action});
 const FocusableAction = action => ({type: "Focusable", action});
 const ButtonAction = action => ({type: "Button", action});
 
-export const Focus/*:Action*/ = FocusableAction(Focusable.Focus);
-export const Blur/*:Action*/ = FocusableAction(Focusable.Blur);
+export const Focus:Action = FocusableAction(Focusable.Focus);
+export const Blur:Action = FocusableAction(Focusable.Blur);
 
-export const Over/*:Action*/ = TargetAction(Target.Over);
-export const Out/*:Action*/ = TargetAction(Target.Out);
+export const Over:Action = TargetAction(Target.Over);
+export const Out:Action = TargetAction(Target.Out);
 
-export const Down/*:Action*/ = ButtonAction(Button.Down);
-export const Up/*:Action*/ = ButtonAction(Button.Up);
+export const Down:Action = ButtonAction(Button.Down);
+export const Up:Action = ButtonAction(Button.Up);
 
 
 const updateTarget = cursor({
@@ -74,7 +74,7 @@ const updateButton = cursor({
 
 
 export const update =
-  (model/*:Model*/, action/*:Action*/)/*:[Model, Effects<Action>]*/ =>
+  (model:Model, action:Action):[Model, Effects<Action>] =>
   ( action.type === "Press"
   ? [ merge(model, {isChecked: !model.isChecked})
     , ( model.isChecked
@@ -102,11 +102,11 @@ export const update =
 
 
 export const view =
-  (key/*:string*/, styleSheet/*:StyleSheet*/)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>
-  ( model/*:Model*/
-  , address/*:Address<Action>*/
+  (key:string, styleSheet:StyleSheet)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>
+  ( model:Model
+  , address:Address<Action>
   , contextStyle/*?:ContextStyle*/
-  )/*:DOM*/ =>
+  ):DOM =>
   html.button({
     key: key,
     className: key,

--- a/src/common/toggle.js
+++ b/src/common/toggle.js
@@ -14,10 +14,10 @@ import * as Button from "../common/button"
 import {Style} from "../common/style"
 import {html, Effects, forward, Task} from "reflex"
 
-/*::
+
 import type {Address, DOM} from "reflex"
 import type {Action, Model, StyleSheet, ContextStyle} from "./toggle"
-*/
+
 
 
 export const init =

--- a/src/common/toggle.js
+++ b/src/common/toggle.js
@@ -102,7 +102,7 @@ export const update =
 
 
 export const view =
-  (key:string, styleSheet:StyleSheet)/*:(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM*/ =>
+  (key:string, styleSheet:StyleSheet):(model:Model, address:Address<Action>, contextStyle?:ContextStyle) => DOM =>
   ( model:Model
   , address:Address<Action>
   , contextStyle/*?:ContextStyle*/

--- a/src/common/toggle.js
+++ b/src/common/toggle.js
@@ -5,19 +5,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {merge, always} from "../common/prelude"
-import {cursor} from "../common/cursor"
-import * as Unknown from "../common/unknown"
-import * as Target from "../common/target"
-import * as Focusable from "../common/focusable"
-import * as Button from "../common/button"
-import {Style} from "../common/style"
-import {html, Effects, forward, Task} from "reflex"
-
-
-import type {Address, DOM} from "reflex"
-import type {Action, Model, StyleSheet, ContextStyle} from "./toggle"
-
+import { merge, always } from '../common/prelude'
+import { cursor } from '../common/cursor'
+import * as Unknown from '../common/unknown'
+import * as Target from '../common/target'
+import * as Focusable from '../common/focusable'
+import * as Button from '../common/button'
+import { Style } from '../common/style'
+import type { Address, DOM } from 'reflex'
+import { html, Effects, forward, Task } from 'reflex'
+import type { Action, Model, StyleSheet, ContextStyle } from './toggle'
 
 
 export const init =

--- a/src/common/unknown.js
+++ b/src/common/unknown.js
@@ -10,26 +10,26 @@ import type {Action} from "./unknown";
 import type {Never} from "reflex";
 
 
-export function warn(...params/*:Array<any>*/)/*:Task<Never, Action>*/ {
+export function warn(...params:Array<any>):Task<Never, Action> {
   return new Task((succeed, fail) => {
     console.warn(...params);
   });
 }
 
-export function log(...params/*:Array<any>*/)/*:Task<Never, Action>*/ {
+export function log(...params:Array<any>):Task<Never, Action> {
   return new Task((succeed, fail) => {
     console.log(...params);
   });
 }
 
-export function error(...params/*:Array<any>*/)/*:Task<Never, Action>*/ {
+export function error(...params:Array<any>):Task<Never, Action> {
   return new Task((succeed, fail) => {
     console.error(...params);
   });
 }
 
 
-export function update<model, action>(model/*:model*/, action/*:action*/)/*:[model, Effects<action>]*/ {
+export function update<model, action>(model:model, action:action):[model, Effects<action>] {
   console.warn('Unknown action was passed & ignored: ', action, Error().stack);
   return [model, Effects.none];
 };

--- a/src/common/unknown.js
+++ b/src/common/unknown.js
@@ -10,27 +10,26 @@ import type {Action} from "./unknown";
 import type {Never} from "reflex";
 
 
-export const warn =
-  (...params/*:Array<any>*/)/*:Task<Never, Action>*/ =>
-  new Task((succeed, fail) => {
+export function warn(...params/*:Array<any>*/)/*:Task<Never, Action>*/ {
+  return new Task((succeed, fail) => {
     console.warn(...params);
   });
+}
 
-export const log =
-  (...params/*:Array<any>*/)/*:Task<Never, Action>*/ =>
-  new Task((succeed, fail) => {
+export function log(...params/*:Array<any>*/)/*:Task<Never, Action>*/ {
+  return new Task((succeed, fail) => {
     console.log(...params);
   });
+}
 
-export const error =
-  (...params/*:Array<any>*/)/*:Task<Never, Action>*/ =>
-  new Task((succeed, fail) => {
+export function error(...params/*:Array<any>*/)/*:Task<Never, Action>*/ {
+  return new Task((succeed, fail) => {
     console.error(...params);
   });
+}
 
 
-export const update = /*::<model, action>*/
-  (model/*:model*/, action/*:action*/)/*:[model, Effects<action>]*/ => {
-    console.warn('Unknown action was passed & ignored: ', action, Error().stack);
-    return [model, Effects.none];
-  };
+export function update<model, action>(model/*:model*/, action/*:action*/)/*:[model, Effects<action>]*/ {
+  console.warn('Unknown action was passed & ignored: ', action, Error().stack);
+  return [model, Effects.none];
+};

--- a/src/common/unknown.js
+++ b/src/common/unknown.js
@@ -5,10 +5,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import {Effects, Task} from "reflex";
-/*::
+
 import type {Action} from "./unknown";
 import type {Never} from "reflex";
-*/
+
 
 export const warn =
   (...params/*:Array<any>*/)/*:Task<Never, Action>*/ =>

--- a/src/common/unknown.js
+++ b/src/common/unknown.js
@@ -4,10 +4,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Effects, Task} from "reflex";
-
-import type {Action} from "./unknown";
-import type {Never} from "reflex";
+import type { Never } from 'reflex'
+import { Effects, Task } from 'reflex'
+import type { Action } from './unknown'
 
 
 export function warn(...params:Array<any>):Task<Never, Action> {

--- a/src/common/url-helper.js
+++ b/src/common/url-helper.js
@@ -5,9 +5,9 @@
  * file, you can obtain one at http://mozilla.org/mpl/2.0/. */
 
 import {URL, nullURL} from "./url"
-/*::
+
 import type {URI} from "../common/prelude"
-*/
+
 
 export const parse = (input/*:string*/)/*:URL*/ => {
   try {

--- a/src/common/url-helper.js
+++ b/src/common/url-helper.js
@@ -9,7 +9,7 @@ import {URL, nullURL} from "./url"
 import type {URI} from "../common/prelude"
 
 
-export const parse = (input/*:string*/)/*:URL*/ => {
+export const parse = (input:string):URL => {
   try {
     return new URL(input);
   } catch(_) {
@@ -18,35 +18,35 @@ export const parse = (input/*:string*/)/*:URL*/ => {
 }
 
 export const hasScheme =
-  (input/*:URI*/)/*:boolean*/ =>
+  (input:URI):boolean =>
   !!(rscheme.exec(input) || [])[0];
 
 export const getOrigin =
-  (url/*:URI*/)/*:string*/ =>
+  (url:URI):string =>
   parse(url).origin;
 
 export const getBaseURI =
-  ()/*:URL*/ =>
+  ():URL =>
   new URL('./', location.href);
 
 export const getHostname =
-  (url/*:URI*/)/*:string*/ =>
+  (url:URI):string =>
   parse(url).hostname;
 
 export const getDomainName =
-  (url/*:URI*/)/*:string*/ =>
+  (url:URI):string =>
   getHostname(url).replace(/^www\./, '');
 
 export const getProtocol =
-  (url/*:URI*/)/*:string*/ =>
+  (url:URI):string =>
   parse(url).protocol;
 
 export const getManifestURL =
-  ()/*:URL*/ =>
+  ():URL =>
   new URL('./manifest.webapp', getBaseURI().href);
 
 export const getPathname =
-  (input/*:URI*/)/*:string*/ =>
+  (input:URI):string =>
   parse(input).pathname;
 
 
@@ -56,17 +56,17 @@ const isHttpOrHttps = (url) => {
 }
 
 export const isAboutURL =
-  (url/*:URI*/)/*:boolean*/ =>
+  (url:URI):boolean =>
   parse(url).protocol === 'about:';
 
-export const isPrivileged = (uri/*:URI*/)/*:boolean*/ => {
+export const isPrivileged = (uri:URI):boolean => {
   // FIXME: not safe. White list?
   return uri.startsWith(new URL('./components/about/', getBaseURI().href).href);
 };
 
 const rscheme = /^(?:[a-z\u00a1-\uffff0-9-+]+)(?::|:\/\/)/i;
 
-export const isNotURL = (input/*:string*/)/*:boolean*/ => {
+export const isNotURL = (input:string):boolean => {
   var str = input.trim();
 
   // for cases, ?abc and 'a? b' which should searching query
@@ -99,17 +99,17 @@ const readAboutURL = input =>
   input === 'about:blank' ? input :
   `${getBaseURI()}components/about/${input.replace('about:', '')}/index.html`;
 
-export const read = (input/*:string*/)/*:URI*/ =>
+export const read = (input:string):URI =>
   isNotURL(input) ? readSearchURL(input) :
   !hasScheme(input) ? `http://${input}` :
   isAboutURL(input) ? readAboutURL(input) :
   input;
 
-export const normalize = (uri/*:URI*/)/*:URI*/ =>
+export const normalize = (uri:URI):URI =>
   isAboutURL(uri) ? readAboutURL(uri) :
   uri;
 
-export const resolve = (from/*:URI*/, to/*:URI*/)/*:URI*/ =>
+export const resolve = (from:URI, to:URI):URI =>
   new URL(to, from).href;
 
 const aboutPattern = /\/about\/([^\/]+)\/index.html$/;
@@ -119,7 +119,7 @@ const readAboutTerm = input => {
   return match != null ? match[1] : null;
 }
 
-export const asAboutURI = (uri/*:URI*/)/*:?URI*/ => {
+export const asAboutURI = (uri:URI):?URI => {
   const base = getBaseURI();
   const {origin, pathname} = new window.URI(uri);
   const about = base.origin === origin ? readAboutTerm(pathname) : null;
@@ -127,7 +127,7 @@ export const asAboutURI = (uri/*:URI*/)/*:?URI*/ => {
 }
 
 // Prettify a URL for display purposes. Will minimize the amount of URL cruft.
-export const prettify = (input/*:URI*/)/*:string*/ =>
+export const prettify = (input:URI):string =>
   // Don't mess with non-urls.
   ( isNotURL(input)
   ? input

--- a/src/common/url-helper.js
+++ b/src/common/url-helper.js
@@ -4,9 +4,8 @@
  * license, v. 2.0. if a copy of the mpl was not distributed with this
  * file, you can obtain one at http://mozilla.org/mpl/2.0/. */
 
-import {URL, nullURL} from "./url"
-
-import type {URI} from "../common/prelude"
+import { URL, nullURL } from './url'
+import type { URI } from '../common/prelude'
 
 
 export const parse = (input:string):URL => {

--- a/src/devtools.js
+++ b/src/devtools.js
@@ -49,21 +49,21 @@ type Flags <model, action, flags> =
 
 
 const TagRecord = /*::<model, action>*/
-  (action/*:Record.Action<model, action>*/)/*:Action<model, action>*/ =>
+  (action:Record.Action<model, action>):Action<model, action> =>
   ( { type: "Record"
     , record: action
     }
   );
 
 const TagLog = /*::<model, action>*/
-  (action/*:Log.Action<model, action>*/)/*:Action<model, action>*/ =>
+  (action:Log.Action<model, action>):Action<model, action> =>
   ( { type: "Log"
     , log: action
     }
   );
 
 const TagReplay = /*::<model, action>*/
-  (action/*:Replay.Action<model, action>*/)/*:Action<model, action>*/ =>
+  (action:Replay.Action<model, action>):Action<model, action> =>
   ( action.type === "Replay"
   ? { type: "ReplayDebuggee"
     , model: action.replay
@@ -74,7 +74,7 @@ const TagReplay = /*::<model, action>*/
   );
 
 const TagDebuggee = /*::<model, action>*/
-  (action/*:action*/)/*:Action<model, action>*/ =>
+  (action:action):Action<model, action> =>
   ( action == null
   ? { type: "Debuggee"
     , debuggee: action
@@ -93,21 +93,21 @@ const TagDebuggee = /*::<model, action>*/
 export const Persist = { type: "Persist" }
 
 export const persist = /*::<model, action, flags>*/
-  ( model/*:Model<model, action>*/
-  )/*:Step<model, action>*/ =>
+  ( model:Model<model, action>
+  ):Step<model, action> =>
   [ model
   , Effects.none
   ];
 
 export const restore = /*::<model, action, flags>*/
-  ({Debuggee, flags}/*:Flags<model, action, flags>*/
-  )/*:Step<model, action>*/ =>
+  ({Debuggee, flags}:Flags<model, action, flags>
+  ):Step<model, action> =>
   [ merge(window.application.model.value, {Debuggee, flags})
   , Effects.none
   ];
 
 export const init = /*::<model, action, flags>*/
-  ({Debuggee, flags}/*:Flags<model, action, flags>*/)/*:Step<model, action>*/ => {
+  ({Debuggee, flags}:Flags<model, action, flags>):Step<model, action> => {
     const disable = [null, Effects.none]
 
     const [record, recordFX] =
@@ -151,9 +151,9 @@ export const init = /*::<model, action, flags>*/
   }
 
 export const update = /*::<model, action, flags>*/
-  ( model/*:Model<model, action>*/
-  , action/*:Action<model, action>*/
-  )/*:Step<model, action>*/ =>
+  ( model:Model<model, action>
+  , action:Action<model, action>
+  ):Step<model, action> =>
   ( action.type === "Record"
   ? ( model.record == null
     ? nofx(model)
@@ -184,15 +184,15 @@ export const update = /*::<model, action, flags>*/
   )
 
 const nofx = /*::<model, action>*/
-  (model/*:model*/)/*:[model, Effects<action>]*/ =>
+  (model:model):[model, Effects<action>] =>
   [ model
   , Effects.none
   ]
 
 const updateRecord = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , action/*:Record.Action<model, action>*/
-  )/*:Step<model, action>*/ => {
+  ( model:Model<model, action>
+  , action:Record.Action<model, action>
+  ):Step<model, action> => {
     const ignore = [null, Effects.none]
     const [record, fx] =
       ( model.record == null
@@ -204,9 +204,9 @@ const updateRecord = /*::<model, action>*/
 
 
 const updateReply = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , action/*:Replay.Action<model, action>*/
-  )/*:Step<model, action>*/ => {
+  ( model:Model<model, action>
+  , action:Replay.Action<model, action>
+  ):Step<model, action> => {
     const ignore = [null, Effects.none]
     const [replay, fx] =
       ( model.replay == null
@@ -217,9 +217,9 @@ const updateReply = /*::<model, action>*/
   }
 
 const updateLog = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , action/*:Log.Action<model, action>*/
-  )/*:Step<model, action>*/ => {
+  ( model:Model<model, action>
+  , action:Log.Action<model, action>
+  ):Step<model, action> => {
     const ignore = [null, Effects.none]
     const [log, fx] =
       ( model.log == null
@@ -231,9 +231,9 @@ const updateLog = /*::<model, action>*/
 
 
 const updateDebuggee = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , action/*:action*/
-  )/*:Step<model, action>*/ => {
+  ( model:Model<model, action>
+  , action:action
+  ):Step<model, action> => {
     const {Debuggee} = model
     const ignore = [null, Effects.none]
 
@@ -284,13 +284,13 @@ const updateDebuggee = /*::<model, action>*/
   }
 
 const replayDebuggee = /*::<model, action>*/
-  (model/*:Model<model, action>*/, debuggee/*:model*/)/*:Step<model, action>*/ =>
+  (model:Model<model, action>, debuggee:model):Step<model, action> =>
   nofx(merge(model, {debuggee}))
 
 export const render = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , address/*:Address<Action<model, action>>*/
-  )/*:DOM*/ =>
+  ( model:Model<model, action>
+  , address:Address<Action<model, action>>
+  ):DOM =>
   html.main
   ( { className: "devtools"
     }
@@ -314,9 +314,9 @@ export const render = /*::<model, action>*/
   )
 
 export const view = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , address/*:Address<Action<model, action>>*/
-  )/*:DOM*/ =>
+  ( model:Model<model, action>
+  , address:Address<Action<model, action>>
+  ):DOM =>
   thunk
   ( 'Devtools'
   , render

--- a/src/devtools.js
+++ b/src/devtools.js
@@ -10,7 +10,7 @@ import * as Replay from "./devtools/replay"
 import * as Record from "./devtools/record"
 import * as Log from "./devtools/log"
 
-/*::
+
 import type {Address, Never, DOM, Init, Update, View, AdvancedConfiguration} from "reflex"
 import type {Result} from "./common/result"
 
@@ -46,7 +46,7 @@ type Flags <model, action, flags> =
   { Debuggee: Debuggee<model, action>
   , flags: flags
   }
-*/
+
 
 const TagRecord = /*::<model, action>*/
   (action/*:Record.Action<model, action>*/)/*:Action<model, action>*/ =>

--- a/src/devtools.js
+++ b/src/devtools.js
@@ -1,18 +1,14 @@
 /* @flow */
 
-import {Effects, Task, thunk, html, forward} from "reflex"
-import {merge} from "./common/prelude"
-import {cursor} from "./common/cursor"
-import {ok, error} from "./common/result"
-import * as Runtime from "./common/runtime"
-import * as Unknown from "./common/unknown"
-import * as Replay from "./devtools/replay"
-import * as Record from "./devtools/record"
-import * as Log from "./devtools/log"
-
-
-import type {Address, Never, DOM, Init, Update, View, AdvancedConfiguration} from "reflex"
-import type {Result} from "./common/result"
+import type { Address, Never, DOM, Init, Update, View, AdvancedConfiguration } from 'reflex'
+import { Effects, thunk, html, forward } from 'reflex'
+import { merge } from './common/prelude'
+import type { Result } from './common/result'
+import * as Runtime from './common/runtime'
+import * as Unknown from './common/unknown'
+import * as Replay from './devtools/replay'
+import * as Record from './devtools/record'
+import * as Log from './devtools/log'
 
 export type Model <model, action> =
   { record: ?Record.Model<model, action>

--- a/src/devtools/log.js
+++ b/src/devtools/log.js
@@ -6,7 +6,7 @@ import {ok, error} from "../common/result"
 import * as Runtime from "../common/runtime"
 import * as Unknown from "../common/unknown"
 
-/*::
+
 import type {Address, Never, DOM, Init, Update, View, AdvancedConfiguration} from "reflex"
 import type {Result} from "../common/result"
 import type {URI, ID} from "../common/prelude"
@@ -24,7 +24,7 @@ type Step <model, action> =
   [ Model<model, action>
   , Effects<Action<model, action>>
   ]
-*/
+
 
 
 

--- a/src/devtools/log.js
+++ b/src/devtools/log.js
@@ -31,7 +31,7 @@ type Step <model, action> =
 const NoOp = always({ type: "NoOp" });
 
 export const init = /*::<model, action, flags>*/
-  ()/*:Step<model, action>*/ =>
+  ():Step<model, action> =>
   ( [ { mode:
         ( Runtime.env.log === 'json'
         ? 'json'
@@ -45,9 +45,9 @@ export const init = /*::<model, action, flags>*/
   )
 
 export const update = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , action/*:Action<model, action>*/
-  )/*:Step<model, action>*/ =>
+  ( model:Model<model, action>
+  , action:Action<model, action>
+  ):Step<model, action> =>
   ( action.type === "NoOp"
   ? nofx(model)
   : action.type === 'Debuggee'
@@ -62,9 +62,9 @@ const nofx =
   ]
 
 const log = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , action/*:action*/
-  )/*:Step<model, action>*/ => {
+  ( model:Model<model, action>
+  , action:action
+  ):Step<model, action> => {
     ( model.mode === 'raw'
     ? console.log('Action >>', action)
     : model.mode === 'json'
@@ -76,7 +76,7 @@ const log = /*::<model, action>*/
   }
 
 export const view = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , address/*:Address<Action<model, action>>*/
-  )/*:DOM*/ =>
+  ( model:Model<model, action>
+  , address:Address<Action<model, action>>
+  ):DOM =>
   html.noscript()

--- a/src/devtools/log.js
+++ b/src/devtools/log.js
@@ -1,15 +1,12 @@
 /* @flow */
 
-import {Effects, Task, html, forward} from "reflex"
-import {merge, always} from "../common/prelude"
-import {ok, error} from "../common/result"
-import * as Runtime from "../common/runtime"
-import * as Unknown from "../common/unknown"
-
-
-import type {Address, Never, DOM, Init, Update, View, AdvancedConfiguration} from "reflex"
-import type {Result} from "../common/result"
-import type {URI, ID} from "../common/prelude"
+import type { Address, Never, DOM, Init, Update, View, AdvancedConfiguration } from 'reflex'
+import { Effects, html } from 'reflex'
+import type { URI, ID } from '../common/prelude'
+import { always } from '../common/prelude'
+import type { Result } from '../common/result'
+import * as Runtime from '../common/runtime'
+import * as Unknown from '../common/unknown'
 
 
 export type Model <model, action> =

--- a/src/devtools/record.js
+++ b/src/devtools/record.js
@@ -7,7 +7,7 @@ import * as Runtime from "../common/runtime"
 import * as Unknown from "../common/unknown"
 import * as Style from "../common/style"
 
-/*::
+
 import type {Address, Never, DOM, Init, Update, View, AdvancedConfiguration} from "reflex"
 import type {Result} from "../common/result"
 import type {URI, ID} from "../common/prelude"
@@ -50,7 +50,7 @@ type Step <model, action> =
   [ Model<model, action>
   , Effects<Action<model, action>>
   ]
-*/
+
 
 
 

--- a/src/devtools/record.js
+++ b/src/devtools/record.js
@@ -59,14 +59,14 @@ const PrintSnapshot = { type: "PrintSnapshot" };
 const PublishSnapshot = { type: "PublishSnapshot" };
 const PrintedSnapshot = always({ type: "PrintedSnapshot" });
 const PublishedSnapshot = /*::<model, action>*/
-  (result/*:Result<Error, Gist>*/)/*:Action<model, action>*/ =>
+  (result:Result<Error, Gist>):Action<model, action> =>
   ( { type: "PublishedSnapshot"
     , result
     }
   );
 
 export const init = /*::<model, action, flags>*/
-  ()/*:Step<model, action>*/ =>
+  ():Step<model, action> =>
   ( [ { status: "Idle"
       , description: ""
       }
@@ -75,9 +75,9 @@ export const init = /*::<model, action, flags>*/
   )
 
 export const update = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , action/*:Action<model, action>*/
-  )/*:Step<model, action>*/ =>
+  ( model:Model<model, action>
+  , action:Action<model, action>
+  ):Step<model, action> =>
   ( action.type === "NoOp"
   ? nofx(model)
   : action.type === "PrintSnapshot"
@@ -100,7 +100,7 @@ const nofx =
   ]
 
 const createSnapshot = /*::<model, action>*/
-  (model/*:Model<model, action>*/)/*:Task<Error, string>*/ =>
+  (model:Model<model, action>):Task<Error, string> =>
   new Task((succeed, fail) => {
     try {
       succeed(JSON.stringify(window.application.model.value.debuggee))
@@ -112,7 +112,7 @@ const createSnapshot = /*::<model, action>*/
 
 
 const printSnapshot = /*::<model, action>*/
-  (model/*:Model<model, action>*/)/*:Step<model, action>*/ =>
+  (model:Model<model, action>):Step<model, action> =>
   [ merge(model, { status: 'Pending', description: 'Printing...' })
   , Effects.batch
     ( [ Effects.perform
@@ -130,13 +130,13 @@ const printSnapshot = /*::<model, action>*/
   ];
 
 const printedSnapshot = /*::<model, action>*/
-  (model/*:Model<model, action>*/)/*:Step<model, action>*/ =>
+  (model:Model<model, action>):Step<model, action> =>
   [ merge(model, { status: 'Idle', description: '' })
   , Effects.none
   ];
 
 const publishSnapshot = /*::<model, action>*/
-  (model/*:Model<model, action>*/)/*:Step<model, action>*/ =>
+  (model:Model<model, action>):Step<model, action> =>
   [ merge(model, {status: "Pending", description: "Publishing..." })
   , Effects.perform
     ( createSnapshot(model)
@@ -148,9 +148,9 @@ const publishSnapshot = /*::<model, action>*/
   ]
 
 const publishedSnapshot = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , result/*:Result<Error, Gist>*/
-  )/*:Step<model, action>*/ =>
+  ( model:Model<model, action>
+  , result:Result<Error, Gist>
+  ):Step<model, action> =>
   [ merge(model, {status: "Idle", description: "" })
   , Effects.perform
     ( result.isError
@@ -161,7 +161,7 @@ const publishedSnapshot = /*::<model, action>*/
   ]
 
 const uploadSnapshot =
-  (snapshot/*:string*/)/*:Task<Error, Gist>*/ =>
+  (snapshot:string):Task<Error, Gist> =>
   new Task((succeed, fail) => {
     const request = new XMLHttpRequest({mozSystem: true});
     request.open('POST', 'https://api.github.com/gists', true);
@@ -186,9 +186,9 @@ const uploadSnapshot =
   });
 
 export const render = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , address/*:Address<Action<model, action>>*/
-  )/*:DOM*/ =>
+  ( model:Model<model, action>
+  , address:Address<Action<model, action>>
+  ):DOM =>
   html.dialog
   ( { id: "record"
     , style: Style.mix
@@ -205,9 +205,9 @@ export const render = /*::<model, action>*/
   );
 
 export const view = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , address/*:Address<Action<model, action>>*/
-  )/*:DOM*/ =>
+  ( model:Model<model, action>
+  , address:Address<Action<model, action>>
+  ):DOM =>
   thunk
   ( "record"
   , render

--- a/src/devtools/record.js
+++ b/src/devtools/record.js
@@ -1,16 +1,13 @@
 /* @flow */
 
-import {Effects, Task, html, thunk, forward} from "reflex"
-import {merge, always} from "../common/prelude"
-import {ok, error} from "../common/result"
-import * as Runtime from "../common/runtime"
-import * as Unknown from "../common/unknown"
-import * as Style from "../common/style"
-
-
-import type {Address, Never, DOM, Init, Update, View, AdvancedConfiguration} from "reflex"
-import type {Result} from "../common/result"
-import type {URI, ID} from "../common/prelude"
+import type { Address, Never, DOM, Init, Update, View, AdvancedConfiguration } from 'reflex'
+import { Effects, Task, html, thunk } from 'reflex'
+import type { URI, ID } from '../common/prelude'
+import { merge, always } from '../common/prelude'
+import type { Result } from '../common/result'
+import { ok, error } from '../common/result'
+import * as Unknown from '../common/unknown'
+import * as Style from '../common/style'
 
 
 export type Gist =

--- a/src/devtools/replay.js
+++ b/src/devtools/replay.js
@@ -7,7 +7,7 @@ import * as Runtime from "../common/runtime"
 import * as Unknown from "../common/unknown"
 import * as Style from "../common/style"
 
-/*::
+
 import type {Address, Never, DOM, Init, Update, View, AdvancedConfiguration} from "reflex"
 import type {Result} from "../common/result"
 
@@ -27,7 +27,7 @@ type Step <model, action> =
   [ Model
   , Effects<Action<model, action>>
   ]
-*/
+
 
 
 

--- a/src/devtools/replay.js
+++ b/src/devtools/replay.js
@@ -34,14 +34,14 @@ type Step <model, action> =
 const Load = { type: "Load" }
 
 const Snapshot = /*::<model, action>*/
-  (result/*:Result<Error, model>*/)/*:Action<model, action>*/ =>
+  (result:Result<Error, model>):Action<model, action> =>
   ( { type: "Snapshot"
     , result
     }
   )
 
 const Replay = /*::<model, action>*/
-  (model/*:model*/)/*:Action<model, action>*/ =>
+  (model:model):Action<model, action> =>
   ( { type: "Replay"
     , replay: model
     }
@@ -49,7 +49,7 @@ const Replay = /*::<model, action>*/
 
 
 export const init = /*::<model, action, flags>*/
-  (flags/*:flags*/)/*:Step<model, action>*/ =>
+  (flags:flags):Step<model, action> =>
   ( [ { flags
       , snapshotURI: String(Runtime.env.replay)
       , error: null
@@ -60,9 +60,9 @@ export const init = /*::<model, action, flags>*/
   )
 
 export const update = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , action/*:Action<model, action>*/
-  )/*:Step<model, action>*/ =>
+  ( model:Model<model, action>
+  , action:Action<model, action>
+  ):Step<model, action> =>
   ( action.type === "Load"
   ? loadSnapshot(model)
   : action.type === "Snapshot"
@@ -79,9 +79,9 @@ const nofx =
   ]
 
 const receiveSnapshot = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , result/*:Result<Error, model>*/
-  )/*:Step<model, action>*/ =>
+  ( model:Model<model, action>
+  , result:Result<Error, model>
+  ):Step<model, action> =>
   ( result.isOk
   ? [ merge(model, {replayed: true})
     , Effects.receive(Replay(result.value))
@@ -90,14 +90,14 @@ const receiveSnapshot = /*::<model, action>*/
   )
 
 const loadSnapshot = /*::<model, action>*/
-  (model/*:Model<model, action>*/)/*:Step<model, action>*/ =>
+  (model:Model<model, action>):Step<model, action> =>
   [ model
   , Effects.perform(fetchSnapshot(model.snapshotURI))
     .map(Snapshot)
   ]
 
 const fetchSnapshot = /*::<model>*/
-  (uri/*:string*/)/*:Task<Never, Result<Error, model>>*/ => new Task(succeed => {
+  (uri:string):Task<Never, Result<Error, model>> => new Task(succeed => {
     const request = new XMLHttpRequest({mozSystem: true});
     request.open
     ( 'GET'
@@ -124,9 +124,9 @@ const fetchSnapshot = /*::<model>*/
 
 
 export const render = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , address/*:Address<Action<model, action>>*/
-  )/*:DOM*/ =>
+  ( model:Model<model, action>
+  , address:Address<Action<model, action>>
+  ):DOM =>
   html.dialog
   ( { id: "replay"
     , style: Style.mix
@@ -152,9 +152,9 @@ export const render = /*::<model, action>*/
   );
 
 export const view = /*::<model, action>*/
-  ( model/*:Model<model, action>*/
-  , address/*:Address<Action<model, action>>*/
-  )/*:DOM*/ =>
+  ( model:Model<model, action>
+  , address:Address<Action<model, action>>
+  ):DOM =>
   thunk
   ( 'replay'
   , render

--- a/src/devtools/replay.js
+++ b/src/devtools/replay.js
@@ -1,15 +1,13 @@
 /* @flow */
 
-import {Effects, Task, html, thunk, forward} from "reflex"
-import {merge} from "../common/prelude"
-import {ok, error} from "../common/result"
-import * as Runtime from "../common/runtime"
-import * as Unknown from "../common/unknown"
-import * as Style from "../common/style"
-
-
-import type {Address, Never, DOM, Init, Update, View, AdvancedConfiguration} from "reflex"
-import type {Result} from "../common/result"
+import type { Address, Never, DOM, Init, Update, View, AdvancedConfiguration } from 'reflex'
+import { Effects, Task, html, thunk } from 'reflex'
+import { merge } from '../common/prelude'
+import type { Result } from '../common/result'
+import { ok, error } from '../common/result'
+import * as Runtime from '../common/runtime'
+import * as Unknown from '../common/unknown'
+import * as Style from '../common/style'
 
 export type Model <model, action> =
   { snapshotURI: string

--- a/src/driver/virtual-dom/index.js
+++ b/src/driver/virtual-dom/index.js
@@ -203,7 +203,7 @@ export const selection = metaProperty((node, next, previous) => {
 });
 
 
-export const forceRender/*:Task<Error, void>*/ =
+export const forceRender:Task<Error, void> =
   new Task
   ( (succeed, fail) => {
       if (window.renderer) {
@@ -234,12 +234,12 @@ const handleEvent = phase => event => {
     handler.handleEvent(event)
   }
 }
-const handleCapturing/*:EventListener*/ = handleEvent('capture')
-const handleBubbling/*:EventListener*/ = handleEvent('bubble')
+const handleCapturing:EventListener = handleEvent('capture')
+const handleBubbling:EventListener = handleEvent('bubble')
 
 
 export const replaceElement =
-  (query/*:string*/, element/*:HTMLElement*/)/*:Task<Error, void>*/ =>
+  (query:string, element:HTMLElement):Task<Error, void> =>
   new Task
   ( ( succeed, fail ) => {
       const target = document.querySelector(query)
@@ -292,6 +292,6 @@ export const replaceElement =
   );
 
 export const forceReplace =
-  (query/*:string*/, element/*:HTMLElement*/)/*:Task<Error, void>*/ =>
+  (query:string, element:HTMLElement):Task<Error, void> =>
   forceRender
   .chain(_ => replaceElement(query, element));

--- a/src/driver/virtual-dom/index.js
+++ b/src/driver/virtual-dom/index.js
@@ -4,8 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {identity} from '../../lang/functional'
-import {forward, Effects, Task} from 'reflex'
+import { Task } from 'reflex'
 export {Renderer} from 'reflex-virtual-dom-driver'
 
 // @TODO documentation

--- a/src/main.js
+++ b/src/main.js
@@ -4,15 +4,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import "babel-polyfill";
-import "./common/request-animation-frame";
-import {start, Effects} from "reflex";
-import * as UI from "./browser";
-import {version} from "../package.json";
-import * as Config from "../browserhtml.json";
-import * as Runtime from "./common/runtime";
-import {Renderer} from "@driver";
-import * as Devtools from "./devtools"
+import 'babel-polyfill'
+import './common/request-animation-frame'
+import { start, Effects } from 'reflex'
+import * as UI from './browser'
+import { version } from '../package.json'
+import * as Runtime from './common/runtime'
+import { Renderer } from '@driver'
+import * as Devtools from './devtools'
 
 const isReload = window.application != null;
 console.timeStamp =


### PR DESCRIPTION
WebStorm has this nice feature for optimizing all imports, and it happens to work quite splendidly on our codebase. Substantially cuts down on LOC, and at least for me has a more visually pleasing result.

Applies on top of #1093, and is quite straight-forward.

r? @Gozala

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1097)
<!-- Reviewable:end -->
