### PR TITLE
Abort search queries when input is submitted.

### DIFF
--- a/src/browser/Navigators/Navigator.js
+++ b/src/browser/Navigators/Navigator.js
@@ -96,6 +96,7 @@ export type Action =
   // Internal
   | { type: "ActivateAssistant"}
   | { type: "DeactivateAssistant" }
+  | { type: "ResetAssistant" }
   | { type: "SetSelectedInputValue", value: string }
 
   // Embedder
@@ -263,6 +264,7 @@ export const Navigate =
 
 const ActivateAssistant = { type: "ActivateAssistant" }
 const DeactivateAssistant = { type: "DeactivateAssistant" }
+const ResetAssistant = { type: "ResetAssistant" }
 
 const SetSelectedInputValue =
   value =>
@@ -455,6 +457,8 @@ export const update =
         return activateAssistant(model);
       case 'DeactivateAssistant':
         return deactivateAssistant(model);
+      case 'ResetAssistant':
+        return resetAssistant(model);
       case 'SetSelectedInputValue':
         return setSelectedInputValue(model, action.value);
 
@@ -581,7 +585,7 @@ const submitInput =
   batch
   ( update
   , model
-  , [ DeactivateAssistant
+  , [ ResetAssistant
     , FocusOutput
     , Navigate(model.input.value)
     ]
@@ -725,6 +729,14 @@ const deactivateAssistant =
   ( model
   , Assistant.Close
   )
+
+const resetAssistant =
+  model =>
+  updateAssistant
+  ( model
+  , Assistant.Reset
+  )
+
 
 const setSelectedInputValue =
   (model, value) =>

--- a/src/browser/Navigators/Navigator/Assistant.js
+++ b/src/browser/Navigators/Navigator/Assistant.js
@@ -113,8 +113,27 @@ export const init =
   };
 
 const reset =
-  model =>
-  init();
+  state => {
+    const [search, search$] = Search.reset(state.search);
+    const [history, history$] = History.reset(state.history);
+
+    const model = {
+      isOpen: false,
+      isExpanded: false,
+      query: "",
+      selected: -1,
+      search,
+      history
+    }
+
+    const fx = Effects.batch
+      ( [ search$.map(SearchAction)
+        , history$.map(HistoryAction)
+        ]
+      )
+
+    return [model, fx]
+  }
 
 const clear =
   model =>

--- a/src/browser/Navigators/Navigator/Assistant/history.js
+++ b/src/browser/Navigators/Navigator/Assistant/history.js
@@ -45,14 +45,10 @@ export type Model =
 
 export type Action =
   | { type: "NoOp" }
-  | { type: "Query"
-    , query: string
-    }
-  | { type: "Suggest"
-    , suggest: Completion
-    }
-  | { type: "Activate"
-    }
+  | { type: "Reset" }
+  | { type: "Query", query: string }
+  | { type: "Suggest", suggest: Completion }
+  | { type: "Activate" }
   | { type: "SelectNext" }
   | { type: "SelectPrevious" }
   | { type: "Unselect" }
@@ -237,6 +233,12 @@ export const update =
   ? updateMatches(model, action.updateMatches)
   : Unknown.update(model, action)
   )
+
+export const reset =
+  (model:Model):[Model, Effects<Action>] => {
+    return [model, Effects.none]
+  }
+
 
 const innerView =
   (model, isSelected) =>


### PR DESCRIPTION
This fixes #1099. Unlike workaround in #1115 this actually resets assistant when input is submitted. Assistant on reset aborts all pending queries, there for late suggestions will no longer be added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1138)
<!-- Reviewable:end -->
