### PR TITLE
Improve type annotation of merge to catch more type mismatches.

### DIFF
--- a/src/about/repl/repl.js
+++ b/src/about/repl/repl.js
@@ -22,7 +22,7 @@ import type {Address, DOM} from "reflex"
 import type {Integer} from "../../common/prelude"
 
 export type Model =
-  { nextID: number
+  { nextID: Integer
   , active: Integer
   , order: [Cell.ID]
   , cells: {[key:Cell.ID]: Cell.Model}
@@ -117,7 +117,7 @@ const createCell =
       ( model
       , { nextID: model.nextID + 1
         , order: [...model.order, id]
-        , active: id
+        , active: model.nextID
         , cells: merge
           ( model.cells
           , {[id]: cell}

--- a/src/browser/Navigators/Navigator/Assistant/history.js
+++ b/src/browser/Navigators/Navigator/Assistant/history.js
@@ -130,7 +130,7 @@ export const init =
 
 const unselect =
   model =>
-  [ merge(model, {selected: null})
+  [ merge(model, {selected: -1})
   , Effects.none
   ]
 

--- a/src/common/prelude.js
+++ b/src/common/prelude.js
@@ -19,9 +19,15 @@ export type Tagged <tag, kind>
     , source: kind
     }
 
-export const merge = <model:{}>
+// Misterious `$Shape` polymorphic type is an experimental flow feature that
+// will likely be replaced in the future with something more generally useful.
+// Type `$Shape<t>` is the type of the objects which include all or a part of
+// the fields of `t` type. In this context this will tell flow to make sure
+// that fields of `patch` are type compatible with a corresponding fields of
+// a `model`.
+export const merge = <model:{}, patch:$Shape<model>>
   ( model:model
-  , changes:{[key:string]: any}
+  , changes:patch
   ):model => {
   let result = model
   for (let key in changes) {


### PR DESCRIPTION
With this changes to `merge` flow ensures that all fields of `patch` are type compatible with corresponding fields of the `model` being patched.

Second commit fixes all the mismatches made apparent by this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1180)
<!-- Reviewable:end -->
