### PR TITLE
Refactor `Input` to avoid mixins.

### DIFF
--- a/src/about/settings/setting.js
+++ b/src/about/settings/setting.js
@@ -12,7 +12,6 @@ import {cursor} from "../../common/cursor"
 import {ok, error} from "../../common/result";
 import * as Unknown from '../../common/unknown';
 import * as Focusable from '../../common/focusable';
-import * as Editable from '../../common/editable';
 import * as TextInput from '../../common/text-input';
 
 
@@ -31,15 +30,9 @@ export type Action =
   | { type: "Edit" }
   | { type: "Abort" }
   | { type: "Submit" }
-  | { type: "Save"
-    , save: Value
-    }
-  | { type: "Change"
-    , change: Value
-    }
-  | { type: "TextInput"
-    , textInput: TextInput.Action
-    }
+  | { type: "Save", save: Value }
+  | { type: "Change", change: Value }
+  | { type: "TextInput", textInput: TextInput.Action }
 
 
 const TextInputAction =
@@ -70,7 +63,7 @@ export const Change =
     }
   );
 
-const FocusInput:Action = TextInputAction(TextInput.Focus);
+const FocusInput:Action = TextInputAction(TextInput.Activate);
 const DisableInput:Action = TextInputAction(TextInput.Disable);
 const EnableInput:Action = TextInputAction(TextInput.Enable);
 const ChangeInput = compose(TextInputAction, TextInput.Change);
@@ -122,7 +115,7 @@ const abort = model =>
   );
 
 const submit = model => {
-  const change = parseInput(model.input.value);
+  const change = parseInput(model.input.edit.value);
   const result =
     ( change.isOk
     ? [ merge(model, {isEditing: false})
@@ -230,7 +223,7 @@ const viewNumber = (value, address, contextStyle) =>
     }
   );
 
-const viewString = (value, address, contextStyle) =>
+const viewString = (value:string, address, contextStyle) =>
   html.code
   ( { style: Style(styleSheet.string, contextStyle)
     , onClick: forward(address, always(Edit))
@@ -239,7 +232,7 @@ const viewString = (value, address, contextStyle) =>
     ]
   );
 
-const viewBoolean = (value, address, contextStyle) =>
+const viewBoolean = (value:boolean, address, contextStyle) =>
   html.code
   ( { style: Style(styleSheet.boolean, contextStyle)
     , onClick:

--- a/src/browser/Navigators/Navigator.js
+++ b/src/browser/Navigators/Navigator.js
@@ -139,21 +139,10 @@ export const Deactivate = { type: "Deactivate" }
 export const Activate = { type: "Activate" }
 export const Deselect = { type: "Deselect" }
 export const Select = { type: "Select" }
-export const FocusInput = { type: "Input", input: Input.Focus }
+export const FocusInput = { type: "Input", input: Input.Activate }
 export const HideInput = { type: "Input", input: Input.Hide }
 export const FocusOutput = { type: "Output", output: Output.Focus }
-export const ClearInput =
-  { type: "Input"
-  , input:
-    { type: "Change"
-    , value: ""
-    , selection:
-      { start: 0
-      , end: 0
-      , direction: "none"
-      }
-    }
-  }
+export const ClearInput = { type: "Input", input: Input.Clear }
 
 const tagInput =
   action => {
@@ -162,7 +151,7 @@ const tagInput =
         return SubmitInput
       case "Abort":
         return EscapeInput
-      case "Focus":
+      case "Activate":
         return ActivateInput
       case "Query":
         return CommitInput
@@ -575,7 +564,7 @@ const commitInput =
   model =>
   updateAssistant
   ( model
-  , Assistant.Query(model.input.value)
+  , Assistant.Query(model.input.edit.value)
   )
 
 const submitInput =
@@ -585,7 +574,7 @@ const submitInput =
   , model
   , [ ResetAssistant
     , FocusOutput
-    , Navigate(model.input.value)
+    , Navigate(model.input.edit.value)
     ]
   );
 

--- a/src/common/editable.js
+++ b/src/common/editable.js
@@ -59,7 +59,7 @@ const select = <model:Model>
   (model:model, selection:Selection):model =>
   merge(model, {selection});
 
-const change = <model:Model>
+export const change = <model:Model>
   (model:model, value:string, selection:Selection):model =>
   merge(model, {selection, value});
 
@@ -72,14 +72,21 @@ const empty =
     }
   }
 
-const clear = <model:Model>
+export const clear = <model:Model>
   (model:model):model =>
   merge(model, empty);
 
 export const init =
-  (value:string, selection:Selection):[Model, Effects<Action>] =>
+  (value:string, selection:?Selection=null):[Model, Effects<Action>] =>
   [ { value
-    , selection
+    , selection:
+      ( selection == null
+      ? { start: value.length
+        , end: value.length
+        , direction: "none"
+        }
+      : selection
+      )
     }
   , Effects.none
   ]

--- a/src/common/focusable.js
+++ b/src/common/focusable.js
@@ -26,24 +26,37 @@ export const Blur:Action =
   { type: "Blur"
   };
 
+export const init =
+  (isFocused:boolean=false):[Model, Effects<Action>] =>
+  [ { isFocused }
+  , Effects.none
+  ]
 
 export const update = <model:Model>
   ( model:model, action:Action):[model, Effects<Action>] =>
   ( action.type === "Focus"
-  ? [ merge
-      ( model
-      , { isFocused: true
-        }
-      )
-    , Effects.none
-    ]
+  ? focus(model)
   : action.type === "Blur"
-  ? [ merge
-      ( model
-      , { isFocused: false
-        }
-      )
-    , Effects.none
-    ]
+  ? blur(model)
   : Unknown.update(model, action)
   );
+
+export const focus = <model:Model>
+  ( model:model ):[model, Effects<Action>] =>
+  [ merge
+    ( model
+    , { isFocused: true
+      }
+    )
+  , Effects.none
+  ]
+
+export const blur = <model:Model>
+  ( model:model ):[model, Effects<Action>] =>
+  [ merge
+    ( model
+    , { isFocused: false
+      }
+    )
+  , Effects.none
+  ]


### PR DESCRIPTION
## This is part of the larger #1185 change & is based off #1201

Refactor `Input` to embed `Focusable`, `Editable` instead of mixing them in.