### PR TITLE
Use xcopy on windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,14 +4,38 @@
 
 use std::env;
 use std::process::Command;
+use std::path::PathBuf;
 
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
+    let target = env::var("TARGET").unwrap();
 
-
-    assert!(Command::new("cp")
-            .args(&["-R", "index.html", "css", "components", &out_dir])
-            .status()
-            .unwrap()
-            .success());
+    if target.contains("windows") {
+        // sigh
+        let mut css_dir = PathBuf::from(&out_dir);
+        css_dir.push("css");
+        let mut components_dir = PathBuf::from(&out_dir);
+        components_dir.push("components");
+        assert!(Command::new("xcopy")
+                .args(&["/QY", "index.html", &out_dir])
+                .status()
+                .unwrap()
+                .success());
+        assert!(Command::new("xcopy")
+                .args(&["/EQIY", "components", components_dir.to_str().unwrap()])
+                .status()
+                .unwrap()
+                .success());
+        assert!(Command::new("xcopy")
+                .args(&["/EQIY", "css", css_dir.to_str().unwrap()])
+                .status()
+                .unwrap()
+                .success());
+    } else {
+        assert!(Command::new("cp")
+                .args(&["-R", "index.html", "css", "components", &out_dir])
+                .status()
+                .unwrap()
+                .success());
+    }
 }


### PR DESCRIPTION
On windows, if we're building without a full msys-like environment, we can't do cp -r.  This has build.rs use xcopy in this case.