### PR TITLE
Fix broken link to pre-requisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We welcome contributions from anyone. See [CONTRIBUTING.md](https://github.com/b
 
 The Browser.html UI is bundled with Servo. To run it, you'll need to build Servo.
 
-First, [install Servo's prerequisites](https://github.com/servo/servo#prerequisites). Then, clone and build Servo:
+First, [install Servo's prerequisites](https://github.com/servo/servo#setting-up-your-environment). Then, clone and build Servo:
 
 ``` sh
 git clone https://github.com/servo/servo


### PR DESCRIPTION
The previous anchor didn't resolve to anything (anymore?). Changed it to what seemed the most likely appropriate target.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/browserhtml/browserhtml/1268)
<!-- Reviewable:end -->
