### PR TITLE
Implement fallback icons

### DIFF
--- a/src/browser/Navigators/Navigator/WebView.js
+++ b/src/browser/Navigators/Navigator/WebView.js
@@ -25,11 +25,11 @@ import * as MozBrowserFrame from './WebView/MozBrowserFrame';
 import * as ElectronFrame from './WebView/ElectronFrame';
 import * as Ref from '../../../common/ref';
 import * as Tab from '../../Sidebar/Tab';
+import * as Favicon from '../../../common/favicon';
 
 
 import type {Address, DOM} from "reflex"
 import type {URI, Time, Integer, Float} from "../../../common/prelude"
-import type {Icon} from "../../../common/favicon"
 import {performance} from "../../../common/performance"
 import type {Report} from "../../IssueReporter"
 
@@ -73,7 +73,7 @@ export type Action =
   | { type: "FirstPaint" }
   | { type: "DocumentFirstPaint" }
   | { type: "MetaChanged", name: string, content: string }
-  | { type: "IconChanged", icon: Icon }
+  | { type: "IconChanged", icon: Favicon.Model }
   | { type: "TitleChanged", title: string }
   | { type: "SecurityChanged"
     , state: "broken" | "secure" | "insecure"
@@ -270,6 +270,8 @@ const TabAction = action => {
         return Close;
       case "Select":
         return Select;
+      case "Page":
+        return PageAction(action.page);
       default:
         return {
           type: "Tab"
@@ -285,6 +287,17 @@ const updatePage = cursor
     , update: Page.update
     }
   );
+
+const delegateTabUpdate =
+  (model, action) => {
+    switch (action.type) {
+      case "Page":
+        return updatePage(model, action.page)
+      default:
+        return updateTab(model, action)
+
+    }
+  }
 
 const updateTab = cursor
   ( { get: model => model.tab
@@ -455,7 +468,7 @@ export const update =
       case "Page":
         return updatePage(model, action.page);
       case "Tab":
-        return updateTab(model, action.tab);
+        return delegateTabUpdate(model, action.tab);
       case "Security":
         return updateSecurity(model, action.security);
       case "Navigation":

--- a/src/browser/Navigators/Navigator/WebView.js
+++ b/src/browser/Navigators/Navigator/WebView.js
@@ -295,7 +295,6 @@ const delegateTabUpdate =
         return updatePage(model, action.page)
       default:
         return updateTab(model, action)
-
     }
   }
 

--- a/src/browser/Navigators/Navigator/WebView/Page.js
+++ b/src/browser/Navigators/Navigator/WebView/Page.js
@@ -4,16 +4,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {Effects, Task} from 'reflex';
-import {merge} from '../../../../common/prelude';
+import {Effects, Task, forward, thunk} from 'reflex';
+import {merge, nofx} from '../../../../common/prelude';
+import {cursor} from '../../../../common/cursor';
 import * as Favicon from '../../../../common/favicon';
+import * as Image from '../../../../common/image';
 import * as Pallet from '../../../../browser/pallet';
 import * as Unknown from '../../../../common/unknown';
 import * as Ref from '../../../../common/ref';
-
+import * as Sign from './Page/Sign';
+import * as Icon from './Page/Icon';
+import * as URL from '../../../../common/url-helper'
 
 import type {URI} from "../../../../common/prelude"
-import type {Icon} from "../../../../common/favicon"
+import type {Address, DOM} from "reflex"
 
 export type Action =
   | { type: "LoadStart" }
@@ -21,9 +25,9 @@ export type Action =
   | { type: "TitleChanged"
     , title: string
     }
-  | { type: "IconChanged"
-    , icon: Icon
-    }
+  | { type: "IconChanged", icon: Favicon.Model }
+  | { type: "IconLoadError" }
+  | { type: "Icon", icon: Icon.Action }
   | { type: "MetaChanged"
     , name: string
     , content: string
@@ -46,22 +50,24 @@ export type Action =
 
 
 export class Model {
-  
+
   uri: URI;
-  title: ?string;
-  faviconURI: ?URI;
-  icon: ?Icon;
+  title: string;
+  icon: ?Image.Model;
+  favicon: ?Favicon.Model;
+  sign: Sign.Model;
 
   themeColor: ?string;
   curatedColor: ?Pallet.Theme;
 
   pallet: Pallet.Model;
-  
+
   constructor(
     uri: URI
-  , title: ?string
-  , faviconURI: ?URI
-  , icon: ?Icon
+  , title: string
+  , icon: ?Image.Model
+  , favicon: ?Favicon.Model
+  , sign: Sign.Model
 
   , themeColor: ?string
   , curatedColor: ?Pallet.Theme
@@ -70,8 +76,9 @@ export class Model {
   ) {
     this.uri = uri
     this.title = title
-    this.faviconURI = faviconURI
     this.icon = icon
+    this.favicon = favicon
+    this.sign = sign
     this.themeColor = themeColor
     this.curatedColor = curatedColor
     this.pallet = pallet
@@ -94,7 +101,7 @@ export const TitleChanged =
  ({type: "TitleChanged", title});
 
 export const IconChanged =
-  (icon:Icon):Action =>
+  (icon:Favicon.Model):Action =>
   ({type: "IconChanged", icon});
 
 export const OverflowChanged =
@@ -122,20 +129,38 @@ export const LocationChanged =
   (uri:URI):Action =>
   ({type: "LocationChanged", uri});
 
+const IconAction =
+  action => {
+    switch (action.type) {
+      case "Error":
+        return IconLoadError
+      default:
+        return { type: "Icon", icon: action }
+    }
+  }
 
-const updateIcon = (model, {icon}) => {
-  const {bestIcon, faviconURI} =
-    ( model.icon == null
-    ? Favicon.getBestIcon([icon])
-    : Favicon.getBestIcon([model.icon, icon])
+const IconLoadError = { type: "IconLoadError" }
+
+const iconChanged = (model, newFavicon) => {
+  const favicon =
+    ( model.favicon == null
+    ? Favicon.getBestIcon([newFavicon])
+    : Favicon.getBestIcon([model.favicon, newFavicon])
     );
+
+    const icon =
+    ( favicon == null
+    ? new Image.Model(Favicon.getFallback(model.uri))
+    : new Image.Model(Favicon.createURL(favicon))
+    )
 
   return [
     new Model
     ( model.uri
     , model.title
-    , faviconURI
-    , bestIcon
+    , icon
+    , favicon
+    , model.sign
     , model.themeColor
     , model.curatedColor
     , model.pallet
@@ -144,14 +169,59 @@ const updateIcon = (model, {icon}) => {
   ];
 };
 
+const iconLoadError =
+  model =>
+  nofx
+  ( new Model
+    ( model.uri
+    , model.title
+    , null
+    , null
+    , model.sign
+    , model.themeColor
+    , model.curatedColor
+    , model.pallet
+    )
+  )
+
+const updateIcon = cursor
+  ( { get: (model) => model.icon
+    , set: (model, icon) =>
+      new Model
+      ( model.uri
+      , model.title
+      , icon
+      , model.favicon
+      , model.sign
+      , model.themeColor
+      , model.curatedColor
+      , model.pallet
+      )
+    , update:
+        (icon, message) => {
+          if (icon == null) {
+            return nofx(icon)
+          }
+          else {
+            // Note: Need to reconstruct due to bug in flow
+            // https://github.com/facebook/flow/issues/2253
+            const [model, fx] = Icon.update(icon, message)
+            return [model, fx]
+          }
+        }
+    , tag: IconAction
+    }
+  );
+
 const updateMeta =
   (model, {name, content}) =>
   [ ( name === 'theme-color'
     ? new Model
       ( model.uri
       , model.title
-      , model.faviconURI
       , model.icon
+      , model.favicon
+      , model.sign
       , content
       , model.curatedColor
       , model.pallet
@@ -161,23 +231,50 @@ const updateMeta =
   , Effects.none
   ];
 
-const updatePallet = (model, _) =>
+const updatePallet =
+  (model, _) =>
+  swapPallet
+  ( model
+  , ( model.curatedColor != null
+    ? Pallet.create
+      ( model.curatedColor.background
+      , model.curatedColor.foreground
+      )
+    : model.themeColor != null
+    ? Pallet.create(...`${model.themeColor}|`.split('|'))
+    : Pallet.blank
+    )
+  );
+
+const chooseInital =
+  (hostname:string, title:string) =>
+  ( hostname == ""
+  ? title
+  : hostname
+  ).substr(0, 1).toUpperCase()
+
+
+const swapPallet =
+  (model, pallet) =>
   [ new Model
     ( model.uri
     , model.title
-    , model.faviconURI
     , model.icon
+    , model.favicon
+    , Sign.init
+      ( chooseInital(URL.getHostname(model.uri), model.title)
+      , pallet.background
+      , ( pallet.foreground == ""
+        ? ( pallet.isDark
+          ? Sign.dark.foreground
+          : Sign.bright.foreground
+          )
+        : pallet.foreground
+        )
+      )
     , model.themeColor
     , model.curatedColor
-    , ( model.curatedColor != null
-      ? Pallet.create
-        ( model.curatedColor.background
-        , model.curatedColor.foreground
-        )
-      : model.themeColor != null
-      ? Pallet.create(...`${model.themeColor}|'`.split('|'))
-      : Pallet.blank
-      )
+    , pallet
     )
   , Effects.none
   ];
@@ -186,9 +283,10 @@ export const init =
   (uri:URI):[Model, Effects<Action>] =>
   [ new Model
     ( uri
+    , ""
     , null
     , null
-    , null
+    , Sign.blank
 
     , null
     , null
@@ -202,9 +300,10 @@ const loadStart =
   model =>
   [ new Model
     ( model.uri
+    , ""
     , null
     , null
-    , null
+    , Sign.blank
 
     , null
     , null
@@ -221,8 +320,9 @@ const updateTitle =
   [ new Model
     ( model.uri
     , title
-    , model.faviconURI
     , model.icon
+    , model.favicon
+    , model.sign
     , model.themeColor
     , model.curatedColor
     , model.pallet
@@ -235,8 +335,9 @@ const updateCuratedColor =
   [ new Model
     ( model.uri
     , model.title
-    , model.faviconURI
     , model.icon
+    , model.favicon
+    , model.sign
     , model.themeColor
     , color
     , model.pallet
@@ -255,8 +356,9 @@ const updateURI =
   : [ new Model
       ( uri
       , model.title
-      , model.faviconURI
       , model.icon
+      , model.favicon
+      , model.sign
       , null
       , null
       , model.pallet
@@ -283,7 +385,11 @@ export const update =
       case "TitleChanged":
         return updateTitle(model, action.title);
       case "IconChanged":
-        return  updateIcon(model, action);
+        return iconChanged(model, action.icon);
+      case "IconLoadError":
+        return iconLoadError(model);
+      case "Icon":
+        return updateIcon(model, action.icon);
       case "MetaChanged":
         return  updateMeta(model, action);
       case "CuratedColorUpdate":
@@ -305,3 +411,10 @@ export const update =
       return Unknown.update(model, action);
     }
   };
+
+export const viewIcon =
+  (model:Model, address:Address<Action>):DOM =>
+  ( model.icon == null
+  ? Sign.view(model.sign)
+  : Icon.view(model.icon, forward(address, IconAction))
+  )

--- a/src/browser/Navigators/Navigator/WebView/Page.js
+++ b/src/browser/Navigators/Navigator/WebView/Page.js
@@ -251,7 +251,7 @@ const chooseInital =
   ( hostname == ""
   ? title
   : hostname
-  ).substr(0, 1).toUpperCase()
+  ).charAt(0).toUpperCase()
 
 
 const swapPallet =

--- a/src/browser/Navigators/Navigator/WebView/Page/Icon.js
+++ b/src/browser/Navigators/Navigator/WebView/Page/Icon.js
@@ -1,0 +1,24 @@
+/* @flow */
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as Image from '../../../../../common/image';
+import * as Style from '../../../../../common/style';
+
+export const view = Image.view('favicon', Style.createSheet({
+  base: {
+    borderRadius: '3px',
+    left: '8px',
+    position: 'absolute',
+    top: '8px',
+    width: '16px',
+    height: '16px'
+  }
+}));
+
+export type Action = Image.Message
+
+export const Model = Image.Model
+export const update = Image.update

--- a/src/browser/Navigators/Navigator/WebView/Page/Sign.js
+++ b/src/browser/Navigators/Navigator/WebView/Page/Sign.js
@@ -1,0 +1,90 @@
+/* @flow */
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {html, thunk} from "reflex"
+import type {DOM} from "reflex"
+import * as Style from "../../../../../common/style"
+
+export class Model {
+  content: string;
+  background: ?string;
+  foreground: ?string;
+  fontFamily: ?string;
+  fontSize: ?string;
+  color: ?string;
+  constructor(
+    content: string
+  , background: ?string
+  , foreground: ?string
+  , fontFamily: ?string
+  , fontSize: ?string
+  ) {
+    this.content = content
+    this.background = background
+    this.foreground = foreground
+    this.color = foreground
+    this.fontFamily = fontFamily
+    this.fontSize = fontSize
+   }
+}
+
+export const init =
+  ( content:string=""
+  , background:?string
+  , foreground:?string
+  , fontFamily:?string
+  , fontSize:?string
+  ):Model =>
+  new Model
+  ( content
+  , ( background == null
+    ? "rgba(255, 255, 255, 0.8)"
+    : background
+    )
+  , ( foreground == null
+    ? "rgba(0, 0, 0, 0.75)"
+    : foreground
+    )
+  , fontFamily
+  , fontSize
+  )
+
+export const blank = init()
+export const bright = init("", "rgba(255, 255, 255, 0.8)", "rgba(0, 0, 0, 0.75)")
+export const dark = init("", "rgba(0, 0, 0, 0.75)", "rgba(255, 255, 255, 0.8)")
+
+export const render =
+  (model:Model):DOM =>
+  ( model.content === ""
+  ? html.figure({ style: styleSheet.base })
+  : html.figure
+    ( { style: Style.mix(styleSheet.base, model) }
+    , [model.content]
+    )
+  )
+
+export const view =
+  (model:Model) =>
+  thunk
+  ( 'Icon'
+  , render
+  , model
+  )
+
+const styleSheet = Style.createSheet
+  ( { base:
+      { border: "none"
+      , borderRadius: "3px"
+      , left: "8px"
+      , position: "absolute"
+      , top: "8px"
+      , width: "16px"
+      , height: "16px"
+      , lineHeight: "16px"
+      , textAlign: "center"
+      }
+    }
+  )

--- a/src/browser/Navigators/Navigator/WebView/Util.js
+++ b/src/browser/Navigators/Navigator/WebView/Util.js
@@ -20,13 +20,6 @@ export const readTitle =
   : fallback
   );
 
-export const readFaviconURI =
-  (model:WebViewModel):string =>
-  ( (model.page && model.page.faviconURI)
-  ? model.page.faviconURI
-  : Favicon.getFallback(model.navigation.url)
-  );
-
 export const isDark =
   (model:WebViewModel):boolean =>
   ( model.page != null

--- a/src/common/image.js
+++ b/src/common/image.js
@@ -4,25 +4,41 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {html, thunk, forward, Effects} from 'reflex';
+import {html, thunk, forward, Effects} from "reflex"
+import {port, always, nofx} from "../common/prelude"
 import * as Style from '../common/style';
+import * as Unknown from "../common/unknown";
 
 
 import type {Address, DOM} from "reflex"
 import type {Rules} from "../common/style"
-import type {URI} from "../common/prelude"
 
-export type Action =
-  | Action
-
-export type {URI}
-
-export type Model =
-  {uri: URI}
+export class Model {
+  url: string;
+  constructor(url:string) {
+    this.url = url
+  }
+}
 
 
-export type StyleSheet =
-  { base: Rules }
+export type Message =
+  | { type: "Error" }
+  | { type: "Load" }
+
+export const update =
+  (model:Model, message:Message):[Model, Effects<Message>] => {
+    switch (message.type) {
+      case "Error":
+        return nofx(model)
+      case "Load":
+        return nofx(model)
+      default:
+        return Unknown.update(model, message)
+    }
+  }
+
+
+export type StyleSheet = { base: Rules }
 export type ContextStyle = Rules
 
 const baseStyleSheet:StyleSheet = Style.createSheet
@@ -31,20 +47,27 @@ const baseStyleSheet:StyleSheet = Style.createSheet
       , backgroundPosition: 'center center'
       , backgroundRepeat: 'no-repeat'
       , border: 'none'
+      , content: `'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"/>'`
       }
     }
   );
 
 export const view =
   (key:string, styleSheet:StyleSheet) =>
-  (model:Model, address:Address<Action>, contextStyle?:ContextStyle):DOM =>
-   html.figure
-   ( { style: Style.mix
-         ( baseStyleSheet.base
-         , styleSheet.base
-         , { backgroundImage: `url(${model.uri})`
-           }
-         , contextStyle
-         )
-     }
-   )
+  (model:Model, address:Address<Message>, contextStyle?:ContextStyle):DOM =>
+  html.img
+  ( { style: Style.mix
+      ( baseStyleSheet.base
+      , styleSheet.base
+      , { backgroundImage: `url(${model.url})`
+        }
+        , contextStyle
+      )
+    , src: model.url
+    , onError: onError(address)
+    , onLoad: onLoad(address)
+    }
+  )
+
+export const onError = port(always({type: "Error"}))
+export const onLoad = port(always({type: "Load"}))


### PR DESCRIPTION
## Fixes #973

Now with pages that don't have favicon you'll see generated icon that has background of a site `theme-color` (see [mozbrowsermetachange](https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowsermetachange) event for more details) and a contrasting foreground color.

Unfortunately [`mozbrowsermetachnage`](https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowsermetachange) events don't seem to be dispatched in servo so colors default dark gray over warm white. Once events will be dispatched this code will take advantage of it.

Unfortunately due to https://github.com/servo/servo/issues/12885 `onerror` events on images aren't fired in servo there for in some cases tabs will have no fallback icons, as we will try to load unavailable image but will never discover it was not available there for won't fallback to generated icon.

I have being testing this with following pages:
https://Gozala.jsbin.com/yugoqil
https://Gozala.jsbin.com/zabifib
http://fitzgeraldnick.com

And observe following results:

## Electron

<img width="337" alt="screen shot 2016-08-15 at 4 58 08 pm" src="https://cloud.githubusercontent.com/assets/21236/17683628/7c4ff2ba-6309-11e6-9c93-7205ad5f2aed.png">

## Servo

<img width="292" alt="screen shot 2016-08-15 at 5 00 35 pm" src="https://cloud.githubusercontent.com/assets/21236/17683661/d1c61b84-6309-11e6-967d-914ea2c75ea8.png">


Differences are due to issues described above + electron seems to fire `iconchange` event regardless of it being present or not, hence `jsbin` icon in electron version.