### PR TITLE
Fix browser.html when using native titlebar.

### DIFF
--- a/src/browser/shell.js
+++ b/src/browser/shell.js
@@ -192,7 +192,7 @@ export const render =
     if (!Runtime.useNativeTitlebar()) {
       return Controls.view(model.controls, forward(address, ControlsAction));
     } else {
-      return "";
+      return html.noscript();
     }
   }
 


### PR DESCRIPTION
Turns out VirtualDOM `thunk` does not like resolution to `””` and always expects node.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1102)
<!-- Reviewable:end -->
