### PR TITLE
Copy evil ad js to dist

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -237,6 +237,7 @@ gulp.task('copydist', function() {
   copy_files('./src/**/*.png', path.join(dist, "components"));
   copy_files('./src/**/*.jpg', path.join(dist, "components"));
   copy_files('./src/**/*.gif', path.join(dist, "components"));
+  copy_files('./src/**/evil_ad/**/*.js', path.join(dist, "components"));
   copy_files('./*.json', path.join(dist, "components"));
 });
 


### PR DESCRIPTION
The js files with the evil ad demo were not being copied by gulp.

Hopefully this will be the last fixup here :wink:

Note: copying all `*.js` broke the newtab page, so I just have this copying the js for the evil ad demo only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1142)
<!-- Reviewable:end -->
