### PR TITLE
Disable assistant once location is submitted.

### DIFF
--- a/src/browser/Navigators/Navigator.js
+++ b/src/browser/Navigators/Navigator.js
@@ -579,7 +579,8 @@ const submitInput =
   batch
   ( update
   , model
-  , [ FocusOutput
+  , [ DeactivateAssistant
+    , FocusOutput
     , Navigate(model.input.value)
     ]
   );


### PR DESCRIPTION
This mitigates #1099 issue. So problem was that as you type we query search service. If you submit input before suggestions come back, suggestions would pop up later in the process. In @paulrouget case it in the background `newtab` page so you see them when you switch back. I think what @metajack was observing is same bug, he just edits tab url and submits it before suggestions show up, but in this case suggestions popup on top of existing page because they are loaded in the same tab.

Now what this change does is it deactivates suggestions bar (a.k.a assistant) when input is submitted. So race is not fixed, suggestions still will get updated etc.. it's just they won't appear over the active or background tab because assistant itself is not going to be displayed. If you activate the input field you'll see those suggestions though :(

Proper fix should actually abort search when input is submitted. But that requires deeper changes. So I'd like to land this first, as it will make issue much more less visible & subtle. I'll do a proper fix in a separate pull.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1115)
<!-- Reviewable:end -->
