### PR TITLE
Address port anotate

### DIFF
--- a/src/common/prelude.js
+++ b/src/common/prelude.js
@@ -206,6 +206,14 @@ type Port <event, message> =
   (address:Address<message>) =>
   Address<event>
 
+
+export const anotate = <tagged, message, event>
+  ( port: Port<event, message>
+  , tag: (input:message) => tagged
+  ):Port<event, tagged> =>
+  (address:Address<tagged>):Address<event> =>
+  port(forward(address, tag))
+
 export const port = <input, message>
   (decoder: (incoming:input) => message):Port<input, message> =>
   (address: Address<message>) =>


### PR DESCRIPTION
## This is part of the #1185 and is based on top of #1197

Utility `anotate` function allows mapping ports such that resulting port will map it's messages via provided `tag` function:

### `Focus.js`
```js
export const onFocus = port(always({ type: “Focus” }))
```

### `Input.js`

```js
import * as Focus from "./Focus"

const tagFocus = message => ({ type: "Focus", focus: message });

// P.S.: Same `tagFocus` is used with `fx.map(tagFx)` 
const onFocus = anotate(Focus.onFocus, tagFocus);

const view = (model, address) =>
  html.input({ onFocus: onFocus(address) /*...*/ })

const update = (model, message) => {
  switch (message.type) {
    case "Focus":
      return setFocus(model, Focus.update(model.focus, message.focus));
      /* ... */
  }
}
```
