### PR TITLE
Fix regression that prevents suggestion to update autocomplete.

### DIFF
--- a/src/browser/Navigators/Navigator/Input.js
+++ b/src/browser/Navigators/Navigator/Input.js
@@ -140,7 +140,7 @@ export const init =
   ];
 
 const suggest = (model, {query, match, hint}) =>
-  ( model.value !== query
+  ( getUnselectedValue(model) !== query
   ? [model, Effects.none]
   : enterSelectionRange
     ( model
@@ -152,6 +152,13 @@ const suggest = (model, {query, match, hint}) =>
     , match.length
     , 'backward'
     )
+  )
+
+const getUnselectedValue
+  = model =>
+  ( model.selection == null
+  ? model.value
+  : model.value.substr(0, model.selection.start)
   )
 
 export const update =


### PR DESCRIPTION
Fixes #1173

Change 8acb7fd started asserting search query to input value to only update input if query matched the value. This did not take into the account that suggested autocomplete is also part of value and there for changing suggestions would no longer update autocomplete.

This change amends original assertion and compares query only to unselected fragment of value so that completion selections do not affect the assertion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1174)
<!-- Reviewable:end -->
