### PR TITLE
Re-enable nodeIntegration; use electron preload

### DIFF
--- a/electron-preload.js
+++ b/electron-preload.js
@@ -1,0 +1,9 @@
+window.onerror = null;
+delete global.__dirname;
+delete global.__filename;
+delete global.clearImmediate;
+delete global.module;
+delete global.process;
+delete global.require;
+delete global.setImmediate;
+delete global.global;

--- a/main.js
+++ b/main.js
@@ -53,7 +53,8 @@ var onReady = function() {
     , height: 740
     , frame: false
     , webPreferences:
-      { nodeIntegration: false
+      { nodeIntegration: true
+      , preload: path.resolve(path.join('.'), 'electron-preload.js')
       }
     }
   );


### PR DESCRIPTION
Per the discussion in #1179, this re-enables `nodeIntegration` and runs a `preload` script to delete the node modules (roughly following what happens [here](https://github.com/electron/electron/blob/9f0fc96025fec8948eeb8ca45184891c3d8e485d/lib/renderer/init.js#L85)).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1184)
<!-- Reviewable:end -->
