### PR TITLE
Make Editable and Focusable embeddable.

### DIFF
--- a/src/common/editable.js
+++ b/src/common/editable.js
@@ -59,7 +59,7 @@ const select = <model:Model>
   (model:model, selection:Selection):model =>
   merge(model, {selection});
 
-const change = <model:Model>
+export const change = <model:Model>
   (model:model, value:string, selection:Selection):model =>
   merge(model, {selection, value});
 
@@ -72,14 +72,21 @@ const empty =
     }
   }
 
-const clear = <model:Model>
+export const clear = <model:Model>
   (model:model):model =>
   merge(model, empty);
 
 export const init =
-  (value:string, selection:Selection):[Model, Effects<Action>] =>
+  (value:string, selection:?Selection=null):[Model, Effects<Action>] =>
   [ { value
-    , selection
+    , selection:
+      ( selection == null
+      ? { start: value.length
+        , end: value.length
+        , direction: "none"
+        }
+      : selection
+      )
     }
   , Effects.none
   ]

--- a/src/common/focusable.js
+++ b/src/common/focusable.js
@@ -26,24 +26,37 @@ export const Blur:Action =
   { type: "Blur"
   };
 
+export const init =
+  (isFocused:boolean=false):[Model, Effects<Action>] =>
+  [ { isFocused }
+  , Effects.none
+  ]
 
 export const update = <model:Model>
   ( model:model, action:Action):[model, Effects<Action>] =>
   ( action.type === "Focus"
-  ? [ merge
-      ( model
-      , { isFocused: true
-        }
-      )
-    , Effects.none
-    ]
+  ? focus(model)
   : action.type === "Blur"
-  ? [ merge
-      ( model
-      , { isFocused: false
-        }
-      )
-    , Effects.none
-    ]
+  ? blur(model)
   : Unknown.update(model, action)
   );
+
+export const focus = <model:Model>
+  ( model:model ):[model, Effects<Action>] =>
+  [ merge
+    ( model
+    , { isFocused: true
+      }
+    )
+  , Effects.none
+  ]
+
+export const blur = <model:Model>
+  ( model:model ):[model, Effects<Action>] =>
+  [ merge
+    ( model
+    , { isFocused: false
+      }
+    )
+  , Effects.none
+  ]


### PR DESCRIPTION
## This is part of the larger #1185 change

Editable and Focusable are implemented as interfaces or components that you need to mix in. This a step towards making them more standard components that can be embedded pretty much like all other components are.