### PR TITLE
Make `Target` implementation monomorphic.

### DIFF
--- a/src/common/button.js
+++ b/src/common/button.js
@@ -274,3 +274,5 @@ export const view =
 
 export const onFocus = anotate(Focus.onFocus, FocusAction)
 export const onBlur = anotate(Focus.onBlur, FocusAction)
+export const onMouseOver = anotate(Target.onMouseOver, TargetAction)
+export const onMouseOut = anotate(Target.onMouseOut, TargetAction)

--- a/src/common/toggle.js
+++ b/src/common/toggle.js
@@ -170,8 +170,8 @@ export const view =
 
     onFocus: onFocus(address),
     onBlur: onBlur(address),
-    onMouseOver: forward(address, always(Over)),
-    onMouseOut: forward(address, always(Out)),
+    onMouseOver: onMouseOver(address),
+    onMouseOut: onMouseOut(address),
     onClick: forward(address, always(Click)),
     onMouseDown: forward(address, always(Down)),
     onMouseUp: forward(address, always(Up))
@@ -187,3 +187,5 @@ export const Up = ButtonAction(Button.Up)
 
 export const onFocus = anotate(Focus.onFocus, ButtonAction)
 export const onBlur = anotate(Focus.onBlur, ButtonAction)
+export const onMouseOver = anotate(Button.onMouseOver, ButtonAction)
+export const onMouseOut = anotate(Button.onMouseOut, ButtonAction)


### PR DESCRIPTION
## This is part of the larger #1185 change & is based off #1206

Make `Target` implementation monomorphic.