### PR TITLE
Refactor `Button` to avoid mixins

### DIFF
--- a/src/common/control.js
+++ b/src/common/control.js
@@ -40,6 +40,12 @@ const disable = <model:Model>
   , Effects.none
   ];
 
+export const init =
+  (isDisabled:boolean=false):[Model, Effects<Action>] =>
+  [ {isDisabled}
+  , Effects.none
+  ];
+
 export const update = <model:Model>
   (model:model, action:Action):[model, Effects<Action>] =>
   ( action.type === "Enable"

--- a/src/common/target.js
+++ b/src/common/target.js
@@ -22,6 +22,12 @@ export type Action
 export const Over:Action = {type: "Over"};
 export const Out:Action = {type: "Out"};
 
+export const init =
+  (isPointerOver:boolean=false):[Model, Effects<Action>] =>
+  [ {isPointerOver}
+  , Effects.none
+  ]
+
 export const update = <model:Model>
   (model:model, action:Action):[model, Effects<Action>] =>
   ( action.type == "Over"

--- a/src/common/toggle.js
+++ b/src/common/toggle.js
@@ -177,7 +177,7 @@ export const view =
     onMouseUp: forward(address, always(Up))
   });
 
-export const Activate = ButtonAction(Button.Focus)
+export const Activate = ButtonAction(Button.Focused)
 export const Blur = ButtonAction(Button.Blur)
 export const Over = ButtonAction(Button.Over)
 export const Out = ButtonAction(Button.Out)


### PR DESCRIPTION
## This is part of the larger #1185 change & is based off #1203

Embed `Control`, `Target` & `Focus` modules instead of mixing them in.