### PR TITLE
Update preference for disabling key shortcuts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ npm run build-server
 Finally, in a new command line interface application (ex: Terminal), start Servo with the Browser.html flags turned on in either debug (`-d`) or release (`-r`) mode:
 
 ``` sh
-./mach run -r -- -b -w --resolution=1024x740 --pref dom.mozbrowser.enabled --pref dom.forcetouch.enabled --pref dom.builtin-key-shortcuts.enabled=false http://localhost:6060
+./mach run -r -- -b -w --resolution=1024x740 --pref dom.mozbrowser.enabled --pref dom.forcetouch.enabled --pref shell.builtin-key-shortcuts.enabled=false http://localhost:6060
 ```
 
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -148,7 +148,7 @@ gulp.task('servo', function() {
           '--resolution', '1024x740',
           '--pref', 'dom.mozbrowser.enabled',
           '--pref', 'dom.forcetouch.enabled',
-          '--pref', 'dom.builtin-key-shortcuts.enabled=false',
+          '--pref', 'shell.builtin-key-shortcuts.enabled=false',
           'http://localhost:' + settings.port
       ], {
           stdio: 'inherit'


### PR DESCRIPTION
Without this change `escape` quits servo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1133)
<!-- Reviewable:end -->
