### PR TITLE
Init devtools only when activated.

### DIFF
--- a/src/common/devtools.js
+++ b/src/common/devtools.js
@@ -134,10 +134,38 @@ const updateSettings = cursor
     }
   );
 
-const toggle = model =>
-  [ merge(model, {isActive: !model.isActive})
+const toggle =
+  model =>
+  ( model.isActive
+  ? deactivate(model)
+  : activate(model)
+  )
+
+const deactivate =
+  model =>
+  [ merge(model, {isActive: false})
   , Effects.none
-  ];
+  ]
+
+const activate =
+  model =>
+  ( model.settings == null
+  ? initSettings(merge(model, {isActive: true}))
+  : [ merge(model, {isActive: true})
+    , Effects.none
+    ]
+  )
+
+const initSettings =
+  model => {
+    const [settings, fx] = Settings.init(Object.keys(descriptions));
+    const result =
+      [ merge(model, {settings})
+      , fx.map(SettingsAction)
+      ]
+    return result
+  }
+
 
 const restart = model =>
   [ model
@@ -182,18 +210,19 @@ const report =
 
 export const init =
   ({isActive}:{isActive:boolean}):[Model, Effects<Action>] => {
-  const [settings, fx] =
-    Settings.init(Object.keys(descriptions));
-
-  const result =
-    [ { isActive
-      , settings
+    const model =
+      { isActive
+      , settings: null
       }
-    , fx.map(SettingsAction)
-    ];
 
-  return result;
-};
+    const result =
+      ( isActive
+      ? initSettings(model)
+      : [ model, Effects.none ]
+      );
+
+    return result;
+  };
 
 
 


### PR DESCRIPTION
Since mozsettings API does not exist in servo, error was logged into a console when attempt to query it was made. This change defers initialization of devtools hud until it is enabled, there for error will not show up unless you activate devtools hud manually.

Fixes #1153

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1169)
<!-- Reviewable:end -->
