### PR TITLE
Make sure element is connected to DOM before element.setVisible()

### DIFF
--- a/src/Browser/Navigators/Navigator/WebView/MozBrowserFrame.js
+++ b/src/Browser/Navigators/Navigator/WebView/MozBrowserFrame.js
@@ -257,19 +257,19 @@ const frameStyleSheet = Style.createSheet({ mozbrowser:
 const visibility = (element:HTMLElement, visible:boolean) =>
   new Task((succeed, fail) => {
     if (typeof (element.setVisible) === 'function') {
-      let isConnectedToDom = false;
+      let isConnectedToDom = false
 
-      for(let p=element; p!=null; p=p.parentNode) {
-        if(p == document) {
-          isConnectedToDom = true;
-          break;
+      for (let p=element; p!=null; p=p.parentNode) {
+        if (p === document) {
+          isConnectedToDom = true
+          break
         }
       }
 
-      //Make sure the element is in the DOM tree.
-      //Otherwise, element.setVisible() does not work.
-      if(isConnectedToDom) {
-        element.setVisible(visible);
+      // Make sure the element is in the DOM tree.
+      // Otherwise, element.setVisible() does not work.
+      if (isConnectedToDom) {
+        element.setVisible(visible)
       }
     }
   })

--- a/src/Browser/Navigators/Navigator/WebView/MozBrowserFrame.js
+++ b/src/Browser/Navigators/Navigator/WebView/MozBrowserFrame.js
@@ -257,7 +257,20 @@ const frameStyleSheet = Style.createSheet({ mozbrowser:
 const visibility = (element:HTMLElement, visible:boolean) =>
   new Task((succeed, fail) => {
     if (typeof (element.setVisible) === 'function') {
-      element.setVisible(visible)
+      let isConnectedToDom = false;
+
+      for(let p=element; p!=null; p=p.parentNode) {
+        if(p == document) {
+          isConnectedToDom = true;
+          break;
+        }
+      }
+
+      //Make sure the element is in the DOM tree.
+      //Otherwise, element.setVisible() does not work.
+      if(isConnectedToDom) {
+        element.setVisible(visible);
+      }
     }
   })
 


### PR DESCRIPTION
In Browser.html home page, this `element.setVisible()` raises an error below:

```
JavaScript error: http://localhost:6060/components/Main.js, line 10: InvalidNodeTypeError: The supplied node is incorrect or has an incorrect ancestor for this operation.
```

It calls this `visibility()` with the page `iframe` as the `element`.
But at the very first time, the `iframe` looks newly created and out of DOM tree;
And it turns out to fail `element.setVisible()` and raise the exception.

So fixed to check `element` is surely under `document` before `element.setVisible()`.
Otherwise, skip it.

With this fix, each element's first call of `visibility()` is ignored.
But such brand-new element should be visible and it does not make any problem, I think.

----

Check environment is below:

- **OS:** Ubuntu 16.04.3 LTS
- **Browser:** Graphene
	- Patched to enable mozbrowser for `http://`
		- https://github.com/KSR-Yasuda/graphene-gecko/commit/aa984ab8761119be5d30d25085810dfd2a4d96d3
	- And set `user_pref("dom.mozBrowserFramesEnabledForContent", true);` in user.js in profile.
