### PR TITLE
Update to flow@0.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "pouchdb": "4.0.0",
     "querystring": "0.2.0",
     "reflex": "0.4.1",
-    "reflex-virtual-dom-driver": "0.2.1",
+    "reflex-virtual-dom-driver": "0.2.3",
     "tinycolor2": "1.1.2"
   },
   "devDependencies": {
@@ -52,7 +52,7 @@
     "browserify": "13.0.0",
     "browserify-hmr": "0.3.1",
     "ecstatic": "0.8.0",
-    "flow-bin": "0.27.0",
+    "flow-bin": "0.28.0",
     "gulp": "3.9.1",
     "gulp-sequence": "0.4.5",
     "gulp-sourcemaps": "1.6.0",

--- a/src/about/settings/setting.js
+++ b/src/about/settings/setting.js
@@ -249,7 +249,7 @@ const viewBoolean = (value, address, contextStyle) =>
         : address(Save(!value))
         )
     }
-  , [ `${value}`
+  , [ value.toString()
     ]
   );
 
@@ -263,20 +263,17 @@ const viewJSON = (value, address, contextStyle) =>
   );
 
 const viewValue = (value, address, contextStyle) => {
-  const type = typeof(value)
-
-  const view =
-    ( type === "number"
-    ? viewNumber(value, address, contextStyle)
-    : type === "string"
-    ? viewString(value, address, contextStyle)
-    : type === "boolean"
-    ? viewBoolean(value, address, contextStyle)
-    : viewJSON(value, address, contextStyle)
-    );
-
-  return view
-};
+  switch (typeof(value)) {
+    case "number":
+      return viewNumber(value, address, contextStyle)
+    case "string":
+      return viewString(value, address, contextStyle)
+    case "boolean":
+      return viewBoolean(value, address, contextStyle)
+    default:
+      return viewJSON(value, address, contextStyle)
+  }
+}
 
 const viewInput = TextInput.view
   ( "input"

--- a/src/browser/Navigators/Navigator/Assistant/search.js
+++ b/src/browser/Navigators/Navigator/Assistant/search.js
@@ -141,8 +141,7 @@ const byURI =
 
 const decodeResponseFailure =
   request =>
-  // @FlowIssue: Flow does not know about `request.response`
-  error(Error(`Can not decode ${request.respose} received from ${request.url}`))
+  error(Error(`Can not decode ${request.response} received from ${request.url || ""}`))
 
 const decodeMatches =
   matches =>
@@ -158,11 +157,9 @@ const decodeMatch =
     }
   );
 
-const decodeResponse = ({target: request}) =>
-  // @FlowIssue: Flow does not know about `request.responseType`
+const decodeResponse = (request) =>
   ( request.responseType !== 'json'
-  // @FlowIssue: Flow does not know about `request.url`
-  ? error(Error(`Can not decode ${request.responseType} type response from ${request.url}`))
+  ? error(Error(`Can not decode ${request.responseType} type response from ${request.url || ""}`))
   : request.response == null
   ? decodeResponseFailure(request)
   : request.response[1] == null
@@ -205,7 +202,7 @@ const search =
     };
     request.onload = event => {
       delete pendingRequests[id];
-      const result = decodeResponse(event);
+      const result = decodeResponse(request);
       if (result.isOk) {
         succeed({ queryID: id, matches: result.value });
       } else {

--- a/src/browser/Navigators/Navigator/Assistant/title.js
+++ b/src/browser/Navigators/Navigator/Assistant/title.js
@@ -50,7 +50,10 @@ export const render =
 export const view =
   (title:?string, isSelected:boolean):DOM =>
   thunk
-  ( `${title}`
+  ( ( title == null
+    ? ""
+    : title
+    )
   , render
   , title
   , isSelected

--- a/src/browser/shell.js
+++ b/src/browser/shell.js
@@ -186,7 +186,7 @@ const toggleFullscreen = model =>
 
 
 export const update =
-  (model:Model, action:Action) =>
+  (model:Model, action:Action):[Model, Effects<Action>] =>
   ( action.type === "Focus"
   ? focus(model)
   : action.type === "Blur"

--- a/src/common/keyboard.js
+++ b/src/common/keyboard.js
@@ -139,8 +139,7 @@ const readModifiers = ({type, metaKey, shiftKey, altKey, ctrlKey}) => {
 
 
 const readKey = key => readKey.table[key] || key;
-// @FlowIssue: Sigh..
-readKey.table = Object.assign(Object.create(null), {
+readKey.table = Object.assign((Object.create(null):{[key:string]: string}), {
   'ctrl': 'Control',
   'accel': platform == 'darwin' ? 'meta' : 'control',
   'ArrowLeft': 'Left',

--- a/src/common/prelude.js
+++ b/src/common/prelude.js
@@ -121,9 +121,9 @@ const alwaysSymbol =
   : Symbol('always')
   )
 
-// @FlowIssue: Frow is unable to infer
+// @FlowIssue: #2071
 const Null = () => null;
-// @FlowIssue: Frow is unable to infer
+// @FlowIssue: #2071
 const Void = () => void(0);
 
 export const always = <a> (a:a):(...args:Array<any>)=>a => {
@@ -141,7 +141,7 @@ export const always = <a> (a:a):(...args:Array<any>)=>a => {
     const f = () => value
     f.value = value
     f.toString = Always.toString
-    // @FlowIssue: Flow guards against primitives but we don't care if they're dropped.
+    // @FlowIssue: Flow guards against property assignements on primitives, we know they're ignored and it's fine.
     value[alwaysSymbol] = f
     return f
   }

--- a/src/common/url-helper.js
+++ b/src/common/url-helper.js
@@ -97,7 +97,7 @@ const readSearchURL = input =>
 
 const readAboutURL = input =>
   input === 'about:blank' ? input :
-  `${getBaseURI()}components/about/${input.replace('about:', '')}/index.html`;
+  `${getBaseURI().toString()}components/about/${input.replace('about:', '')}/index.html`;
 
 export const read = (input:string):URI =>
   isNotURL(input) ? readSearchURL(input) :


### PR DESCRIPTION
- Update reflex-virtual-driver that failed on flow@0.28
- Use `toString()` in template string variables with non strings as required in flow@0.28.
- Add missing type annotations.
- Get rid off @FlowIssue suppression comments where possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1183)
<!-- Reviewable:end -->
