### PR TITLE
Use xcopy only with msvc target, as dir paths are different with mingw

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -325,7 +325,7 @@ fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let target = env::var("TARGET").unwrap();
 
-    if target.contains("windows") {
+    if target.contains("msvc") {
         // sigh
         let mut css_dir = PathBuf::from(&out_dir);
         css_dir.push("css");

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "browser.html",
   "description": "Experimental Servo browser built in HTML",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "homepage": "https://github.com/browserhtml/browserhtml",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This needs to just be for msvc, as for mingw dir paths get specified using mingw syntax. Sigh.