### PR TITLE
Address port

### DIFF
--- a/src/common/prelude.js
+++ b/src/common/prelude.js
@@ -4,7 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Effects} from "reflex"
+import {Effects, forward} from "reflex"
+import type {Address} from "reflex"
 
 
 export type ID = string
@@ -201,3 +202,11 @@ export const appendFX = <model, action>
   ):[model, Effects<action>] =>
   [model, Effects.batch([fx, extraFX])];
 
+type Port <event, message> =
+  (address:Address<message>) =>
+  Address<event>
+
+export const port = <input, message>
+  (decoder: (incoming:input) => message):Port<input, message> =>
+  (address: Address<message>) =>
+  forward(address, decoder)


### PR DESCRIPTION
## This is part of the #1185 and is based on top of #1196

Utility `port` function allows creation of endpoints to which `address` could be passed.

```js
export const onFocus = port(always({ type: “Focus” }))
html.input({ onFocus: onFocus(address) })
```

Idea is that `Port` instances could be shared and reused across modules.

