### PR TITLE
Update Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,30 +16,17 @@ This repository is for Browser.html (the front-end). Active development of Graph
 We welcome contributions from anyone. See [CONTRIBUTING.md](https://github.com/browserhtml/browserhtml/blob/master/CONTRIBUTING.md) for help getting started.
 
 
-### Building and Running
+## Development
 
-The Browser.html UI is bundled with Servo. To run it, you'll need to build Servo.
+There are two major components to the browser.html application.
 
-First, [install Servo's prerequisites](https://github.com/servo/servo#setting-up-your-environment). Then, clone and build Servo:
-
-``` sh
-git clone https://github.com/servo/servo
-cd servo
-./mach build -r
-```
-
-Finally, run Servo with the `--browserhtml` flag.
-
-``` sh
-./mach run -r --browserhtml
-```
+1. Local server that serves application UI.
+2. Client that is a application shell that connects to the server and renders served UI.
 
 
-### Developing the Front-end
+### Server
 
-If you're working on the Browser.html front-end, you'll want to run the web app locally.
-
-**Prerequisites**: You'll need [Node](https://nodejs.org/) and NPM. Next, clone Browser.html and install its Node dependencies.
+If you're working on the Browser.html front-end, you'll need a [node][] to install all dependcies and run development toolchain.
 
 ``` sh
 git clone https://github.com/browserhtml/browserhtml.git
@@ -47,35 +34,51 @@ cd browserhtml
 npm install --no-optional
 ```
 
-Then, start the front-end local server:
+Once all dependencies are installed, you can run a server component with following command:
 
 ``` sh
 npm run build-server
 ```
 
-Finally, in a new command line interface application (ex: Terminal), start Servo with the Browser.html flags turned on in either debug (`-d`) or release (`-r`) mode:
+Any changes to the source code will trigger a build, once complete server will serve a new version. That will allow you to reload a client in order to see your changes. Alternatively you could run a "live server" which also re-builds on changes, but in addition it also provides live code reload for the UI such that application state is preserves and no reload of the client is required. You can run "live server" with a following command:
 
-``` sh
-./mach run -r -- -b -w --pref dom.mozbrowser.enabled --pref dom.forcetouch.enabled --pref shell.builtin-key-shortcuts.enabled=false http://localhost:6060
+```sh
+npm run live-server
 ```
 
+### Client
 
-### Running in Gecko
+In order to run browser.html application itself, you will need a client component. This would be a Graphene runtime, built into a servo binary. You can either [download][servo download] pre-built nightly snapshots or [build it yourself][bulid servo] and run with `--browserhtml` flag. Assuming you have pre-built snapshot in default location on a Mac you can run browser.html application with a following command:
 
-Browser.html can also be run on top of a Gecko-based version of Graphene. We sometimes use this variant to test and debug features that haven't yet landed in Servo. Build instructions for Gecko-flavored Graphene can be found [on the wiki](https://github.com/browserhtml/browserhtml/wiki/Building-Graphene-%28Gecko-flavor%29).
-
-
-### Using WebIDE
-
-The easiest way to use developer tools with Browser.html is to select the "Remote Runtime" option in WebIDE while using the Gecko Graphene runtime.
-
-By default you should be able to connect to the running browser at: localhost:6000.
-
-
-### Integration Tests
-
-Run integration tests with `./test/runall.sh`. You need to have a Graphene Gecko binary symlinked in the root of the repository.
 
 ``` sh
-ln -s ../gecko/obj-graphene/dist/Graphene.app graphene
+ /Applications/Servo.app/Contents/MacOS/servo -b -w --pref dom.mozbrowser.enabled --pref dom.forcetouch.enabled --pref shell.builtin-key-shortcuts.enabled=false http://localhost:6060
 ```
+
+### Gecko Client
+
+Browser.html can also be run on top of a Gecko-based version of Graphene. We used to use this variant to test and debug features that were not yet in Servo. You could either [download][dowload gecko] pre-build nightly snapshots or [build it yourself](https://github.com/browserhtml/browserhtml/wiki/Building-Graphene-%28Gecko-flavor%29). Assuming you have pre-build snapshot in default location on a Mac you can run browser.html appliaction with a following command:
+
+```sh
+/Applications/B2G.app/Contents/MacOS/b2g-bin --start-manifest=http://localhost:6060/manifest.webapp --profile ./.profile
+```
+
+### Electron Client
+
+Browser.html can also run as an [Electron][] application. Assuming you have `electron` installed you could run browser.html application with a following command (must be run from the project root):
+
+```sh
+electron .
+```
+
+### Browser Client
+
+You could also just load http://localhost:6060/ in your favourite web browser, but be aware that very few features will work in this case given that application additional API not available for web content. 
+
+
+[download servo]:https://download.servo.org/
+[node]:(https://nodejs.org/)
+[npm]:https://www.npmjs.com/
+[build servo]:https://github.com/servo/servo/blob/master/docs/HACKING_QUICKSTART.md
+[download gecko]:https://ftp.mozilla.org/pub/b2g/nightly/latest-mozilla-central/
+[Electron]:https://electron.atom.io/

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ There are two major components to the browser.html application.
 
 ### Server
 
-If you're working on the Browser.html front-end, you'll need a [node][] to install all dependcies and run development toolchain.
+If you're working on the Browser.html front-end, you'll need [Node.js][] to install all dependencies and run the development toolchain.
 
 ``` sh
 git clone https://github.com/browserhtml/browserhtml.git
@@ -34,13 +34,13 @@ cd browserhtml
 npm install --no-optional
 ```
 
-Once all dependencies are installed, you can run a server component with following command:
+Once all dependencies are installed, you can run the server component with the following command:
 
 ``` sh
 npm run build-server
 ```
 
-Any changes to the source code will trigger a build, once complete server will serve a new version. That will allow you to reload a client in order to see your changes. Alternatively you could run a "live server" which also re-builds on changes, but in addition it also provides live code reload for the UI such that application state is preserves and no reload of the client is required. You can run "live server" with a following command:
+Any changes to the source code will trigger a build, which is then automatically served. That will allow you to reload a client in order to see your changes. Alternatively you can use `live-server` to not only rebuild, but also trigger an automatic live code reload for the UI such that application state is preserved:
 
 ```sh
 npm run live-server
@@ -48,7 +48,7 @@ npm run live-server
 
 ### Client
 
-In order to run browser.html application itself, you will need a client component. This would be a Graphene runtime, built into a servo binary. You can either [download][servo download] pre-built nightly snapshots or [build it yourself][bulid servo] and run with `--browserhtml` flag. Assuming you have pre-built snapshot in default location on a Mac you can run browser.html application with a following command:
+In order to run the browser.html application itself, you will need a client component. This would be a Servo binary with the Graphene runtime. You can either [download][servo download] pre-built nightly snapshots or [build it yourself][build servo] and run with the `--browserhtml` flag. Assuming you have a pre-built snapshot in the default location on a Mac you can run the browser.html application with the following command:
 
 
 ``` sh
@@ -57,7 +57,7 @@ In order to run browser.html application itself, you will need a client componen
 
 ### Gecko Client
 
-Browser.html can also be run on top of a Gecko-based version of Graphene. We used to use this variant to test and debug features that were not yet in Servo. You could either [download][dowload gecko] pre-build nightly snapshots or [build it yourself](https://github.com/browserhtml/browserhtml/wiki/Building-Graphene-%28Gecko-flavor%29). Assuming you have pre-build snapshot in default location on a Mac you can run browser.html appliaction with a following command:
+Browser.html can also be run on top of a Gecko-based version of Graphene. We used to use this variant to test and debug features that were not yet in Servo. You can either [download][dowload gecko] pre-built nightly snapshots or [build it yourself][build gecko][]. Assuming you have a pre-built snapshot in default location on a Mac you can run the browser.html application with the following command:
 
 ```sh
 /Applications/B2G.app/Contents/MacOS/b2g-bin --start-manifest=http://localhost:6060/manifest.webapp --profile ./.profile
@@ -65,7 +65,7 @@ Browser.html can also be run on top of a Gecko-based version of Graphene. We use
 
 ### Electron Client
 
-Browser.html can also run as an [Electron][] application. Assuming you have `electron` installed you could run browser.html application with a following command (must be run from the project root):
+Browser.html can also run as an [Electron][] application. Assuming you have `electron` installed you can run browser.html application with the following command (must be run from the project root):
 
 ```sh
 electron .
@@ -73,12 +73,13 @@ electron .
 
 ### Browser Client
 
-You could also just load http://localhost:6060/ in your favourite web browser, but be aware that very few features will work in this case given that application additional API not available for web content. 
+You can also just load http://localhost:6060/ in your favourite web browser, but be aware that many features with not work because they require APIs not available to web content.
 
 
 [download servo]:https://download.servo.org/
-[node]:(https://nodejs.org/)
+[Node.js]:(https://nodejs.org/)
 [npm]:https://www.npmjs.com/
 [build servo]:https://github.com/servo/servo/blob/master/docs/HACKING_QUICKSTART.md
 [download gecko]:https://ftp.mozilla.org/pub/b2g/nightly/latest-mozilla-central/
 [Electron]:https://electron.atom.io/
+[build gecko]:https://github.com/browserhtml/browserhtml/wiki/Building-Graphene-%28Gecko-flavor%29


### PR DESCRIPTION
Bring readme up to date.

- Remove servo build requirement.
- Provide instructions for running on top of gecko & electron.


Fixes #1274