### PR TITLE
Provide type annotations for @driver module

### DIFF
--- a/src/browser/Navigators/Navigator.js
+++ b/src/browser/Navigators/Navigator.js
@@ -910,7 +910,7 @@ export const render =
       , styleBackground(model.output)
       )
     }
-  , [ Output.view(model.output, forward(address, tagOutput))
+  , [ Output.view(model.isSelected, model.output, forward(address, tagOutput))
     , Overlay.view(model.overlay, forward(address, tagOverlay))
     , Assistant.view(model.assistant, forward(address, tagAssistant))
     , Header.view
@@ -953,7 +953,8 @@ const styleSheet = Style.createSheet
       , transitionDuration: '300ms'
       }
     , selected:
-      { zIndex: 2 }
+      { zIndex: 2
+      }
     , unselected:
       { zIndex: 1
       , visibility: 'hidden'

--- a/src/browser/Navigators/Navigator/WebView.js
+++ b/src/browser/Navigators/Navigator/WebView.js
@@ -490,5 +490,5 @@ const Frame =
 
 
 export const view =
-  (model:Model, address:Address<Action>):DOM =>
-  Frame.view(styleSheet, model, address);
+  (isSelected:boolean, model:Model, address:Address<Action>):DOM =>
+  Frame.view(styleSheet, isSelected, model, address);

--- a/src/browser/Navigators/Navigator/WebView/ElectronFrame.js
+++ b/src/browser/Navigators/Navigator/WebView/ElectronFrame.js
@@ -24,6 +24,7 @@ const DocumentFirstPaint = always({ type: "DocumentFirstPaint" });
 
 export const view =
   ( styleSheet:{ base: Style.Rules }
+  , selected:boolean
   , model:Model
   , address:Address<Action>
   ):DOM =>

--- a/src/browser/Navigators/Navigator/WebView/MozBrowserFrame.js
+++ b/src/browser/Navigators/Navigator/WebView/MozBrowserFrame.js
@@ -1,10 +1,14 @@
 /* @flow */
 
-import {Effects, node, html, forward} from 'reflex';
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {Effects, Task, node, html, forward} from 'reflex';
 import * as URL from '../../../../common/url-helper';
 import * as Driver from '@driver';
 import * as Style from '../../../../common/style';
-import {on} from '@driver';
+import {on, setting} from '@driver';
 import {always} from '../../../../common/prelude';
 
 
@@ -12,7 +16,6 @@ import {always} from '../../../../common/prelude';
 import type {Address, DOM} from "reflex"
 import type {Model, Action} from "../WebView"
 import {performance} from "../../../../common/performance"
-
 
 const Blur = always({ type: "Blur" });
 const Focus = always({ type: "Focus" });
@@ -22,6 +25,7 @@ const DocumentFirstPaint = always({ type: "DocumentFirstPaint" });
 
 export const view =
   ( styleSheet:{ base: Style.Rules }
+  , selected:boolean
   , model:Model
   , address:Address<Action>
   ):DOM =>
@@ -49,6 +53,7 @@ export const view =
         )
       , mozallowfullscreen: true
       }
+    , visibility: setting(visibility, selected)
 
     // Events
 
@@ -256,3 +261,10 @@ const frameStyleSheet = Style.createSheet
       }
     }
   );
+
+const visibility = (element:HTMLElement, visible:boolean) =>
+  new Task((succeed, fail) => {
+    if (typeof(element.setVisible) === "function") {
+      element.setVisible(visible)
+    }
+  })

--- a/src/common/keyboard.js
+++ b/src/common/keyboard.js
@@ -11,19 +11,6 @@ export type kind =
   | "KeyDown"
   | "KeyPress"
 
-export type Abort =
-  { type: "AbortEvent"
-  , action:
-    { type: kind
-    , combination: string
-    , key: string
-    , metaKey: boolean
-    , shiftKey: boolean
-    , altKey: boolean
-    , ctrlKey: boolean
-    }
-  }
-
 export type BindingTable <Action> =
   { [key:string]: (event:KeyboardEvent) => Action
   }
@@ -176,7 +163,7 @@ const writeChord = event => {
 
 
 export const bindings = <Action>
-  (bindingTable:BindingTable<Action>):(event:KeyboardEvent) => Action | Abort => {
+  (bindingTable:BindingTable<Action>):(event:KeyboardEvent) => ?Action => {
   const bindings = Object.create(null);
   Object.keys(bindingTable).forEach(key => {
     bindings[readChord(key)] = bindingTable[key];
@@ -192,23 +179,7 @@ export const bindings = <Action>
       return binding(event);
     }
     else {
-      return {
-        type: "AbortEvent"
-      , action:
-        { type
-            : event.type === "keyup"
-            ? "KeyUp"
-            : event.type === "keydown"
-            ? "KeyDown"
-            : "KeyPress"
-        , combination: combination
-        , key: event.key
-        , metaKey: event.metaKey
-        , shiftKey: event.shiftKey
-        , altKey: event.altKey
-        , ctrlKey: event.ctrlKey
-        }
-      };
+      return null
     }
   };
 };

--- a/src/driver/virtual-dom/index.js
+++ b/src/driver/virtual-dom/index.js
@@ -148,6 +148,34 @@ class MetaProperty {
 export const metaProperty = update => value =>
   new MetaProperty(value, update)
 
+type Setter <data, element:HTMLElement> =
+  (target:element, value:data) => Task<Never, void>
+
+class Setting <data, element:HTMLElement> {
+  value: data;
+  setter: Setter<data, element>;
+  constructor(setter:Setter<data, element>, value:data) {
+    this.value = value
+    this.setter = setter
+  }
+  hook(node, name, previous) {
+    this
+      .setter(node, this.value)
+      .fork(this.onSucceed, this.onFail);
+  }
+  onFail(error) {
+    console.error(error);
+  }
+  onSucceed() {
+
+  }
+}
+
+
+export const setting = <element:HTMLElement, data>
+  ( setter:Setter<data, element>
+  , value:data
+  ) => new Setting(setter, value)
 
 // Bunch of meta properties are booleans, meaning they can be toggled on
 // or off. This function is an optimized version of metaProperty for such

--- a/src/driver/virtual-dom/index.js
+++ b/src/driver/virtual-dom/index.js
@@ -20,7 +20,7 @@ class On {
         void(0) :
         handler.decode(event)
 
-      if (data == null || data.type !== "AbortEvent") {
+      if (data !== null) {
         if (handler.stopPropagation) {
           if (handler.stopPropagation(data)) {
             event.stopPropagation()

--- a/src/driver/virtual-dom/index.js.flow
+++ b/src/driver/virtual-dom/index.js.flow
@@ -1,0 +1,51 @@
+/* @flow */
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type {Address, Task, Never} from "reflex"
+
+export {Renderer} from "reflex-virtual-dom-driver"
+
+type Mapper <from, to> =
+  (input:from) => to
+
+type ListenerOption <data> =
+  { stopPropagation?: (input:data) => boolean
+  , preventDefault?: (input:data) => boolean
+  }
+
+type Property =
+  | Property
+
+declare export function on <message, element:HTMLElement, event:Event>
+  ( address:Address<message>
+  , decode?:Mapper<event, ?message>
+  , options?:ListenerOption<message>
+  , getTarget?:(source:element) => HTMLElement
+  ):Property
+
+declare export function onWindow <message, event:Event>
+  ( address:Address<message>
+  , decode?:Mapper<event, ?message>
+  , options?:ListenerOption<message>
+  ):Property
+
+declare export function focus (value:boolean):Property
+
+type Selection =
+  { start: number
+  , end: number
+  , direction: 'forward' | 'backward' | 'none'
+  }
+
+declare export function selection (value:Selection):Property
+
+type Setter <data, element:HTMLElement> =
+  (target:element, value:data) => Task<Never, void>
+
+declare export function setting <element:HTMLElement, data>
+  ( setter:Setter<data, element>
+  , value:data
+  ):Property


### PR DESCRIPTION
This change follows up on #1213 so please ignore first two commits. It also does two changes:

1. Creates `index.js.flow` so flow can ensure that `@driver` module is used properly.
2. Special `Abort` type is replaced with `null` which aborts feeding event back into update loop. This change was done as otherwise type annotations were becoming too complex and was not worth it.