### PR TITLE
Fix always displayed scrollbars in tabs sidebar on Gecko.

### DIFF
--- a/src/browser/Sidebar/Tabs.js
+++ b/src/browser/Sidebar/Tabs.js
@@ -37,7 +37,8 @@ const styleSheet = Style.createSheet({
     height: `calc(100% - ${Toolbar.height})`,
     // This padding matches title bar height.
     paddingTop: '32px',
-    overflowY: 'scroll',
+    overflowX: 'hidden',
+    overflowY: 'auto',
     boxSizing: 'border-box'
   }
 });


### PR DESCRIPTION
browser.html master works great on gecko once you do rm -rf node-modules and re run everything from scratch...

I just have this very tiny fix. I don't know if this `overflow-y: scroll` is very important on Servo,
but it makes the scrollbar always visible on Gecko. Which looks very ugly on Windows.
And not setting anything for `overflow-x` also makes the x-scrollbar always visible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1168)
<!-- Reviewable:end -->
