### PR TITLE
Set rect count in Transparent Rects demo to a saner value

### DIFF
--- a/src/about/newtab/demos/transparent_rects.html
+++ b/src/about/newtab/demos/transparent_rects.html
@@ -20,7 +20,7 @@ var RECT_MAX_SIZE = 25;
 var MIN_BORDER_RADIUS = 3;
 var MAX_BORDER_RADIUS = 16;
 var RECT_SPEED = 5;
-var RECT_COUNT = 700; // 700
+var RECT_COUNT = 500;
 function lerp(a, b, t) {
     return a + (b - a) * t;
 }


### PR DESCRIPTION
Who'd ever need more than 500 rects?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1143)
<!-- Reviewable:end -->
