### PR TITLE
Use iframe.setVisibile on mozbrowser iframes

### DIFF
--- a/src/browser/Navigators/Navigator.js
+++ b/src/browser/Navigators/Navigator.js
@@ -910,7 +910,7 @@ export const render =
       , styleBackground(model.output)
       )
     }
-  , [ Output.view(model.output, forward(address, tagOutput))
+  , [ Output.view(model.isSelected, model.output, forward(address, tagOutput))
     , Overlay.view(model.overlay, forward(address, tagOverlay))
     , Assistant.view(model.assistant, forward(address, tagAssistant))
     , Header.view
@@ -953,7 +953,8 @@ const styleSheet = Style.createSheet
       , transitionDuration: '300ms'
       }
     , selected:
-      { zIndex: 2 }
+      { zIndex: 2
+      }
     , unselected:
       { zIndex: 1
       , visibility: 'hidden'

--- a/src/browser/Navigators/Navigator/WebView.js
+++ b/src/browser/Navigators/Navigator/WebView.js
@@ -490,5 +490,5 @@ const Frame =
 
 
 export const view =
-  (model:Model, address:Address<Action>):DOM =>
-  Frame.view(styleSheet, model, address);
+  (isSelected:boolean, model:Model, address:Address<Action>):DOM =>
+  Frame.view(styleSheet, isSelected, model, address);

--- a/src/browser/Navigators/Navigator/WebView/ElectronFrame.js
+++ b/src/browser/Navigators/Navigator/WebView/ElectronFrame.js
@@ -24,6 +24,7 @@ const DocumentFirstPaint = always({ type: "DocumentFirstPaint" });
 
 export const view =
   ( styleSheet:{ base: Style.Rules }
+  , selected:boolean
   , model:Model
   , address:Address<Action>
   ):DOM =>

--- a/src/browser/Navigators/Navigator/WebView/MozBrowserFrame.js
+++ b/src/browser/Navigators/Navigator/WebView/MozBrowserFrame.js
@@ -1,10 +1,14 @@
 /* @flow */
 
-import {Effects, node, html, forward} from 'reflex';
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {Effects, Task, node, html, forward} from 'reflex';
 import * as URL from '../../../../common/url-helper';
 import * as Driver from '@driver';
 import * as Style from '../../../../common/style';
-import {on} from '@driver';
+import {on, setting} from '@driver';
 import {always} from '../../../../common/prelude';
 
 
@@ -12,7 +16,6 @@ import {always} from '../../../../common/prelude';
 import type {Address, DOM} from "reflex"
 import type {Model, Action} from "../WebView"
 import {performance} from "../../../../common/performance"
-
 
 const Blur = always({ type: "Blur" });
 const Focus = always({ type: "Focus" });
@@ -22,6 +25,7 @@ const DocumentFirstPaint = always({ type: "DocumentFirstPaint" });
 
 export const view =
   ( styleSheet:{ base: Style.Rules }
+  , selected:boolean
   , model:Model
   , address:Address<Action>
   ):DOM =>
@@ -49,6 +53,7 @@ export const view =
         )
       , mozallowfullscreen: true
       }
+    , visibility: setting(visibility, selected)
 
     // Events
 
@@ -256,3 +261,10 @@ const frameStyleSheet = Style.createSheet
       }
     }
   );
+
+const visibility = (element:HTMLElement, visible:boolean) =>
+  new Task((succeed, fail) => {
+    if (typeof(element.setVisible) === "function") {
+      element.setVisible(visible)
+    }
+  })

--- a/src/driver/virtual-dom/index.js
+++ b/src/driver/virtual-dom/index.js
@@ -148,6 +148,34 @@ class MetaProperty {
 export const metaProperty = update => value =>
   new MetaProperty(value, update)
 
+type Setter <data, element:HTMLElement> =
+  (target:element, value:data) => Task<Never, void>
+
+class Setting <data, element:HTMLElement> {
+  value: data;
+  setter: Setter<data, element>;
+  constructor(setter:Setter<data, element>, value:data) {
+    this.value = value
+    this.setter = setter
+  }
+  hook(node, name, previous) {
+    this
+      .setter(node, this.value)
+      .fork(this.onSucceed, this.onFail);
+  }
+  onFail(error) {
+    console.error(error);
+  }
+  onSucceed() {
+
+  }
+}
+
+
+export const setting = <element:HTMLElement, data>
+  ( setter:Setter<data, element>
+  , value:data
+  ) => new Setting(setter, value)
 
 // Bunch of meta properties are booleans, meaning they can be toggled on
 // or off. This function is an optimized version of metaProperty for such


### PR DESCRIPTION
Set visibility on/of if frame is / isn’t selected.

First commit also adds a generic hook into virtual-dom, that runs a task with corresponding DOM element and passed value to do custom modifications when patch is applied.

I have being testing this feature via command:

```
/Applications/Servo.app/Contents/MacOS/servo -w -b --pref dom.mozbrowser.enabled --pref dom.forcetouch.enabled --pref  shell.builtin-key-shortcuts.enabled=false http://localhost:6060\?url\=https://Gozala.jsbin.com/mudum
```

Open tab increments number on animation frames, so if you switch to other tab it will stop incrementing & resume when you're back.


P.S.: I will do a followup to use same `setting` hook for other workarounds we currently have.
