### PR TITLE
Autocomplete with backward selection.

### DIFF
--- a/src/browser/Navigators/Navigator/Input.js
+++ b/src/browser/Navigators/Navigator/Input.js
@@ -107,16 +107,16 @@ const enter = (model) => {
   return [result, Effects.batch([focusFx, editFx])];
 }
 
-const enterSelection = (model, value) =>
-  enterSelectionRange(model, value, 0, value.length);
+const enterSelection = (model, value, direction='forward') =>
+  enterSelectionRange(model, value, 0, value.length, direction);
 
-const enterSelectionRange = (model, value, start, end) => {
+const enterSelectionRange = (model, value, start, end, direction) => {
   const [next, focusFx] =
     mapFX(FocusableAction, Focusable.update(model, Focusable.Focus));
 
   const [result, editFx] =
     mapFX(EditableAction, Editable.update(next, Editable.Change(value, {
-      start, end, direction: 'forward'
+      start, end, direction
     })));
 
   return [result, Effects.batch([focusFx, editFx])];
@@ -150,6 +150,7 @@ const suggest = (model, {query, match, hint}) =>
       : match.length
       )
     , match.length
+    , 'backward'
     )
   )
 


### PR DESCRIPTION
Fixes #1171

With this change autocomplete behavior is more natural as `Shift+LeftArrow` selects last typed character, instead of unselecting part of the autocomplete.

Please note: This solves issue on the app side. With this change it will behave as expected on Electron but issue will still be present in servo until https://github.com/servo/servo/issues/12300 is fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1172)
<!-- Reviewable:end -->
