### PR TITLE
Increase default vertical size to 740

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ npm run build-server
 Finally, in a new command line interface application (ex: Terminal), start Servo with the Browser.html flags turned on in either debug (`-d`) or release (`-r`) mode:
 
 ``` sh
-./mach run -r -- -b -w --resolution=1024x720 --pref dom.mozbrowser.enabled --pref dom.forcetouch.enabled --pref dom.builtin-key-shortcuts.enabled=false http://localhost:6060
+./mach run -r -- -b -w --resolution=1024x740 --pref dom.mozbrowser.enabled --pref dom.forcetouch.enabled --pref dom.builtin-key-shortcuts.enabled=false http://localhost:6060
 ```
 
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -145,7 +145,7 @@ gulp.task('servo', function() {
       var app = child.spawn(settings.servoPath, [
           '-w',
           '-b',
-          '--resolution', '1024x720',
+          '--resolution', '1024x740',
           '--pref', 'dom.mozbrowser.enabled',
           '--pref', 'dom.forcetouch.enabled',
           '--pref', 'dom.builtin-key-shortcuts.enabled=false',

--- a/main.js
+++ b/main.js
@@ -50,7 +50,7 @@ var onReady = function() {
   // Create the browser window.
   mainWindow = new BrowserWindow
   ( { width: 1024
-    , height: 720
+    , height: 740
     , frame: false
     , webPreferences:
       { nodeIntegration: false


### PR DESCRIPTION
Makes github work by changing a media query's result.

r? @paulrouget

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1125)
<!-- Reviewable:end -->
