### PR TITLE
Fix type errors introduced by #1180 over #1178

### DIFF
--- a/src/common/editable.js
+++ b/src/common/editable.js
@@ -63,9 +63,18 @@ const change = <model:Model>
   (model:model, value:string, selection:Selection):model =>
   merge(model, {selection, value});
 
+const empty =
+  { value: ""
+  , selection:
+    { start: 0
+    , end: 0
+    , direction: "none"
+    }
+  }
+
 const clear = <model:Model>
   (model:model):model =>
-  merge(model, {value: "", selection: null});
+  merge(model, empty);
 
 export const init =
   (value:string, selection:Selection):[Model, Effects<Action>] =>


### PR DESCRIPTION
In #1180 type annotations of `merge` got improved to handle type mismatches. But #1178 introduced type mismatch that flow was unable to catch until #1180 fixed that. There for landing #1180 start reporting type mismatches.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1181)
<!-- Reviewable:end -->
