### PR TITLE
Fix bug in selection update code.

### DIFF
--- a/src/browser/Navigators/Navigator/Input.js
+++ b/src/browser/Navigators/Navigator/Input.js
@@ -28,7 +28,7 @@ export type Model =
   { isVisible: boolean
   , isFocused: boolean
   , value: string
-  , selection: ?Editable.Selection
+  , selection: Editable.Selection
   }
 
 export type Suggestion =
@@ -133,7 +133,11 @@ export const init =
   [ ( { value: flags.value
       , isFocused: !!flags.isFocused
       , isVisible: !!flags.isVisible
-      , selection: null
+      , selection:
+        { start: flags.value.length
+        , end: flags.value.length
+        , direction: 'none'
+        }
       }
     )
   , Effects.none

--- a/src/common/editable.js
+++ b/src/common/editable.js
@@ -26,7 +26,7 @@ export type Selection =
   }
 
 export type Model =
-  { selection: ?Selection
+  { selection: Selection
   , value: string
   }
 
@@ -68,7 +68,7 @@ const clear = <model:Model>
   merge(model, {value: "", selection: null});
 
 export const init =
-  (value:string, selection:?Selection=null):[Model, Effects<Action>] =>
+  (value:string, selection:Selection):[Model, Effects<Action>] =>
   [ { value
     , selection
     }

--- a/src/common/text-input.js
+++ b/src/common/text-input.js
@@ -35,7 +35,7 @@ export type ContextStyle = Rules
 
 export type Model =
   { value: string
-  , selection: ?Editable.Selection
+  , selection: Editable.Selection
   , placeholder: ?string
   , isDisabled: boolean
   , isFocused: boolean
@@ -95,7 +95,14 @@ export const init =
   ):[Model, Effects<Action>] =>
   [ { value
     , placeholder
-    , selection
+    , selection:
+      ( selection == null
+      ? { start: value.length
+        , end: value.length
+        , direction: 'none'
+        }
+      : selection
+      )
     , isDisabled
     , isFocused: false
     }

--- a/src/driver/virtual-dom/index.js
+++ b/src/driver/virtual-dom/index.js
@@ -195,16 +195,30 @@ export const focus = metaBooleanProperty((node, next, previous) => {
 });
 
 
-// Equality checking for selections.
-const isSameSelection = (a, b) =>
-  (a && b && a.start === b.start && a.end === b.end && a.direction === b.direction);
-
 export const selection = metaProperty((node, next, previous) => {
-  if (next != null && !isSameSelection(next, previous)) {
-    const {start, end, direction} = next;
-    node.setSelectionRange(start === Infinity ? node.value.length : start,
-                           end === Infinity ? node.value.length : end,
-                           direction);
+  const {direction} = next
+  const start =
+    ( next.start === Infinity
+    ? node.value.length
+    : next.start
+    );
+  const end =
+    ( next.end === Infinity
+    ? node.value.length
+    : next.end
+    );
+
+  // Note that call to `node.setSelectionRange` triggers `select` event
+  // regardless of whether there was a change in selection. In order to avoid
+  // potential inifinite selection change loop we check if call will actually
+  // change a selection & only perform call if it will.
+  const isUpdateRequired =
+    node.selectionStart !== start ||
+    node.selectionEnd !== end ||
+    node.selectionDirection !== direction
+
+  if (isUpdateRequired) {
+    node.setSelectionRange(start, end, direction);
   }
 });
 


### PR DESCRIPTION
Fixes #1176

Previous code was trying to avoid infinite selection update loop by comparing `previous` and `next` selection ranges and dropping updates if they were equal. This did not properly handled a case where input was updated with different value `value` but equal `selection` as selection update code would run before `select` event would occur. With this change selection change now is determined by comparing `next` selection range to an actual selection on the DOM element, avoiding both infinite loops and above mentioned issue.

This change also makes `selection` field mandatory on models as `null` selection makes things less deterministic and opens possibility for race conditions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1178)
<!-- Reviewable:end -->
