### PR TITLE
Workaround iframe API limitations at the DOM level.

### DIFF
--- a/src/browser/Navigators/Navigator.js
+++ b/src/browser/Navigators/Navigator.js
@@ -694,11 +694,11 @@ const editInput =
   ( update
   , model
   , [ ActivateInput
-      // @TODO: Do not use `model.output.navigation.currentURI` as it ties it
+      // @TODO: Do not use `model.output.navigation.url` as it ties it
       // to webView API too much.
     , ( model.isInputEmbedded
       ? SetSelectedInputValue('')
-      : SetSelectedInputValue(model.output.navigation.currentURI)
+      : SetSelectedInputValue(model.output.navigation.url)
       )
     ]
   )

--- a/src/browser/Navigators/Navigator/WebView/ElectronFrame.js
+++ b/src/browser/Navigators/Navigator/WebView/ElectronFrame.js
@@ -1,10 +1,10 @@
 /* @flow */
 
-import {Effects, node, html, forward} from 'reflex';
+import {Effects, Task, node, html, forward} from 'reflex';
 import * as URL from '../../../../common/url-helper';
 import * as Driver from '@driver';
 import * as Style from '../../../../common/style';
-import {on} from '@driver';
+import {on, setting} from '@driver';
 import {always} from '../../../../common/prelude';
 
 
@@ -31,8 +31,7 @@ export const view =
   node
   ( 'webview'
   , { [model.ref.name]: model.ref.value
-    , src: model.navigation.src
-    , 'data-current-uri': model.navigation.currentURI
+    , location: setting(location, model.navigation.url)
     , 'data-name': model.name
     , 'data-features': model.features
     // Stock electron does not actually connect a window with it's opener in any
@@ -166,3 +165,23 @@ const decodeMetaChange =
     , content: event.themeColor
     }
   );
+
+
+const location =
+  (element, url) =>
+  new Task((succeed, fail) => {
+    if (!element.onURLChange) {
+      element.onURLChange = onURLChange
+      element.addEventListener("did-navigate", onURLChange)
+    }
+
+    if (element.dataset.url !== url) {
+      element.setAttribute('src', url)
+    }
+
+    element.dataset.url = url
+  })
+
+const onURLChange =
+  event =>
+  event.target.dataset.url = event.url

--- a/src/browser/Navigators/Navigator/WebView/Util.js
+++ b/src/browser/Navigators/Navigator/WebView/Util.js
@@ -15,8 +15,8 @@ export const readTitle =
       model.page.title !== ''
     )
   ? model.page.title
-  : model.navigation.currentURI.search(/^\s*$/)
-  ? URI.prettify(model.navigation.currentURI)
+  : model.navigation.url.search(/^\s*$/)
+  ? URI.prettify(model.navigation.url)
   : fallback
   );
 
@@ -24,7 +24,7 @@ export const readFaviconURI =
   (model:WebViewModel):string =>
   ( (model.page && model.page.faviconURI)
   ? model.page.faviconURI
-  : Favicon.getFallback(model.navigation.currentURI)
+  : Favicon.getFallback(model.navigation.url)
   );
 
 export const isDark =


### PR DESCRIPTION
We used to keep track `src` and currently loaded `url` as separate fields in the model so that we would only update `src` when user edited url. But that logic had a major issue #949:

If user initial loads url `a` than navigates to `b` by clicking a link and then edits url to navigate to `a` nothing would happen. That is because Virtual DOM would diff and see that src in both cases is `a` and do not update `iframe.src`.

With this change we use `setting(location, url)` for updating `iframe.src`. As of `location` setter it keeps track of iframe location and only reflects passed `url` if it is different from it.

This approach fixes #949 and makes state model simpler.