### PR TITLE
Make `Focus` implementation monomorphic.

### DIFF
--- a/src/browser/Navigators/Navigator/Input.js
+++ b/src/browser/Navigators/Navigator/Input.js
@@ -7,7 +7,7 @@
 import {html, forward, Effects} from 'reflex';
 import {on, focus as isFocused, selection} from '@driver';
 import {identity} from '../../../lang/functional';
-import {always, merge, nofx, mapFX} from '../../../common/prelude';
+import {always, merge, nofx, mapFX, appendFX, anotate} from '../../../common/prelude';
 import {compose, debounce} from '../../../lang/functional';
 import {cursor} from '../../../common/cursor';
 import * as Focus from '../../../common/focusable';
@@ -462,8 +462,12 @@ export const view =
       selection: selection(model.edit.selection),
       onInput: on(address, readChange),
       onSelect: on(address, readSelect),
-      onFocus: forward(address, always(Activate)),
-      onBlur: forward(address, always(Blur)),
+      onFocus: onFocus(address),
+      onBlur: onBlur(address),
       onKeyDown: on(address, decodeKeyDown)
     })
   ]);
+
+
+const onFocus = anotate(Focus.onFocus, FocusAction)
+const onBlur = anotate(Focus.onBlur, FocusAction)

--- a/src/common/button.js
+++ b/src/common/button.js
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {merge, always, nofx, mapFX} from "../common/prelude"
+import {merge, always, nofx, mapFX, anotate, port} from "../common/prelude"
 import * as Unknown from "../common/unknown"
 import * as Target from "../common/target"
 import * as Focus from "../common/focusable"
@@ -259,8 +259,8 @@ export const view =
       , contextStyle
       ),
 
-    onFocus: forward(address, always(Focused)),
-    onBlur: forward(address, always(Blur)),
+    onFocus: onFocus(address),
+    onBlur: onBlur(address),
 
     onMouseOver: forward(address, always(Over)),
     onMouseOut: forward(address, always(Out)),
@@ -271,3 +271,6 @@ export const view =
   }, [
     model.label
   ]);
+
+export const onFocus = anotate(Focus.onFocus, FocusAction)
+export const onBlur = anotate(Focus.onBlur, FocusAction)

--- a/src/common/focusable.js
+++ b/src/common/focusable.js
@@ -5,58 +5,62 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {merge} from "../common/prelude";
-import * as Unknown from "../common/unknown";
-import {Effects} from "reflex";
+import {always, port} from "../common/prelude"
+import * as Unknown from "../common/unknown"
+import {Effects, forward} from "reflex"
 
+import type {Address} from "reflex"
 
-export type Model =
-  { isFocused: boolean
+export class Model {
+  isFocused: boolean;
+  static focused: Model;
+  static blured: Model;
+  constructor(isFocused:boolean) {
+    this.isFocused = isFocused
   }
+}
+Model.focused = new Model(true)
+Model.blured = new Model(false)
 
 export type Action =
   | { type: "Focus" }
   | { type: "Blur" }
 
-export const Focus:Action =
-  { type:"Focus"
-  };
-
-export const Blur:Action =
-  { type: "Blur"
-  };
+export const Focus = { type:"Focus" }
+export const Blur = { type: "Blur" }
 
 export const init =
   (isFocused:boolean=false):[Model, Effects<Action>] =>
-  [ { isFocused }
-  , Effects.none
-  ]
-
-export const update = <model:Model>
-  ( model:model, action:Action):[model, Effects<Action>] =>
-  ( action.type === "Focus"
-  ? focus(model)
-  : action.type === "Blur"
-  ? blur(model)
-  : Unknown.update(model, action)
-  );
-
-export const focus = <model:Model>
-  ( model:model ):[model, Effects<Action>] =>
-  [ merge
-    ( model
-    , { isFocused: true
-      }
+  [ ( isFocused
+    ? Model.focused
+    : Model.blured
     )
   , Effects.none
   ]
 
-export const blur = <model:Model>
-  ( model:model ):[model, Effects<Action>] =>
-  [ merge
-    ( model
-    , { isFocused: false
-      }
-    )
+export const update =
+  ( model:Model, action:Action):[Model, Effects<Action>] => {
+    switch (action.type) {
+      case "Focus":
+        return focus(model)
+      case "Blur":
+        return blur(model)
+      default:
+        return Unknown.update(model, action)
+    }
+  };
+
+export const focus =
+  (model:Model):[Model, Effects<Action>] =>
+  [ Model.focused
   , Effects.none
   ]
+
+export const blur =
+  (model:Model):[Model, Effects<Action>] =>
+  [ Model.blured
+  , Effects.none
+  ]
+
+export const onFocus = port(always(Focus));
+export const onBlur = port(always(Blur));

--- a/src/common/text-input.js
+++ b/src/common/text-input.js
@@ -7,7 +7,7 @@
 import {html, forward, Effects} from 'reflex';
 import {Style} from '../common/style';
 import {compose} from '../lang/functional';
-import {tag, tagged, mapFX, merge, always} from '../common/prelude';
+import {tag, tagged, anotate, mapFX, always} from '../common/prelude';
 import * as Unknown from '../common/unknown';
 import * as Focus from '../common/focusable';
 import * as Edit from '../common/editable';
@@ -218,8 +218,8 @@ export function view(key:string,
     , onInput: on(address, decodeChange)
     , onKeyUp: on(address, decodeSelect)
     , onSelect: on(address, decodeSelect)
-    , onFocus: forward(address, always(Activate))
-    , onBlur: forward(address, always(Deactivate))
+    , onFocus: onFocus(address)
+    , onBlur: onBlur(address)
     , style: Style
       ( styleSheet.base
       , ( model.isDisabled
@@ -231,3 +231,6 @@ export function view(key:string,
     }
   )
 }
+
+export const onFocus = anotate(Focus.onFocus, FocusAction)
+export const onBlur = anotate(Focus.onBlur, FocusAction)

--- a/src/common/toggle.js
+++ b/src/common/toggle.js
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-import {merge, always, nofx, mapFX} from "../common/prelude"
+import {tag, tagged, anotate, nofx, mapFX, always} from '../common/prelude';
 import * as Unknown from "../common/unknown"
 import * as Target from "../common/target"
 import * as Focus from "../common/focusable"
@@ -168,8 +168,8 @@ export const view =
       , contextStyle
       ),
 
-    onFocus: forward(address, always(Activate)),
-    onBlur: forward(address, always(Blur)),
+    onFocus: onFocus(address),
+    onBlur: onBlur(address),
     onMouseOver: forward(address, always(Over)),
     onMouseOut: forward(address, always(Out)),
     onClick: forward(address, always(Click)),
@@ -184,3 +184,6 @@ export const Out = ButtonAction(Button.Out)
 export const Click = ButtonAction(Button.Press)
 export const Down = ButtonAction(Button.Down)
 export const Up = ButtonAction(Button.Up)
+
+export const onFocus = anotate(Focus.onFocus, ButtonAction)
+export const onBlur = anotate(Focus.onBlur, ButtonAction)


### PR DESCRIPTION
## This is part of the larger #1185 change & is based off #1204

Make `Focus` implementation monomorphic.